### PR TITLE
test(xtask): cover mixed consumer provider clusters

### DIFF
--- a/xtask/src/env/config.rs
+++ b/xtask/src/env/config.rs
@@ -103,6 +103,21 @@ pub(crate) enum ClusterRole {
 
     /// Consumes inference from other sites.
     Consumer,
+
+    /// Both consumes inference and provides local inference backends.
+    Both,
+}
+
+impl ClusterRole {
+    /// Whether this role can host provider backends.
+    pub(crate) fn is_provider(self) -> bool {
+        matches!(self, Self::Provider | Self::Both)
+    }
+
+    /// Whether this role can host a consumer gateway.
+    pub(crate) fn is_consumer(self) -> bool {
+        matches!(self, Self::Consumer | Self::Both)
+    }
 }
 
 /// External mock provider configuration.
@@ -193,7 +208,7 @@ impl EnvConfig {
                 self.clusters
                     .definitions
                     .get(*name)
-                    .is_some_and(|d| d.role == ClusterRole::Consumer)
+                    .is_some_and(|d| d.role.is_consumer())
             })
             .map(String::as_str)
     }
@@ -277,6 +292,33 @@ vertex = { port = 10004, project = "test-project" }
             ClusterRole::Consumer,
             "cluster-c should be consumer"
         );
+    }
+
+    #[test]
+    fn parse_both_cluster_role() {
+        let toml = r#"
+[clusters]
+names = ["edge"]
+
+[clusters.edge]
+models = ["model-local"]
+role = "both"
+
+[providers]
+openai = { port = 10001 }
+anthropic = { port = 10002 }
+bedrock = { port = 10003, region = "us-east-1" }
+vertex = { port = 10004, project = "test-project" }
+"#;
+        let cfg = EnvConfig::from_str(toml).unwrap_or_else(|_| std::process::abort());
+        let edge = cfg
+            .clusters
+            .definitions
+            .get("edge")
+            .unwrap_or_else(|| std::process::abort());
+        assert_eq!(edge.role, ClusterRole::Both, "role must parse as both");
+        assert!(edge.role.is_consumer(), "both must be consumer-capable");
+        assert!(edge.role.is_provider(), "both must be provider-capable");
     }
 
     #[test]
@@ -479,6 +521,30 @@ vertex = { port = 10004, project = "test-project" }
             cfg.consumer_cluster_name(),
             Some("consumer-b"),
             "must return the consumer cluster name"
+        );
+    }
+
+    #[test]
+    fn consumer_cluster_name_accepts_both_cluster() {
+        let toml = r#"
+[clusters]
+names = ["edge"]
+
+[clusters.edge]
+models = ["model-local"]
+role = "both"
+
+[providers]
+openai = { port = 10001 }
+anthropic = { port = 10002 }
+bedrock = { port = 10003, region = "us-east-1" }
+vertex = { port = 10004, project = "test-project" }
+"#;
+        let cfg = EnvConfig::from_str(toml).unwrap_or_else(|_| std::process::abort());
+        assert_eq!(
+            cfg.consumer_cluster_name(),
+            Some("edge"),
+            "both-role cluster must be eligible as the consumer cluster"
         );
     }
 

--- a/xtask/src/env/consumer.rs
+++ b/xtask/src/env/consumer.rs
@@ -20,7 +20,7 @@ use std::{
 };
 
 use crate::env::{
-    config::{ClusterDef, ClusterRole, EnvConfig},
+    config::{ClusterDef, EnvConfig},
     image_overrides,
     kind::kubectl_context,
     kubectl,
@@ -97,7 +97,7 @@ pub(crate) fn probe_network(cfg: &EnvConfig) -> Result<(), Box<dyn std::error::E
         let Some(def) = cfg.clusters.definitions.get(name) else {
             continue;
         };
-        if def.role != ClusterRole::Provider {
+        if !def.role.is_provider() {
             continue;
         }
         probe_provider_reachability(name, def, &consumer_ctx)?;
@@ -480,7 +480,7 @@ fn collect_provider_endpoints(cfg: &EnvConfig) -> Result<Vec<ProviderEndpoint>, 
         let Some(def) = cfg.clusters.definitions.get(name) else {
             continue;
         };
-        if def.role != ClusterRole::Provider || def.models.is_empty() {
+        if !def.role.is_provider() || def.models.is_empty() {
             continue;
         }
         endpoints.push(resolve_provider_endpoint(name, def)?);
@@ -1694,7 +1694,7 @@ pub(crate) fn verify_e2e(cfg: &EnvConfig) -> Result<(), Box<dyn std::error::Erro
         let Some(def) = cfg.clusters.definitions.get(name) else {
             continue;
         };
-        if def.role != ClusterRole::Provider {
+        if !def.role.is_provider() {
             continue;
         }
         for model in &def.models {
@@ -1891,7 +1891,7 @@ pub(crate) fn verify_responses_e2e(cfg: &EnvConfig) -> Result<(), Box<dyn std::e
         let Some(def) = cfg.clusters.definitions.get(name) else {
             continue;
         };
-        if def.role != ClusterRole::Provider {
+        if !def.role.is_provider() {
             continue;
         }
         for model in &def.models {

--- a/xtask/src/env/gateway.rs
+++ b/xtask/src/env/gateway.rs
@@ -11,7 +11,7 @@
 use std::{path::PathBuf, process::Command};
 
 use crate::env::{
-    config::{ClusterDef, ClusterRole, EnvConfig, ProviderBackend},
+    config::{ClusterDef, EnvConfig, ProviderBackend},
     image_overrides, kind, kubectl,
     verify::{HttpResponse, PortForwardGuard, Tally, find_free_port, parse_curl_output, safe_truncate, wait_for_port},
 };
@@ -67,7 +67,7 @@ pub(crate) fn deploy_all(cfg: &EnvConfig) -> Result<(), Box<dyn std::error::Erro
         let Some(def) = cfg.clusters.definitions.get(name) else {
             continue;
         };
-        if def.role != ClusterRole::Provider || def.models.is_empty() {
+        if !def.role.is_provider() || def.models.is_empty() {
             continue;
         }
         deploy_provider(name, def)?;
@@ -94,7 +94,7 @@ pub(crate) fn verify_all(cfg: &EnvConfig) -> Result<(), Box<dyn std::error::Erro
         let Some(def) = cfg.clusters.definitions.get(name) else {
             continue;
         };
-        if def.role != ClusterRole::Provider || def.models.is_empty() {
+        if !def.role.is_provider() || def.models.is_empty() {
             continue;
         }
         found = true;

--- a/xtask/src/env/kind.rs
+++ b/xtask/src/env/kind.rs
@@ -2,8 +2,10 @@
 
 use std::{fmt::Write as _, process::Command};
 
+#[cfg(test)]
+use crate::env::config::ClusterRole;
 use crate::env::{
-    config::{ClusterDef, ClusterRole, ProviderBackend},
+    config::{ClusterDef, ProviderBackend},
     image_overrides, kubectl,
 };
 
@@ -77,7 +79,7 @@ pub(crate) fn create_cluster(name: &str, def: &ClusterDef) -> Result<(), Box<dyn
         run_cmd("kind", &["create", "cluster", "--name", &full])?;
     }
 
-    if def.role == ClusterRole::Provider && !def.models.is_empty() {
+    if def.role.is_provider() && !def.models.is_empty() {
         match def.backend {
             ProviderBackend::InferenceSim => deploy_inference_sim(&full, name, def)?,
             ProviderBackend::MockOpenai => deploy_mock_openai(&full, name)?,

--- a/xtask/src/env/mod.rs
+++ b/xtask/src/env/mod.rs
@@ -21,7 +21,9 @@ use std::{
 
 use clap::Subcommand;
 
-use self::config::{ClusterRole, EnvConfig, ProviderBackend};
+#[cfg(test)]
+use self::config::ClusterRole;
+use self::config::{EnvConfig, ProviderBackend};
 
 // ---------------------------------------------------------------------------
 // Shared infrastructure helpers
@@ -829,7 +831,7 @@ fn report_cluster_status(cfg: &EnvConfig, mut all_ok: bool) -> bool {
         eprintln!("  grid-{name}: {}", status_label(ok));
         if ok
             && let Some(def) = cfg.clusters.definitions.get(name)
-            && def.role == ClusterRole::Provider
+            && def.role.is_provider()
         {
             let deploy_ok = kind::is_provider_backend_ready(name, def);
             all_ok = all_ok && deploy_ok;
@@ -1435,8 +1437,7 @@ fn provider_clusters_from_config(cfg: &EnvConfig) -> Vec<(String, Vec<String>)> 
         .iter()
         .filter_map(|name| {
             cfg.clusters.definitions.get(name).and_then(|def| {
-                (def.role == ClusterRole::Provider && !def.models.is_empty())
-                    .then(|| (name.clone(), def.models.clone()))
+                (def.role.is_provider() && !def.models.is_empty()).then(|| (name.clone(), def.models.clone()))
             })
         })
         .collect()
@@ -1494,7 +1495,7 @@ fn resolve_operator_site_name<'a>(
                 cfg.clusters
                     .definitions
                     .get(*name)
-                    .is_some_and(|d| d.role == ClusterRole::Provider)
+                    .is_some_and(|d| d.role.is_provider())
             })
             .map(String::as_str)
             .ok_or_else(|| "no provider site in config".into())
@@ -1516,7 +1517,7 @@ fn resolve_operator_provider(
         .definitions
         .get(site_name)
         .ok_or_else(|| format!("operator provider site {site_name:?} not found in config"))?;
-    if def.role != ClusterRole::Provider {
+    if !def.role.is_provider() {
         return Err(format!("operator site {site_name:?} is not a provider cluster").into());
     }
     let model = def
@@ -3012,7 +3013,7 @@ fn llmd_compat_check_all_model_fields(cfg: &EnvConfig, port: u16) -> StepResult 
         let Some(def) = cfg.clusters.definitions.get(name) else {
             continue;
         };
-        if def.role != ClusterRole::Provider {
+        if !def.role.is_provider() {
             continue;
         }
         for model in &def.models {
@@ -3216,7 +3217,7 @@ fn responses_check_all_model_fields(cfg: &EnvConfig, port: u16) -> StepResult {
         let Some(def) = cfg.clusters.definitions.get(name) else {
             continue;
         };
-        if def.role != ClusterRole::Provider {
+        if !def.role.is_provider() {
             continue;
         }
         for model in &def.models {
@@ -3620,12 +3621,7 @@ fn env_verify_metrics_routing(config: &Path) -> Result<(), Box<dyn std::error::E
         .clusters
         .names
         .iter()
-        .find(|n| {
-            cfg.clusters
-                .definitions
-                .get(*n)
-                .is_some_and(|d| d.role == ClusterRole::Consumer)
-        })
+        .find(|n| cfg.clusters.definitions.get(*n).is_some_and(|d| d.role.is_consumer()))
         .map(String::as_str)
         .ok_or("no consumer cluster in config")?;
 
@@ -4388,12 +4384,7 @@ fn env_verify_failover_under_lost_peer(config: &Path) -> Result<(), Box<dyn std:
         .clusters
         .names
         .iter()
-        .find(|n| {
-            cfg.clusters
-                .definitions
-                .get(*n)
-                .is_some_and(|d| d.role == ClusterRole::Consumer)
-        })
+        .find(|n| cfg.clusters.definitions.get(*n).is_some_and(|d| d.role.is_consumer()))
         .map(String::as_str)
         .ok_or("no consumer cluster in config")?;
     let consumer_ctx = kind::kubectl_context(consumer_site);
@@ -5441,6 +5432,24 @@ mod multi_provider_tests {
         let cfg = make_config(&[("consumer", ClusterRole::Consumer, vec!["x".to_owned()])]);
         let providers = provider_clusters_from_config(&cfg);
         assert!(providers.is_empty(), "consumer clusters must not appear as providers");
+    }
+
+    #[test]
+    fn provider_clusters_from_config_includes_both_role_cluster() {
+        let cfg = make_config(&[("edge", ClusterRole::Both, vec!["model-local".to_owned()])]);
+        let providers = provider_clusters_from_config(&cfg);
+        assert_eq!(providers.len(), 1, "both-role cluster must be provider-capable");
+        assert_eq!(providers[0].0, "edge", "provider site should be the mixed-role cluster");
+        assert_eq!(
+            providers[0].1,
+            vec!["model-local"],
+            "provider models should come from the mixed-role cluster"
+        );
+        assert_eq!(
+            cfg.consumer_cluster_name(),
+            Some("edge"),
+            "same cluster must also be selected as the consumer"
+        );
     }
 
     #[test]

--- a/xtask/src/env/trust.rs
+++ b/xtask/src/env/trust.rs
@@ -14,7 +14,7 @@ use certs::{generate_ca, generate_site_cert};
 
 use crate::env::{
     certs::WRONG_ORG,
-    config::{ClusterRole, EnvConfig},
+    config::EnvConfig,
     gateway::HOST_CA_CERT,
     kind::kubectl_context,
     verify::{HttpResponse, PortForwardGuard, Tally, find_free_port, parse_curl_output, safe_truncate, wait_for_port},
@@ -67,7 +67,7 @@ pub(crate) fn verify_mtls_trust(cfg: &EnvConfig) -> Result<(), Box<dyn std::erro
         let Some(def) = cfg.clusters.definitions.get(name) else {
             continue;
         };
-        if def.role != ClusterRole::Provider || def.models.is_empty() {
+        if !def.role.is_provider() || def.models.is_empty() {
             continue;
         }
         found = true;

--- a/xtask/src/env/verify.rs
+++ b/xtask/src/env/verify.rs
@@ -11,8 +11,10 @@ use std::{
     time::Duration,
 };
 
+#[cfg(test)]
+use crate::env::config::ClusterRole;
 use crate::env::{
-    config::{ClusterDef, ClusterRole, EnvConfig, ProviderBackend},
+    config::{ClusterDef, EnvConfig, ProviderBackend},
     kind,
 };
 
@@ -62,7 +64,7 @@ pub(crate) fn verify_providers(cfg: &EnvConfig) -> Result<(), Box<dyn std::error
         let Some(def) = cfg.clusters.definitions.get(name) else {
             continue;
         };
-        if def.role != ClusterRole::Provider || def.models.is_empty() {
+        if !def.role.is_provider() || def.models.is_empty() {
             continue;
         }
         providers_found = true;


### PR DESCRIPTION
Add an explicit xtask role for clusters that both consume traffic and host provider backends.

Route provider and consumer checks through role helpers so existing provider-only and consumer-only configs keep their behavior while mixed-role test topologies are representable.

Opening a PR to validate workflows.