### PR TITLE
feat: add mTLS metrics scraping for providers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1507,6 +1507,7 @@ dependencies = [
  "kube",
  "prometheus",
  "rustls",
+ "rustls-pemfile",
  "schemars",
  "scoring",
  "serde",
@@ -1933,6 +1934,15 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ kube = { version = "3.1.0", features = ["client", "derive", "runtime", "rustls-t
 prometheus = "0.14"
 rcgen = "0.14.8"
 rustls = { version = "0.23", default-features = false, features = ["logging", "std", "tls12"] }
+rustls-pemfile = "2"
 schemars = "1.2.1"
 sha2 = "0.10"
 serde = { version = "1.0.228", features = ["derive"] }

--- a/charts/grid-operator/crds/inferenceprovider.yaml
+++ b/charts/grid-operator/crds/inferenceprovider.yaml
@@ -12,377 +12,439 @@ spec:
     singular: inferenceprovider
   scope: Cluster
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .spec.providerKind
-          name: Provider
-          type: string
-        - jsonPath: .status.phase
-          name: Phase
-          type: string
-      name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: Auto-generated derived type for InferenceProviderSpec via `CustomResource`
-          properties:
-            spec:
-              description: Specification for an [`InferenceProvider`].
-              properties:
-                accessPolicy:
-                  default:
-                    siteSelector:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.providerKind
+      name: Provider
+      type: string
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Auto-generated derived type for InferenceProviderSpec via `CustomResource`
+        properties:
+          spec:
+            description: Specification for an [`InferenceProvider`].
+            properties:
+              accessPolicy:
+                default:
+                  siteSelector:
+                    matchLabels: {}
+                description: Which sites can consume this provider.
+                properties:
+                  siteSelector:
+                    default:
                       matchLabels: {}
-                  description: Which sites can consume this provider.
-                  properties:
-                    siteSelector:
-                      default:
-                        matchLabels: {}
-                      description: Which sites can route to this provider.
-                      properties:
-                        matchLabels:
-                          additionalProperties:
-                            type: string
-                          default: {}
-                          description: Label key-value pairs that must match.
-                          type: object
-                      type: object
-                  type: object
-                auth:
-                  description: Authentication configuration.
-                  nullable: true
-                  properties:
-                    manual:
-                      default: false
-                      description: |-
-                        Whether the user manages credentials manually.
-
-                        When true, the operator does not inject credentials
-                        and the user is responsible for configuring auth.
-                      type: boolean
-                    secretRef:
-                      description: Reference to a Secret containing the credential.
-                      nullable: true
-                      properties:
-                        key:
-                          description: |-
-                            Key within the Secret's `data` map.
-
-                            Required when the Secret holds multiple keys (e.g. credential references
-                            in `InferenceProvider.spec.auth.secretRef`).  Omit only when the entire
-                            Secret is consumed (e.g. TLS `ca_secret_ref`).
-                          nullable: true
-                          type: string
-                        name:
-                          description: Secret name.
-                          type: string
-                        namespace:
-                          description: Secret namespace.
-                          type: string
-                      required:
-                        - name
-                        - namespace
-                      type: object
-                    strategy:
-                      description: How credentials are presented to the provider.
-                      enum:
-                        - api_key
-                        - bearer_token
-                        - custom
-                        - mtls_only
-                        - oauth2
-                        - service_account
-                        - sigv4
-                      type: string
-                  required:
-                    - strategy
-                  type: object
-                backendKind:
-                  description: Backend deployment category.
-                  type: string
-                cost:
-                  description: Cost information.
-                  nullable: true
-                  properties:
-                    perMillionInputTokens:
-                      default: 0.0
-                      description: Cost per million input tokens (USD).
-                      format: double
-                      type: number
-                    perMillionOutputTokens:
-                      default: 0.0
-                      description: Cost per million output tokens (USD).
-                      format: double
-                      type: number
-                  type: object
-                endpoint:
-                  description: HTTP endpoint URL.
-                  type: string
-                gridNetworkRef:
-                  description: |-
-                    Name of the [`GridNetwork`] this provider belongs to.
-
-                    [`GridNetwork`]: crate::crd::grid_network::GridNetwork
-                  type: string
-                healthCheck:
-                  description: Health check configuration.
-                  nullable: true
-                  properties:
-                    interval:
-                      description: Check interval (e.g. "30s").
-                      nullable: true
-                      type: string
-                    path:
-                      description: HTTP path for health probes.
-                      nullable: true
-                      type: string
-                    timeout:
-                      description: Timeout per check (e.g. "5s").
-                      nullable: true
-                      type: string
-                  type: object
-                metricsConfig:
-                  description: |-
-                    Prometheus metrics scraping configuration.
-
-                    When set, the Grid operator scrapes the provider's metrics endpoint during
-                    each [`GridNetwork`] reconcile and incorporates the parsed signals into the
-                    routing overlay scoring pass.  When absent, the provider uses locality and
-                    cost as the only scoring signals (static ordering).
-
-                    [`GridNetwork`]: crate::crd::grid_network::GridNetwork
-                  nullable: true
-                  properties:
-                    metricsEndpoint:
-                      description: |-
-                        Base URL for the metrics endpoint, independent of `spec.endpoint`.
-
-                        When set, the scrape URL is `{metrics_endpoint}{path}` instead of
-                        `{spec.endpoint}{path}`.  This allows scraping metrics from a separate
-                        service (such as an llm-d EPP) while the provider inference endpoint
-                        points at the pool's request path.
-
-                        When absent, the scrape URL uses `spec.endpoint` as before.
-                      minLength: 1
-                      nullable: true
-                      type: string
-                    path:
-                      default: /metrics
-                      description: |-
-                        HTTP path for the Prometheus metrics endpoint.
-
-                        Appended to `metrics_endpoint` (when set) or `spec.endpoint`.
-                        Defaults to `"/metrics"` when absent.
-                      type: string
-                    poolName:
-                      description: |-
-                        Expected Prometheus `name` label value for pool-level metric selection.
-
-                        When set, the parser only matches metric samples whose `name` label
-                        equals this value.  This is required when scraping an endpoint that
-                        exposes metrics for multiple pools (such as an llm-d EPP), ensuring
-                        the configured pool is selected deterministically.
-
-                        The parser rejects the scrape when the expected pool series is absent
-                        or when a metric sample has no `name` label and this field is set.
-
-                        When absent, labels are stripped before matching as in v1 (backward
-                        compatible).
-                      minLength: 1
-                      nullable: true
-                      type: string
-                    queueCapacity:
-                      description: |-
-                        Maximum queue slot count for normalising a raw queue-size metric to
-                        0.0–1.0.
-
-                        When set, the `queue_depth` signal value is divided by this capacity
-                        and clamped to `[0.0, 1.0]` before scoring.  This allows consuming raw
-                        average queue-size metrics (such as `llm_d_router_epp_average_queue_size`)
-                        without requiring the exporter to pre-normalise.
-
-                        When absent, the `queue_depth` signal must already be normalised to
-                        0.0–1.0 by the exporter (backward compatible).
-                      format: uint32
-                      minimum: 1.0
-                      nullable: true
-                      type: integer
-                    signalNames:
-                      default:
-                        errorRate: null
-                        healthy: null
-                        kvCacheUtilization: null
-                        latencyP99Ms: null
-                        prefixCacheHitRatio: null
-                        queueDepth: null
-                      description: |-
-                        Mapping from scoring signal names to Prometheus metric names.
-
-                        Signals without a configured name are skipped during parsing and receive the
-                        neutral default value (`0.5`) in scoring.
-                      properties:
-                        errorRate:
-                          description: Metric name for normalised error rate (0.0–1.0).
-                          nullable: true
-                          type: string
-                        healthy:
-                          description: Metric name for a health gauge (any positive value = healthy).
-                          nullable: true
-                          type: string
-                        kvCacheUtilization:
-                          description: Metric name for KV-cache utilisation (0.0–1.0).
-                          nullable: true
-                          type: string
-                        latencyP99Ms:
-                          description: Metric name for P99 request latency in milliseconds (pre-computed gauge).
-                          nullable: true
-                          type: string
-                        prefixCacheHitRatio:
-                          description: Metric name for prefix-cache hit ratio (0.0–1.0).
-                          nullable: true
-                          type: string
-                        queueDepth:
-                          description: Metric name for normalised queue depth (0.0–1.0).
-                          nullable: true
-                          type: string
-                      type: object
-                    staleMetricsSeconds:
-                      description: |-
-                        Maximum age in seconds for which a previously-scraped metric sample may be
-                        used when the current scrape fails.
-
-                        When a Prometheus scrape fails (connection refused, timeout, HTTP error) the
-                        operator normally drops the provider's metrics and falls back to neutral
-                        (`0.5`) scoring for all signals.  Setting this field enables a grace period:
-                        if the last *successful* scrape is no older than `stale_metrics_seconds`, that
-                        cached sample is used instead of neutral scoring.
-
-                        After the grace period expires, or when no successful scrape has ever been
-                        recorded for this reconcile epoch, the provider returns to neutral scoring.
-
-                        **Default (absent):** no grace period — scrape failures immediately produce
-                        neutral scoring.  This preserves backward-compatible behaviour.
-
-                        **Minimum value:** `1` second.  The schema rejects `0`; the operator also
-                        treats zero defensively as absent.
-                      format: uint32
-                      minimum: 1.0
-                      nullable: true
-                      type: integer
-                    timeout:
-                      default: 2s
-                      description: |-
-                        Per-request scrape timeout (e.g. `"2s"`, `"500ms"`).
-
-                        Defaults to `"2s"`.  Only `s` and `ms` suffixes are recognised; unrecognised
-                        values fall back to the default.
-                      type: string
-                  type: object
-                models:
-                  default: []
-                  description: Models served by this provider.
-                  items:
-                    description: Model metadata for an inference provider.
+                    description: Which sites can route to this provider.
                     properties:
-                      capabilities:
-                        default: []
-                        description: Supported capabilities.
-                        items:
+                      matchLabels:
+                        additionalProperties:
                           type: string
-                        type: array
-                      contextWindow:
-                        description: Maximum context window size.
-                        format: uint32
-                        minimum: 0.0
+                        default: {}
+                        description: Label key-value pairs that must match.
+                        type: object
+                    type: object
+                type: object
+              auth:
+                description: Authentication configuration.
+                nullable: true
+                properties:
+                  manual:
+                    default: false
+                    description: |-
+                      Whether the user manages credentials manually.
+
+                      When true, the operator does not inject credentials
+                      and the user is responsible for configuring auth.
+                    type: boolean
+                  secretRef:
+                    description: Reference to a Secret containing the credential.
+                    nullable: true
+                    properties:
+                      key:
+                        description: |-
+                          Key within the Secret's `data` map.
+
+                          Required when the Secret holds multiple keys (e.g. credential references
+                          in `InferenceProvider.spec.auth.secretRef`).  Omit only when the entire
+                          Secret is consumed (e.g. TLS `ca_secret_ref`).
+                        minLength: 1
                         nullable: true
-                        type: integer
+                        type: string
                       name:
-                        description: Model name.
+                        description: Secret name.
+                        minLength: 1
+                        type: string
+                      namespace:
+                        description: Secret namespace.
+                        minLength: 1
                         type: string
                     required:
-                      - name
+                    - name
+                    - namespace
                     type: object
-                  type: array
-                providerKind:
-                  description: Inference provider type.
-                  type: string
-                routingClusterRef:
-                  description: |-
-                    Optional routing identity used in overlay candidate `site` and `cluster` fields.
-
-                    When set, routing overlay candidates produced for this provider use this value
-                    instead of `metadata.name`:
-
-                    - In Phase 1 (no [`GridSite`] inventory), both `candidate.site` and `candidate.cluster` are set to this value.
-                    - When [`GridSite`] resources are present, only `candidate.cluster` is overridden; `candidate.site` is derived
-                      from the matched `GridSite`.
-
-                    Use this to align the provider's routing identity with an upstream cluster
-                    name already configured in the consumer gateway, such as a Praxis
-                    `load_balancer` cluster entry.  When absent, `metadata.name` is used.
-
-                    [`GridSite`]: crate::crd::grid_site::GridSite
-                  nullable: true
-                  type: string
-                siteSelector:
-                  default:
-                    matchLabels: {}
-                  description: Which sites host this provider.
-                  properties:
-                    matchLabels:
-                      additionalProperties:
-                        type: string
-                      default: {}
-                      description: Label key-value pairs that must match.
-                      type: object
-                  type: object
-              required:
-                - backendKind
-                - endpoint
-                - gridNetworkRef
-                - providerKind
-              type: object
-            status:
-              description: Observed status of an [`InferenceProvider`].
-              nullable: true
-              properties:
-                matchingSites:
-                  default: []
-                  description: Sites matched by the site selector.
-                  items:
+                  strategy:
+                    description: How credentials are presented to the provider.
+                    enum:
+                    - api_key
+                    - bearer_token
+                    - custom
+                    - mtls_only
+                    - oauth2
+                    - service_account
+                    - sigv4
                     type: string
-                  type: array
-                observedGeneration:
-                  default: 0
-                  description: Last observed generation.
-                  format: int64
-                  type: integer
-                phase:
-                  default: Pending
-                  description: Current phase.
-                  enum:
-                    - Pending
-                    - Available
-                    - Degraded
-                    - Unavailable
-                  type: string
-                reason:
-                  description: |-
-                    Machine-readable reason for the current phase when not `Available`.
+                required:
+                - strategy
+                type: object
+              backendKind:
+                description: Backend deployment category.
+                type: string
+              cost:
+                description: Cost information.
+                nullable: true
+                properties:
+                  perMillionInputTokens:
+                    default: 0.0
+                    description: Cost per million input tokens (USD).
+                    format: double
+                    type: number
+                  perMillionOutputTokens:
+                    default: 0.0
+                    description: Cost per million output tokens (USD).
+                    format: double
+                    type: number
+                type: object
+              endpoint:
+                description: HTTP endpoint URL.
+                type: string
+              gridNetworkRef:
+                description: |-
+                  Name of the [`GridNetwork`] this provider belongs to.
 
-                    Set when the provider cannot reach `Available` due to a configuration
-                    or credential error.  `None` when the provider is `Available`, `Pending`,
-                    or the reason is unknown.
+                  [`GridNetwork`]: crate::crd::grid_network::GridNetwork
+                type: string
+              healthCheck:
+                description: Health check configuration.
+                nullable: true
+                properties:
+                  interval:
+                    description: Check interval (e.g. "30s").
+                    nullable: true
+                    type: string
+                  path:
+                    description: HTTP path for health probes.
+                    nullable: true
+                    type: string
+                  timeout:
+                    description: Timeout per check (e.g. "5s").
+                    nullable: true
+                    type: string
+                type: object
+              metricsConfig:
+                description: |-
+                  Prometheus metrics scraping configuration.
 
-                    Stable reason values: `UnsupportedAuthStrategy`, `CredentialSecretRefInvalid`,
-                    `CredentialSecretMissing`, `CredentialSecretKeyMissing`,
-                    `CredentialSecretValueInvalid`.
-                  nullable: true
+                  When set, the Grid operator scrapes the provider's metrics endpoint during
+                  each [`GridNetwork`] reconcile and incorporates the parsed signals into the
+                  routing overlay scoring pass.  When absent, the provider uses locality and
+                  cost as the only scoring signals (static ordering).
+
+                  [`GridNetwork`]: crate::crd::grid_network::GridNetwork
+                nullable: true
+                properties:
+                  metricsEndpoint:
+                    description: |-
+                      Base URL for the metrics endpoint, independent of `spec.endpoint`.
+
+                      When set, the scrape URL is `{metrics_endpoint}{path}` instead of
+                      `{spec.endpoint}{path}`.  This allows scraping metrics from a separate
+                      service (such as an llm-d EPP) while the provider inference endpoint
+                      points at the pool's request path.
+
+                      When absent, the scrape URL uses `spec.endpoint` as before.
+                    minLength: 1
+                    nullable: true
+                    type: string
+                  path:
+                    default: /metrics
+                    description: |-
+                      HTTP path for the Prometheus metrics endpoint.
+
+                      Appended to `metrics_endpoint` (when set) or `spec.endpoint`.
+                      Defaults to `"/metrics"` when absent.
+                    type: string
+                  poolName:
+                    description: |-
+                      Expected Prometheus `name` label value for pool-level metric selection.
+
+                      When set, the parser only matches metric samples whose `name` label
+                      equals this value.  This is required when scraping an endpoint that
+                      exposes metrics for multiple pools (such as an llm-d EPP), ensuring
+                      the configured pool is selected deterministically.
+
+                      The parser rejects the scrape when the expected pool series is absent
+                      or when a metric sample has no `name` label and this field is set.
+
+                      When absent, labels are stripped before matching as in v1 (backward
+                      compatible).
+                    minLength: 1
+                    nullable: true
+                    type: string
+                  queueCapacity:
+                    description: "Maximum queue slot count for normalising a raw queue-size metric to\n0.0\u20131.0.\n\nWhen set, the `queue_depth` signal value is divided by this capacity\nand clamped\
+                      \ to `[0.0, 1.0]` before scoring.  This allows consuming raw\naverage queue-size metrics (such as `llm_d_router_epp_average_queue_size`)\nwithout requiring the exporter to pre-normalise.\n\
+                      \nWhen absent, the `queue_depth` signal must already be normalised to\n0.0\u20131.0 by the exporter (backward compatible)."
+                    format: uint32
+                    minimum: 1.0
+                    nullable: true
+                    type: integer
+                  signalNames:
+                    default:
+                      errorRate: null
+                      healthy: null
+                      kvCacheUtilization: null
+                      latencyP99Ms: null
+                      prefixCacheHitRatio: null
+                      queueDepth: null
+                    description: |-
+                      Mapping from scoring signal names to Prometheus metric names.
+
+                      Signals without a configured name are skipped during parsing and receive the
+                      neutral default value (`0.5`) in scoring.
+                    properties:
+                      errorRate:
+                        description: "Metric name for normalised error rate (0.0\u20131.0)."
+                        nullable: true
+                        type: string
+                      healthy:
+                        description: Metric name for a health gauge (any positive value = healthy).
+                        nullable: true
+                        type: string
+                      kvCacheUtilization:
+                        description: "Metric name for KV-cache utilisation (0.0\u20131.0)."
+                        nullable: true
+                        type: string
+                      latencyP99Ms:
+                        description: Metric name for P99 request latency in milliseconds (pre-computed gauge).
+                        nullable: true
+                        type: string
+                      prefixCacheHitRatio:
+                        description: "Metric name for prefix-cache hit ratio (0.0\u20131.0)."
+                        nullable: true
+                        type: string
+                      queueDepth:
+                        description: "Metric name for normalised queue depth (0.0\u20131.0)."
+                        nullable: true
+                        type: string
+                    type: object
+                  staleMetricsSeconds:
+                    description: "Maximum age in seconds for which a previously-scraped metric sample may be\nused when the current scrape fails.\n\nWhen a Prometheus scrape fails (connection refused, timeout,\
+                      \ HTTP error) the\noperator normally drops the provider's metrics and falls back to neutral\n(`0.5`) scoring for all signals.  Setting this field enables a grace period:\nif the last\
+                      \ *successful* scrape is no older than `stale_metrics_seconds`, that\ncached sample is used instead of neutral scoring.\n\nAfter the grace period expires, or when no successful scrape\
+                      \ has ever been\nrecorded for this reconcile epoch, the provider returns to neutral scoring.\n\n**Default (absent):** no grace period \u2014 scrape failures immediately produce\nneutral\
+                      \ scoring.  This preserves backward-compatible behaviour.\n\n**Minimum value:** `1` second.  The schema rejects `0`; the operator also\ntreats zero defensively as absent."
+                    format: uint32
+                    minimum: 1.0
+                    nullable: true
+                    type: integer
+                  timeout:
+                    default: 2s
+                    description: |-
+                      Per-request scrape timeout (e.g. `"2s"`, `"500ms"`).
+
+                      Defaults to `"2s"`.  Only `s` and `ms` suffixes are recognised; unrecognised
+                      values fall back to the default.
+                    type: string
+                  tls:
+                    description: |-
+                      TLS configuration for the metrics endpoint.
+
+                      When set, the operator uses the provided CA certificate for TLS server
+                      verification and optionally presents a client certificate for mutual TLS
+                      (mTLS).  When absent, the scraper uses system root certificates
+                      (backward-compatible).
+
+                      **Fail-closed:** when configured but the referenced Secrets cannot be
+                      resolved or contain invalid material, the scrape is skipped entirely.
+                      The scraper never falls back to system roots or plain HTTP.
+                    nullable: true
+                    properties:
+                      caSecretRef:
+                        description: "Reference to a Secret containing the CA certificate PEM for server\nverification.\n\nThe Secret must contain the PEM-encoded CA certificate under the key\n`ca.crt`\
+                          \ (or the key specified by `key`).  When this CA is\nset, the scraper trusts **only** this CA \u2014 system root certificates\nare not consulted."
+                        properties:
+                          key:
+                            description: |-
+                              Key within the Secret's `data` map.
+
+                              Required when the Secret holds multiple keys (e.g. credential references
+                              in `InferenceProvider.spec.auth.secretRef`).  Omit only when the entire
+                              Secret is consumed (e.g. TLS `ca_secret_ref`).
+                            minLength: 1
+                            nullable: true
+                            type: string
+                          name:
+                            description: Secret name.
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: Secret namespace.
+                            minLength: 1
+                            type: string
+                        required:
+                        - name
+                        - namespace
+                        type: object
+                      clientCertificateSecretRef:
+                        description: |-
+                          Reference to a Secret containing the client certificate and private
+                          key for mutual TLS.
+
+                          When set, the scraper presents this identity during the TLS handshake.
+                          The Secret must contain `tls.crt` (or `certificate_key`) and
+                          `tls.key` (or `private_key_key`) in PEM format.
+
+                          When absent, the scraper performs one-way TLS only (server verification
+                          with the CA from `ca_secret_ref`, no client certificate).
+                        nullable: true
+                        properties:
+                          certificateKey:
+                            default: tls.crt
+                            description: Key within `Secret.data` holding the PEM-encoded client certificate.
+                            minLength: 1
+                            type: string
+                          name:
+                            description: Secret name.
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: Secret namespace.
+                            minLength: 1
+                            type: string
+                          privateKeyKey:
+                            default: tls.key
+                            description: Key within `Secret.data` holding the PEM-encoded private key.
+                            minLength: 1
+                            type: string
+                        required:
+                        - name
+                        - namespace
+                        type: object
+                    required:
+                    - caSecretRef
+                    type: object
+                type: object
+              models:
+                default: []
+                description: Models served by this provider.
+                items:
+                  description: Model metadata for an inference provider.
+                  properties:
+                    capabilities:
+                      default: []
+                      description: Supported capabilities.
+                      items:
+                        type: string
+                      type: array
+                    contextWindow:
+                      description: Maximum context window size.
+                      format: uint32
+                      minimum: 0.0
+                      nullable: true
+                      type: integer
+                    name:
+                      description: Model name.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              providerKind:
+                description: Inference provider type.
+                type: string
+              routingClusterRef:
+                description: |-
+                  Optional routing identity used in overlay candidate `site` and `cluster` fields.
+
+                  When set, routing overlay candidates produced for this provider use this value
+                  instead of `metadata.name`:
+
+                  - In Phase 1 (no [`GridSite`] inventory), both `candidate.site` and `candidate.cluster` are set to this value.
+                  - When [`GridSite`] resources are present, only `candidate.cluster` is overridden; `candidate.site` is derived
+                    from the matched `GridSite`.
+
+                  Use this to align the provider's routing identity with an upstream cluster
+                  name already configured in the consumer gateway, such as a Praxis
+                  `load_balancer` cluster entry.  When absent, `metadata.name` is used.
+
+                  [`GridSite`]: crate::crd::grid_site::GridSite
+                nullable: true
+                type: string
+              siteSelector:
+                default:
+                  matchLabels: {}
+                description: Which sites host this provider.
+                properties:
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    default: {}
+                    description: Label key-value pairs that must match.
+                    type: object
+                type: object
+            required:
+            - backendKind
+            - endpoint
+            - gridNetworkRef
+            - providerKind
+            type: object
+          status:
+            description: Observed status of an [`InferenceProvider`].
+            nullable: true
+            properties:
+              matchingSites:
+                default: []
+                description: Sites matched by the site selector.
+                items:
                   type: string
-              type: object
-          required:
-            - spec
-          title: InferenceProvider
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                type: array
+              observedGeneration:
+                default: 0
+                description: Last observed generation.
+                format: int64
+                type: integer
+              phase:
+                default: Pending
+                description: Current phase.
+                enum:
+                - Pending
+                - Available
+                - Degraded
+                - Unavailable
+                type: string
+              reason:
+                description: |-
+                  Machine-readable reason for the current phase when not `Available`.
+
+                  Set when the provider cannot reach `Available` due to a configuration,
+                  credential, or metrics collection error.  `None` when the provider is
+                  `Available`, `Pending`, or the reason is unknown.
+
+                  Stable reason values:
+                  - `UnsupportedAuthStrategy`, `CredentialSecretRefInvalid`, `CredentialSecretMissing`,
+                    `CredentialSecretKeyMissing`, `CredentialSecretValueInvalid`
+                  - `MetricsTlsSecretMissing`, `MetricsTlsKeyMissing`, `MetricsTlsMaterialInvalid`,
+                    `MetricsTlsIdentityMismatch`
+                nullable: true
+                type: string
+            type: object
+        required:
+        - spec
+        title: InferenceProvider
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/crdt/src/grid_state.rs
+++ b/crdt/src/grid_state.rs
@@ -22,7 +22,6 @@ use std::collections::BTreeMap;
 use serde::{Deserialize, Serialize};
 
 use crate::OrSet;
-
 // ---------------------------------------------------------------------------
 // Access policy
 // ---------------------------------------------------------------------------
@@ -39,7 +38,6 @@ pub struct ProviderAccessPolicy {
     /// Non-empty requires exact label matching.
     pub match_labels: BTreeMap<String, String>,
 }
-
 
 // ---------------------------------------------------------------------------
 // Capability

--- a/demos/grid-combined-site/README.md
+++ b/demos/grid-combined-site/README.md
@@ -133,6 +133,9 @@ cargo xtask env run-grid-combined-site-demo \
   --teardown
 ```
 
+See [e2e-demo-output.txt](e2e-demo-output.txt) for example narrated output
+from a quick cold run with external OpenAI provider.
+
 Without these flags, the demo must create no external-provider Secret,
 configuration, candidate, or evidence. With the flags, only the selected
 site's provider gateway may mount the credential. The generated upstream

--- a/demos/grid-combined-site/e2e-demo-output.txt
+++ b/demos/grid-combined-site/e2e-demo-output.txt
@@ -1,0 +1,301 @@
+===============================================================================
+Grid Combined-Site Demo
+Mode: quick
+Config: demos/grid-combined-site/forge.yaml
+===============================================================================
+
+[SETUP 1/14] Resolving Forge config and building images
+  [OK] Forge config resolved to demos/grid-combined-site/.forge.resolved.yaml
+
+[SETUP 2/14] Generating TLS certificates for all sites
+  reusing existing CA certificate
+  generated cert for west (SAN: west.grid.internal)
+  generated cert for central (SAN: central.grid.internal)
+  generated cert for east (SAN: east.grid.internal)
+  reusing wrong-org cert
+  [OK] TLS certificates generated for west, central, east
+
+[SETUP 3/14] Creating three Kind clusters: west, central, east
+network 'grid-combined-site-net' ready
+created cluster 'west' (kind name: grid-combined-west)
+created cluster 'central' (kind name: grid-combined-central)
+created cluster 'east' (kind name: grid-combined-east)
+  [OK] All three clusters created
+
+[SETUP 4/14] Loading container images into Kind clusters
+  verified local image: praxis-ai:combined-site-demo
+  verified local image: grid-operator:combined-site-demo
+  verified local image: grid-mock-providers:combined-site-demo
+  verified numeric USER for grid-mock-providers:combined-site-demo
+  loading praxis-ai:combined-site-demo into west...
+  loading grid-operator:combined-site-demo into west...
+  loading grid-mock-providers:combined-site-demo into west...
+  [OK] west: all images loaded
+  loading praxis-ai:combined-site-demo into central...
+  loading grid-operator:combined-site-demo into central...
+  loading grid-mock-providers:combined-site-demo into central...
+  [OK] central: all images loaded
+  loading praxis-ai:combined-site-demo into east...
+  loading grid-operator:combined-site-demo into east...
+  loading grid-mock-providers:combined-site-demo into east...
+  [OK] east: all images loaded
+
+[SETUP 5/14] Deploying infrastructure stacks
+  applying metallb to west...
+applied stack metallb -> west (3 steps)
+  applying metallb to central...
+applied stack metallb -> central (3 steps)
+  applying metallb to east...
+applied stack metallb -> east (3 steps)
+  applying west-operator-base to west...
+applied stack west-operator-base -> west (3 steps)
+  applying central-operator-base to central...
+applied stack central-operator-base -> central (3 steps)
+  applying east-operator-base to east...
+applied stack east-operator-base -> east (3 steps)
+  [OK] Infrastructure stacks applied
+
+[SETUP 6/14] Verifying Grid operators are ready
+  waiting for grid-operator in deployment (ns=grid-system)...
+deployment "grid-operator" successfully rolled out
+  [OK] west: Grid operator ready
+  waiting for grid-operator in deployment (ns=grid-system)...
+deployment "grid-operator" successfully rolled out
+  [OK] central: Grid operator ready
+  waiting for grid-operator in deployment (ns=grid-system)...
+deployment "grid-operator" successfully rolled out
+  [OK] east: Grid operator ready
+
+[SETUP 7/14] Deploying mock providers
+secret/mock-inference-credential created
+  [OK] west: mock-inference-credential created
+  applying mock-providers to west...
+applied stack mock-providers -> west (3 steps)
+secret/mock-inference-credential created
+  [OK] central: mock-inference-credential created
+  applying mock-providers to central...
+applied stack mock-providers -> central (3 steps)
+secret/mock-inference-credential created
+  [OK] east: mock-inference-credential created
+  applying mock-providers to east...
+applied stack mock-providers -> east (3 steps)
+  [OK] Mock providers deployed
+
+[SETUP 8/14] Deploying grid-site resources
+  applying west-site to west...
+applied stack west-site -> west (1 steps)
+  applying central-site to central...
+applied stack central-site -> central (1 steps)
+  applying east-site to east...
+applied stack east-site -> east (1 steps)
+  [OK] Grid site resources deployed
+
+[SETUP 9/14] Waiting for local overlay ConfigMaps
+  Polling for local overlay ConfigMaps (timeout 180s)...
+  west: sim-west-provider present (semantic_rev=58a156ab437bdab3d77d354c821e729861abae165a3e1bd7d12de3e6d0d06b98, stable_id=65b2bd5b)
+  central: sim-central-provider present (semantic_rev=438a7577f9a1e5756aa4d2a83aa9b9cb56e2c226423bd9bf77947437f308a850, stable_id=2b659cf3)
+  east: sim-east-provider present (semantic_rev=4cd36ca32ad84b2791f579ce32228cc0814d7d7f981944e5857ec8bd55a9e9e9, stable_id=aaea54b3)
+  [OK] Local overlay ConfigMaps ready
+
+[SETUP 10/14] Materializing provider config and installing trust
+Warning: resource secrets/consumer-gateway-tls is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
+secret/consumer-gateway-tls configured
+secret/provider-gateway-tls created
+secret/wrong-org-client-tls created
+  [OK] west: TLS secrets installed
+Warning: resource secrets/consumer-gateway-tls is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
+secret/consumer-gateway-tls configured
+secret/provider-gateway-tls created
+secret/wrong-org-client-tls created
+  [OK] central: TLS secrets installed
+Warning: resource secrets/consumer-gateway-tls is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
+secret/consumer-gateway-tls configured
+secret/provider-gateway-tls created
+secret/wrong-org-client-tls created
+  [OK] east: TLS secrets installed
+  [OK] central: external provider Secret created from key file
+inferenceprovider.grid.praxis-proxy.io/external-open-ai created
+  [OK] central: external InferenceProvider created
+  [OK] External provider configured at central
+  Waiting for external candidate 'openai-api' in central overlay...
+  [OK] External candidate stable_id=518e434a
+  west: sim-west-provider -> 65b2bd5b
+configmap/provider-gateway-config created
+  [OK] west: provider-gateway-config created (stable_id=65b2bd5b)
+  central: sim-central-provider -> 2b659cf3
+  central: external provider config appended (external-open-ai route + cluster, candidate_id=518e434a)
+configmap/provider-gateway-config created
+  [OK] central: provider-gateway-config created (stable_id=2b659cf3)
+  east: sim-east-provider -> aaea54b3
+configmap/provider-gateway-config created
+  [OK] east: provider-gateway-config created (stable_id=aaea54b3)
+  [OK] Provider config materialized, trust installed
+
+[SETUP 11/14] Deploying provider gateways
+  applying provider-gateway to west...
+applied stack provider-gateway -> west (3 steps)
+  applying provider-gateway-external to central...
+applied stack provider-gateway-external -> central (3 steps)
+  applying provider-gateway to east...
+applied stack provider-gateway -> east (3 steps)
+  [OK] Provider gateways deployed
+
+[SETUP 12/14] Deploying consumer gateways
+  applying consumer-gateway to west...
+applied stack consumer-gateway -> west (5 steps)
+  applying consumer-gateway to central...
+applied stack consumer-gateway -> central (5 steps)
+  applying consumer-gateway to east...
+applied stack consumer-gateway -> east (5 steps)
+  [OK] Consumer gateways deployed
+
+[SETUP 13/14] SWIM discovery and trust authorization
+  west: SWIM LB IP = 172.19.255.231
+  central: SWIM LB IP = 172.19.255.211
+  east: SWIM LB IP = 172.19.255.191
+  [OK] west: SWIM peers configured
+  [OK] central: SWIM peers configured
+  [OK] east: SWIM peers configured
+  waiting for grid-operator in deployment (ns=grid-system)...
+deployment "grid-operator" successfully rolled out
+  [OK] west: operator restarted with SWIM config
+  waiting for grid-operator in deployment (ns=grid-system)...
+deployment "grid-operator" successfully rolled out
+  [OK] central: operator restarted with SWIM config
+  waiting for grid-operator in deployment (ns=grid-system)...
+deployment "grid-operator" successfully rolled out
+  [OK] east: operator restarted with SWIM config
+
+  west: authorizing remote provider sites
+  [OK] GridSite "grid-combined-site-central" auto-created by operator (gridNetworkRef="grid-combined-site")
+  [OK] GridSite "grid-combined-site-central": advertised certificate matches the staged identity
+  [OK] GridSite "grid-combined-site-central": canonicalFingerprints + serverName="central.grid.internal" patched
+  [OK] GridSite "grid-combined-site-central": phase="Active" (confirmed)
+  [OK] GridSite "grid-combined-site-east" auto-created by operator (gridNetworkRef="grid-combined-site")
+  [OK] GridSite "grid-combined-site-east": advertised certificate matches the staged identity
+  [OK] GridSite "grid-combined-site-east": canonicalFingerprints + serverName="east.grid.internal" patched
+  [OK] GridSite "grid-combined-site-east": phase="Active" (confirmed)
+
+  central: authorizing remote provider sites
+  [OK] GridSite "grid-combined-site-west" auto-created by operator (gridNetworkRef="grid-combined-site")
+  [OK] GridSite "grid-combined-site-west": advertised certificate matches the staged identity
+  [OK] GridSite "grid-combined-site-west": canonicalFingerprints + serverName="west.grid.internal" patched
+  [OK] GridSite "grid-combined-site-west": phase="Active" (confirmed)
+  [OK] GridSite "grid-combined-site-east" auto-created by operator (gridNetworkRef="grid-combined-site")
+  [OK] GridSite "grid-combined-site-east": advertised certificate matches the staged identity
+  [OK] GridSite "grid-combined-site-east": canonicalFingerprints + serverName="east.grid.internal" patched
+  [OK] GridSite "grid-combined-site-east": phase="Active" (confirmed)
+
+  east: authorizing remote provider sites
+  [OK] GridSite "grid-combined-site-west" auto-created by operator (gridNetworkRef="grid-combined-site")
+  [OK] GridSite "grid-combined-site-west": advertised certificate matches the staged identity
+  [OK] GridSite "grid-combined-site-west": canonicalFingerprints + serverName="west.grid.internal" patched
+  [OK] GridSite "grid-combined-site-west": phase="Active" (confirmed)
+  [OK] GridSite "grid-combined-site-central" auto-created by operator (gridNetworkRef="grid-combined-site")
+  [OK] GridSite "grid-combined-site-central": advertised certificate matches the staged identity
+  [OK] GridSite "grid-combined-site-central": canonicalFingerprints + serverName="central.grid.internal" patched
+  [OK] GridSite "grid-combined-site-central": phase="Active" (confirmed)
+  [OK] All auto-discovered remote GridSites authorized and Active
+
+[SETUP 14/14] Waiting for global overlay convergence
+  Waiting for global overlay convergence (4 candidates on all clusters, timeout 180s)...
+  east: missing candidates ["openai-api", "sim-central-provider", "sim-west-provider"]
+  east: missing candidates ["openai-api", "sim-central-provider", "sim-west-provider"]
+  east: missing candidates ["openai-api", "sim-central-provider", "sim-west-provider"]
+  External candidate external-open-ai: model=gpt-4o-mini, site=central, routing_cluster=openai-api validated
+  Global overlay converged: 4 candidates on all 3 clusters, stable_ids agree
+  [WAIT] west: Grid operator convergence
+  waiting for grid-operator in deployment (ns=grid-system)...
+deployment "grid-operator" successfully rolled out
+  waiting for consumer-gateway in deployment (ns=grid-system)...
+deployment "consumer-gateway" successfully rolled out
+  waiting for provider-gateway in deployment (ns=grid-system)...
+deployment "provider-gateway" successfully rolled out
+  [OK] west: Gateways ready
+  [WAIT] central: Grid operator convergence
+  waiting for grid-operator in deployment (ns=grid-system)...
+deployment "grid-operator" successfully rolled out
+  waiting for consumer-gateway in deployment (ns=grid-system)...
+deployment "consumer-gateway" successfully rolled out
+  waiting for provider-gateway in deployment (ns=grid-system)...
+deployment "provider-gateway" successfully rolled out
+  [OK] central: Gateways ready
+  [WAIT] east: Grid operator convergence
+  waiting for grid-operator in deployment (ns=grid-system)...
+deployment "grid-operator" successfully rolled out
+  waiting for consumer-gateway in deployment (ns=grid-system)...
+deployment "consumer-gateway" successfully rolled out
+  waiting for provider-gateway in deployment (ns=grid-system)...
+deployment "provider-gateway" successfully rolled out
+  [OK] east: Gateways ready
+  [OK] All three combined sites converged and gateways ready
+
+===============================================================================
+ENVIRONMENT READY - Starting proof scenarios
+===============================================================================
+
+=== QUICK MODE SCENARIOS ===
+
+[SCENARIO 1] Verify three clusters are healthy
+  [ASSERT] cluster_health
+  [OK] cluster_health: All 3 clusters are healthy with ready nodes
+
+[SCENARIO 2] Verify component deployment
+  [ASSERT] component_deployment
+  [OK] component_deployment: All 4 components are ready across 3 sites
+
+[SCENARIO 3] Verify SWIM convergence
+  [ASSERT] swim_convergence
+  [OK] swim_convergence: Every GridNetwork is Active with both remote sites connected
+
+[SCENARIO 4] Verify site auto-discovery
+  [ASSERT] site_auto_discovery
+  [OK] site_auto_discovery: Every cluster has two Active/TlsVerified remote GridSites with :8443 addresses and trust configuration
+
+[SCENARIO 5] Verify external provider isolation (site: central)
+
+[SCENARIO 6] Verify external provider gateway config (site: central)
+
+[SCENARIO 7] Verify overlay acceptance
+  [ASSERT] overlay_acceptance
+  [OK] overlay_acceptance: All sites: overlay ConfigMap exists with data, gateway ready, health check passes
+
+[SCENARIO 8] Verify local provider selection
+  [ASSERT] local_provider_selection
+  [OK] local_provider_selection: All consumer sites correctly prefer their local provider (west→west, central→central, east→east)
+
+[SCENARIO 9] Verify response attribution
+  [ASSERT] response_attribution
+  [OK] response_attribution: All responses include complete attribution: consumer site, provider site, instance, session, and revision
+
+[SCENARIO 10] Verify TLS certificate rejection
+  [ASSERT] tls_certificate_validation
+  [OK] tls_certificate_validation: TLS validation correct: no-cert and wrong-organization identities rejected; consumer identity accepted
+
+[SCENARIO 11] Verify authorization replacement
+  [ASSERT] authorization_replacement
+  [OK] authorization_replacement: Authorized provider-hop traffic succeeds with caller authorization properly replaced at final hop
+
+[SCENARIO 12] Verify credential isolation
+  [ASSERT] credential_isolation
+  [OK] credential_isolation: Provider credentials are absent from consumer and operator mounts; consumer Secret reads are denied
+
+[SCENARIO 13] Verify backend access denial
+  [ASSERT] backend_access_denial
+  [OK] backend_access_denial: Direct consumer/workload backend access is correctly denied by NetworkPolicy
+
+[SCENARIO 14] Verify negative routing (invalid inputs)
+  [ASSERT] negative_routing
+  [OK] negative_routing: All negative routing inputs correctly rejected (positive control passed first)
+
+=== TEARDOWN ===
+deleted cluster 'east' (kind name: grid-combined-east)
+deleted cluster 'central' (kind name: grid-combined-central)
+deleted cluster 'west' (kind name: grid-combined-west)
+removed network 'grid-combined-site-net'
+  [OK] Environment torn down successfully
+
+===============================================================================
+Demo completed in 392.8s
+Evidence: demos/grid-combined-site/evidence-1785898332/results.json
+===============================================================================

--- a/demos/grid-glb-demo/README.md
+++ b/demos/grid-glb-demo/README.md
@@ -1227,6 +1227,9 @@ cargo xtask env run-grid-glb-demo \
   2>&1 | tee grid-glb-demo-output.txt
 ```
 
+See [e2e-demo-output.txt](e2e-demo-output.txt) for example narrated output
+from a quick cold run.
+
 The command:
 
 1. resolves image overrides without changing source manifests;

--- a/demos/grid-glb-demo/e2e-demo-output.txt
+++ b/demos/grid-glb-demo/e2e-demo-output.txt
@@ -1,0 +1,243 @@
+
+===============================================================================
+ENVIRONMENT SETUP
+===============================================================================
+
+[SETUP 1/9] Staging demo certificates and provider identities
+  reusing existing CA certificate
+  generated cert for east-edge (SAN: east-edge.grid.internal)
+  generated cert for west-edge (SAN: west-edge.grid.internal)
+  generated cert for edge-untrusted (SAN: edge-untrusted.grid.internal)
+  generated cert for east-provider (SAN: east-provider.grid.internal)
+  generated cert for west-provider (SAN: west-provider.grid.internal)
+  reusing wrong-org cert
+  reusing existing CA certificate
+
+[SETUP 2/9] Creating five Kind clusters on one shared cross-cluster network
+            Forge will report again after cluster creation completes.
+
+[SETUP 3/9] Resolving and loading runtime images
+  gateway:       praxis-ai:glb-demo
+  operator:      grid-operator:glb-demo
+  mock provider: grid-mock-providers:glb-demo
+  pull policy:   Never
+
+[SETUP 4/9] Installing MetalLB, SWIM services, and Grid operators
+
+[SETUP 5/9] Installing provider trust, credentials, and policy
+namespace/grid-system created
+secret/edge-gateway-tls created
+secret/edge-gateway-tls created
+secret/gtm-emulator-tls created
+configmap/provider-gateway-config created
+secret/provider-gateway-tls created
+secret/mock-inference-credential created
+secret/mock-inference-secondary-credential created
+configmap/provider-gateway-config created
+secret/provider-gateway-tls created
+secret/mock-inference-credential created
+grid-routing: edge identities, GTM certificate, provider configs, mTLS material, and credentials installed
+
+[SETUP 6/9] Deploying two provider gateways and three private inference providers
+
+[SETUP 7/9] Configuring edge trust and deploying Praxis edge gateways
+  [OK] east-edge: local edge site configured
+  [OK] west-edge: local edge site configured
+
+  east-edge trust view: authorizing providers discovered through Grid
+  [OK] GridSite "glb-demo-east-provider" auto-created by operator (gridNetworkRef="glb-demo")
+  [OK] GridSite "glb-demo-east-provider": advertised certificate matches the staged identity
+  [OK] GridSite "glb-demo-east-provider": canonicalFingerprints + serverName="east-provider.grid.internal" patched
+  [OK] GridSite "glb-demo-east-provider": phase="Active" (confirmed)
+  [OK] GridSite "glb-demo-west-provider" auto-created by operator (gridNetworkRef="glb-demo")
+  [OK] GridSite "glb-demo-west-provider": advertised certificate matches the staged identity
+  [OK] GridSite "glb-demo-west-provider": canonicalFingerprints + serverName="west-provider.grid.internal" patched
+  [OK] GridSite "glb-demo-west-provider": phase="Active" (confirmed)
+
+  west-edge trust view: authorizing providers discovered through Grid
+  [OK] GridSite "glb-demo-east-provider" auto-created by operator (gridNetworkRef="glb-demo")
+  [OK] GridSite "glb-demo-east-provider": advertised certificate matches the staged identity
+  [OK] GridSite "glb-demo-east-provider": canonicalFingerprints + serverName="east-provider.grid.internal" patched
+  [OK] GridSite "glb-demo-east-provider": phase="Active" (confirmed)
+  [OK] GridSite "glb-demo-west-provider" auto-created by operator (gridNetworkRef="glb-demo")
+  [OK] GridSite "glb-demo-west-provider": advertised certificate matches the staged identity
+  [OK] GridSite "glb-demo-west-provider": canonicalFingerprints + serverName="west-provider.grid.internal" patched
+  [OK] GridSite "glb-demo-west-provider": phase="Active" (confirmed)
+  [OK] east-edge: Praxis edge gateway deployed
+  [OK] west-edge: Praxis edge gateway deployed
+
+[SETUP 8/9] Deploying the GTM emulator in front of both edges
+
+[SETUP 9/9] Waiting for both edge-local routing overlays to converge
+            Each edge must receive one complete, versioned provider view.
+            This proves distribution; Praxis acceptance is verified next.
+  distributed → east-edge: revision=2e72db5b51ec21d4…
+  distributed → west-edge: revision=c93cdc56350ee985…
+
+[READY] Environment deployed from demos/grid-glb-demo/.forge.resolved.yaml
+        east-edge=3 candidates, projected `ConfigMap`, west-edge=3 candidates, projected `ConfigMap`
+
+===============================================================================
+PRAXIS GRID GLOBAL INGRESS DEMO
+===============================================================================
+
+Mode: QUICK
+Proof policy: Every PASS comes from a runtime assertion; manifest intent is not
+              counted as proof.
+
+EXPECTED PATH
+  client -> stable Praxis HTTPS -> selected Praxis edge
+         -> Grid-selected provider gateway -> private backend
+
+Live edge/provider paths appear under OBSERVED ROUTES after Demo 1
+runtime validation completes.
+
+===============================================================================
+DEMO 1 | ACTIVE/ACTIVE GLOBAL AND PROVIDER ROUTING
+===============================================================================
+
+USER STORY
+  As an application owner, I need one stable HTTPS endpoint backed by active
+  edges while Grid independently selects an admitted provider.
+
+DETAILED RUNTIME PROOF
+-------------------------------------------------------------------------------
+  [CHECK] Prerequisites
+  [CHECK] validating forge config
+  [CHECK] checking environment status
+  [CHECK] checking clusters live
+  [CHECK] checking provider gateway IPs
+  [CHECK] checking SWIM LB services
+  [CHECK] checking operator SWIM advertise address
+  [CHECK] checking GridNetwork seeds
+  [CHECK] checking overlay candidate metadata
+  rendered → revision=2e72db5b51ec21d4…
+  distributed → revision=2e72db5b51ec21d4…, resourceVersion=6194
+  [CHECK] checking multiple providers in one site overlay
+  [CHECK] checking provider gateway self-discovery
+  [CHECK] checking remote GridSite egress addresses
+  [CHECK] checking provider service selector
+  [CHECK] checking provider gateway pods
+  [CHECK] checking backend private service
+  [CHECK] checking backend network policy
+  [CHECK] checking provider mTLS trust matrix
+  [CHECK] checking provider peer policy
+  [CHECK] checking provider request boundary
+  [CHECK] checking edge config applied
+  [CHECK] checking edge overlay projections
+  distributed → east-edge: revision=2e72db5b51ec21d4…
+  distributed → west-edge: revision=c93cdc56350ee985…
+  [CHECK] capturing edge gateway pod identity
+  accepted → east-edge: revision=2e72db5b51ec21d4…
+  accepted → west-edge: revision=c93cdc56350ee985…
+  [CHECK] sending inference request
+  serving → revision=2e72db5b51ec21d4…
+  [CHECK] routing to both providers hosted by the east site
+  waiting for mock-inference in east-provider (ns=grid-system)...
+deployment "mock-inference" successfully rolled out
+  waiting for mock-inference in east-provider (ns=grid-system)...
+deployment "mock-inference" successfully rolled out
+
+RUNTIME PROOF RESULTS
+-------------------------------------------------------------------------------
+Grid must update live edge routing from discovered provider state while authenticated provider gateways protect private backends.
+
+
+| Step | Result | Evidence |
+|---|---|---|
+| prerequisites | **PASS** | config validation passed |
+| forge status | **PASS** | forge status returned OK |
+| clusters live | **PASS** | all 5 clusters live |
+| provider gateway IPs | **PASS** | east-provider=172.19.255.232, west-provider=172.19.255.212 |
+| swim lb services | **PASS** | east-edge=172.19.255.191, east-provider=172.19.255.231, west-edge=172.19.255.171, west-provider=172.19.255.211 |
+| swim advertise addr | **PASS** | east-edge=172.19.255.191:7946, east-provider=172.19.255.231:7946, west-edge=172.19.255.171:7946, west-provider=172.19.255.211:7946 |
+| gridnetwork seeds | **PASS** | seeds: east-edge=3, east-provider=3, west-edge=3, west-provider=3 |
+| overlay metadata | **PASS** | dual-key: 3 candidate(s), validated: stable_id, admission_state, selection_tier, rank, generated_at; envelope: schema=1.0.0, revision=2e72db5b51ec21d4…, annotations and Grid status verified |
+| same-site provider candidates | **PASS** | east-edge: east-provider clusters=[sim-east-provider,sim-east-provider-secondary], stable_ids=[84f799fe,eaf38b2d]; west-edge: east-provider clusters=[sim-east-provider,sim-east-provider-secondary], stable_ids=[84f799fe,eaf38b2d] |
+| provider gateway addr | **PASS** | east-provider=172.19.255.232:8443 (self-discovered, broadcast via SWIM), west-provider=172.19.255.212:8443 (self-discovered, broadcast via SWIM) |
+| remote gridsite egress | **PASS** | east-provider=172.19.255.232:8443, west-provider=172.19.255.212:8443 |
+| provider service selector | **PASS** | east-provider: port=8443, selector={"app.kubernetes.io/instance":"provider-gateway","app.kubernetes.io/name":"provider-gateway"}; west-provider: port=8443, selector={"app.kubernetes.io/instance":"provider-gateway","app.kubernetes.io/name":"provider-gateway"} |
+| provider gateway pods | **PASS** | east-provider: Running, image=praxis-ai:glb-demo; west-provider: Running, image=praxis-ai:glb-demo |
+| backend private service | **PASS** | east-provider/mock-inference: type=ClusterIP; east-provider/mock-inference-secondary: type=ClusterIP; west-provider/mock-inference: type=ClusterIP |
+| backend network policy | **PASS** | east-provider/primary: allowed=connected, unlabeled=denied, no_auth=HTTP_401, client_auth=HTTP_403; east-provider/secondary: allowed=connected, unlabeled=denied, no_auth=HTTP_401, client_auth=HTTP_403; west-provider/primary: allowed=connected, unlabeled=denied, no_auth=HTTP_401, client_auth=HTTP_403 |
+| provider mTLS trust matrix | **PASS** | east-provider: valid_edges=2, no_cert/wrong_sni/wrong_ca=TLS_REFUSED; west-provider: valid_edges=2, no_cert/wrong_sni/wrong_ca=TLS_REFUSED |
+| provider peer policy | **PASS** | east-provider: wrong_org=HTTP_403, unknown_digest=HTTP_403; west-provider: wrong_org=HTTP_403, unknown_digest=HTTP_403 |
+| provider request boundary | **PASS** | east-provider: unknown_candidate=HTTP_403, wrong_path=HTTP_404; west-provider: unknown_candidate=HTTP_403, wrong_path=HTTP_404 |
+| edge config applied | **PASS** | GridNetwork 'glb-demo' applied on both edge clusters |
+| edge overlays mounted | **PASS** | east-edge=3 candidates, projected `ConfigMap`, west-edge=3 candidates, projected `ConfigMap` |
+| edge gateways running | **PASS** | east-edge=uid:bdf18297-62c…, restarts:0, accepted_revision:2e72db5b51ec21d4…, west-edge=uid:2eda5814-c89…, restarts:0, accepted_revision:c93cdc56350ee985… |
+| inference routed | **PASS** | HTTP 200, model=sim-model-v1, provider=east-provider, gateway=east-provider, backend_request_id=5843b2e061d9d298…, overlay_revision=2e72db5b51ec21d4…, provider credential replaced client-supplied credential |
+| same-site providers routed | **PASS** | east-provider gateway routed sim-model-v1 to independent providers east-provider and east-provider-secondary; provider=east-provider, queue_depth=0.95, overlay admission_state=existing_only; overlay reload observed: before=4, after=5; queue_depth=0.10, overlay admission_state=new_and_existing; overlay reload observed: before=5, after=6 |
+
+[PASS] All routing and provider-boundary proof points passed.
+
+OBSERVED ROUTES
+  [PASS] east-edge -> east-provider  (fixtures: narrated-edge-1 / narrated-provider-1)
+  [PASS] west-edge -> west-provider  (fixtures: narrated-edge-0 / narrated-provider-0)
+         client -> east-edge -> east-provider gateway -> east-provider backend
+         client -> west-edge -> west-provider gateway -> west-provider backend
+
+===============================================================================
+DEMO 2 | SECURE PROVIDER BOUNDARY
+===============================================================================
+
+USER STORY
+  As a provider and security owner, I need authenticated Grid traffic, exact
+  local policy, private backend isolation, and final-hop credential
+  replacement.
+
+[PASS] Both provider gateways required mTLS, accepted both pinned edge
+       identities, rejected missing or invalid TLS identities, and enforced
+       exact candidate/model/path policy for three provider candidates.
+
+[PASS] All three private provider paths are isolated by NetworkPolicy and
+       provider-local credentials; the two east providers use distinct backends
+       and credentials behind one site gateway.
+
+[SKIP] Demos 3-5 run only in full mode.
+
+===============================================================================
+DEMONSTRATED BOUNDARY
+===============================================================================
+
+[PROVEN] Two Praxis edges served one verified HTTPS name, and Grid routed
+         across three provider candidates.
+[PROVEN] Versioned per-edge overlays with three candidates, including two
+         independently routed providers in one cluster, plus exact
+         rendered/distributed/accepted/serving revision evidence.
+[PROVEN] Metrics-driven same-site provider drain, hot reload, provider mTLS,
+         and peer authorization.
+[PROVEN] Provider-local credential replacement and NetworkPolicy-enforced
+         private backend access.
+[OUT OF SCOPE] Managed DNS/Anycast, internet DDoS/WAF, geo-latency GTM
+               steering, shared affinity storage, or in-flight stream
+               migration.
+
+[CLEANUP] Tearing down demo clusters...
+[CLEANUP] Teardown complete.
+
+===============================================================================
+FINAL RESULT
+===============================================================================
+[PASS   ] Active/active routing
+          2 edges observed; 3 provider candidates include 2 independently
+          routed providers in one cluster
+[PASS   ] Observable overlay contract
+          one revision matched rendered/distributed/accepted/serving evidence
+[PASS   ] Secure provider boundary
+          mTLS, peer auth, NetworkPolicy, credential replacement verified
+[SKIPPED] Session affinity and drain
+          quick mode
+[SKIPPED] Edge withdrawal and recovery
+          quick mode
+[SKIPPED] Grid restart recovery and soak
+          quick mode
+[SKIPPED] Live external provider
+          not enabled; OpenAI Secret, InferenceProvider, provider route, and
+          edge clusters absent
+
+OVERALL   PASS
+MODE      QUICK
+ELAPSED   495.9s
+EVIDENCE  demos/grid-glb-demo/.forge/evidence/glb-demo-20260805T023508Z
+[EVIDENCE] Human narration and results.json written to demos/grid-glb-demo/.forge/evidence/glb-demo-20260805T023508Z

--- a/demos/grid-llmd-pool-metrics/README.md
+++ b/demos/grid-llmd-pool-metrics/README.md
@@ -215,6 +215,9 @@ cargo run -p xtask -- env run-grid-llmd-pool-metrics-demo --full --evidence-dir 
 cargo run -p xtask -- env run-grid-llmd-pool-metrics-demo --full --teardown
 ```
 
+See [e2e-demo-output.txt](e2e-demo-output.txt) for example narrated output
+from a full cold run.
+
 ## Prerequisites
 
 ### Local Repositories and Images

--- a/demos/grid-llmd-pool-metrics/e2e-demo-output.txt
+++ b/demos/grid-llmd-pool-metrics/e2e-demo-output.txt
@@ -1,0 +1,312 @@
+===============================================================================
+Grid llm-d Pool-Metrics Routing Demo
+Mode: full
+Config: demos/grid-llmd-pool-metrics/forge.yaml
+===============================================================================
+  Images:
+    gateway:      praxis-ai:glb-demo
+    operator:     grid-operator:llmd-pool-metrics-demo
+    epp:          llm-d-epp:llmd-pool-metrics-demo
+    sim:          llm-d-inference-sim:llmd-pool-metrics-demo
+    overlay-sync: grid-overlay-sync:llmd-pool-metrics-demo
+    nginx:        nginx:metrics-proxy-demo
+  tagged praxis-ai:glb-demo -> praxis-ai:llmd-pool-metrics-demo
+
+[SETUP 1/11] Validating Forge config
+  [OK] Config: demos/grid-llmd-pool-metrics/.forge.resolved.yaml
+
+[SETUP 2/11] Generating TLS certificates
+  reusing existing CA certificate
+  reusing cert for pool-a
+  reusing cert for pool-b
+  reusing wrong-org cert
+  [OK] TLS certificates generated for pool-a, pool-b
+  [OK] Metrics TLS certificates generated (separate CA)
+
+[SETUP 3/11] Creating two Kind clusters: pool-a, pool-b
+
+[SETUP 4/11] Loading container images into clusters
+Image: "grid-operator:llmd-pool-metrics-demo" with ID "sha256:aec534367ab833b3d7f8a91d6b00ad580e04379d924c3978363eaf7e78c168f2" not yet present on node "grid-llmd-pm-pool-a-control-plane", loading...
+Image: "grid-overlay-sync:llmd-pool-metrics-demo" with ID "sha256:7318c7840022d224274a3ff4b3b41dbaa2b3168971c40b565bd8e7d78253c675" not yet present on node "grid-llmd-pm-pool-a-control-plane", loading...
+Image: "praxis-ai:llmd-pool-metrics-demo" with ID "sha256:ba793df04668f9835fb8cf7175dff5dbd0f48d6f27f138cdb53d2b71454334fe" not yet present on node "grid-llmd-pm-pool-a-control-plane", loading...
+Image: "llm-d-epp:llmd-pool-metrics-demo" with ID "sha256:ca7b4e42fdc2b4b9f327b245237e55be3b1ca044fd4d96475b1a4cede216b0f0" not yet present on node "grid-llmd-pm-pool-a-control-plane", loading...
+Image: "llm-d-inference-sim:llmd-pool-metrics-demo" with ID "sha256:9b4734b61b1dbd036d63b88f210f1e3a85b724f1fe79230c36b5223cf7289e30" not yet present on node "grid-llmd-pm-pool-a-control-plane", loading...
+Image: "nginx:metrics-proxy-demo" with ID "sha256:dce494e22cc769b643412276f57181a31d17a3b5ae28aeaab420aa6fbc93c6d5" not yet present on node "grid-llmd-pm-pool-a-control-plane", loading...
+  [OK] pool-a: all images loaded
+Image: "grid-operator:llmd-pool-metrics-demo" with ID "sha256:aec534367ab833b3d7f8a91d6b00ad580e04379d924c3978363eaf7e78c168f2" not yet present on node "grid-llmd-pm-pool-b-control-plane", loading...
+Image: "grid-overlay-sync:llmd-pool-metrics-demo" with ID "sha256:7318c7840022d224274a3ff4b3b41dbaa2b3168971c40b565bd8e7d78253c675" not yet present on node "grid-llmd-pm-pool-b-control-plane", loading...
+Image: "praxis-ai:llmd-pool-metrics-demo" with ID "sha256:ba793df04668f9835fb8cf7175dff5dbd0f48d6f27f138cdb53d2b71454334fe" not yet present on node "grid-llmd-pm-pool-b-control-plane", loading...
+Image: "llm-d-epp:llmd-pool-metrics-demo" with ID "sha256:ca7b4e42fdc2b4b9f327b245237e55be3b1ca044fd4d96475b1a4cede216b0f0" not yet present on node "grid-llmd-pm-pool-b-control-plane", loading...
+Image: "llm-d-inference-sim:llmd-pool-metrics-demo" with ID "sha256:9b4734b61b1dbd036d63b88f210f1e3a85b724f1fe79230c36b5223cf7289e30" not yet present on node "grid-llmd-pm-pool-b-control-plane", loading...
+Image: "nginx:metrics-proxy-demo" with ID "sha256:dce494e22cc769b643412276f57181a31d17a3b5ae28aeaab420aa6fbc93c6d5" not yet present on node "grid-llmd-pm-pool-b-control-plane", loading...
+  [OK] pool-b: all images loaded
+
+[SETUP 5/11] Installing MetalLB and Grid operators
+  [OK] pool-a: MetalLB and operator ready
+  [OK] pool-b: MetalLB and operator ready
+
+[SETUP 6/11] Seeding SWIM cross-cluster membership
+  pool-a: SWIM LB IP = 172.19.255.231
+  pool-b: SWIM LB IP = 172.19.255.211
+  pool-a: seeds=172.19.255.211:7946
+  pool-b: seeds=172.19.255.231:7946
+Waiting for deployment "grid-operator" rollout to finish: 1 old replicas are pending termination...
+Waiting for deployment "grid-operator" rollout to finish: 1 old replicas are pending termination...
+deployment "grid-operator" successfully rolled out
+  [OK] pool-a: operator restarted with SWIM seeds
+Waiting for deployment "grid-operator" rollout to finish: 1 old replicas are pending termination...
+Waiting for deployment "grid-operator" rollout to finish: 1 old replicas are pending termination...
+deployment "grid-operator" successfully rolled out
+  [OK] pool-b: operator restarted with SWIM seeds
+
+[SETUP 7/11] Installing metrics TLS secrets for EPP sidecar
+secret/metrics-ca created
+secret/metrics-server-tls created
+secret/metrics-client-tls created
+  [OK] pool-a: metrics TLS secrets installed
+secret/metrics-ca created
+secret/metrics-server-tls created
+secret/metrics-client-tls created
+  [OK] pool-b: metrics TLS secrets installed
+
+[SETUP 8/11] Deploying llm-d simulators and EPP
+  [OK] pool-a: sim-1, sim-2, and EPP running
+  [OK] pool-b: sim-1, sim-2, and EPP running
+
+[SETUP 9/11] Installing provider trust and credentials
+secret/consumer-gateway-tls created
+secret/provider-gateway-tls created
+secret/sim-inference-credential created
+  [OK] pool-a: TLS secrets and credentials installed
+secret/consumer-gateway-tls created
+secret/provider-gateway-tls created
+secret/sim-inference-credential created
+  [OK] pool-b: TLS secrets and credentials installed
+
+[SETUP 10/11] Deploying Grid site resources and gateways
+  [OK] pool-a: site and provider-gateway deployed
+  [OK] pool-b: site and provider-gateway deployed
+  [OK] pool-a: consumer-gateway deployed
+  [OK] pool-b: consumer-gateway deployed
+
+[SETUP 11/11] Waiting for overlay convergence
+  pool-a: authorizing remote provider sites
+  [OK] GridSite "grid-llmd-pool-metrics-pool-b" auto-created by operator (gridNetworkRef="grid-llmd-pool-metrics")
+  [OK] GridSite "grid-llmd-pool-metrics-pool-b": advertised certificate matches the staged identity
+  [OK] GridSite "grid-llmd-pool-metrics-pool-b": canonicalFingerprints + serverName="pool-b.grid.internal" patched
+  [OK] GridSite "grid-llmd-pool-metrics-pool-b": phase="Active" (confirmed)
+  pool-b: authorizing remote provider sites
+  [OK] GridSite "grid-llmd-pool-metrics-pool-a" auto-created by operator (gridNetworkRef="grid-llmd-pool-metrics")
+  [OK] GridSite "grid-llmd-pool-metrics-pool-a": advertised certificate matches the staged identity
+  [OK] GridSite "grid-llmd-pool-metrics-pool-a": canonicalFingerprints + serverName="pool-a.grid.internal" patched
+  [OK] GridSite "grid-llmd-pool-metrics-pool-a": phase="Active" (confirmed)
+  [OK] All auto-discovered remote GridSites authorized and Active
+  [OK] pool-a: overlay converged with both providers
+  [OK] pool-b: overlay converged with both providers
+
+[READY] Environment deployed
+
+===============================================================================
+ENVIRONMENT READY - Starting proof scenarios
+===============================================================================
+  Waiting for pool-a to become preferred (ramp reset)...
+  pool-a: queue=6.0 rank=1 (waiting for ramp reset)
+  pool-a: queue=6.0 rank=1 (waiting for ramp reset)
+  pool-a: queue=6.0 rank=1 (waiting for ramp reset)
+  pool-a: queue=6.0 rank=1 (waiting for ramp reset)
+  pool-a: queue=7.0 rank=1 (waiting for ramp reset)
+  pool-a: queue=7.0 rank=1 (waiting for ramp reset)
+  pool-a: queue=7.0 rank=1 (waiting for ramp reset)
+  pool-a: queue=7.0 rank=1 (waiting for ramp reset)
+  pool-a: queue=7.0 rank=1 (waiting for ramp reset)
+  pool-a: queue=8.0 rank=1 (waiting for ramp reset)
+  pool-a: queue=8.0 rank=1 (waiting for ramp reset)
+  pool-a: queue=8.0 rank=1 (waiting for ramp reset)
+  pool-a: queue=8.0 rank=1 (waiting for ramp reset)
+  pool-a: queue=8.0 rank=1 (waiting for ramp reset)
+  pool-a: queue=8.0 rank=1 (waiting for ramp reset)
+  pool-a: queue=8.0 rank=1 (waiting for ramp reset)
+  pool-a: queue=8.0 rank=1 (waiting for ramp reset)
+  pool-a: queue=9.0 rank=1 (waiting for ramp reset)
+  pool-a: queue=9.0 rank=1 (waiting for ramp reset)
+  pool-a: queue=9.0 rank=1 (waiting for ramp reset)
+  pool-a: queue=9.0 rank=1 (waiting for ramp reset)
+  pool-a: queue=10.0 rank=1 (waiting for ramp reset)
+  pool-a: queue=10.0 rank=1 (waiting for ramp reset)
+  pool-a: queue=10.0 rank=1 (waiting for ramp reset)
+  pool-a: queue=10.0 rank=1 (waiting for ramp reset)
+  pool-a: queue=10.0 rank=1 (waiting for ramp reset)
+  pool-a: queue=10.0 rank=1 (waiting for ramp reset)
+  pool-a: queue=10.0 rank=1 (waiting for ramp reset)
+  pool-a: queue=10.0 rank=1 (waiting for ramp reset)
+  pool-a: queue=10.0 rank=1 (waiting for ramp reset)
+  pool-a: queue=11.0 rank=1 (waiting for ramp reset)
+  pool-a: queue=11.0 rank=1 (waiting for ramp reset)
+  pool-a: queue=11.0 rank=1 (waiting for ramp reset)
+  pool-a: queue=11.0 rank=1 (waiting for ramp reset)
+  pool-a: queue=12.0 rank=1 (waiting for ramp reset)
+  pool-a: queue=12.0 rank=1 (waiting for ramp reset)
+  pool-a: queue=12.0 rank=1 (waiting for ramp reset)
+  pool-a: queue=12.0 rank=1 (waiting for ramp reset)
+  pool-a: queue=12.0 rank=1 (waiting for ramp reset)
+  pool-a: queue=12.0 rank=1 (waiting for ramp reset)
+  pool-a: queue=12.0 rank=1 (waiting for ramp reset)
+  pool-a: queue=12.0 rank=1 (waiting for ramp reset)
+  pool-a: queue=13.0 rank=1 (waiting for ramp reset)
+  pool-a: queue=13.0 rank=1 (waiting for ramp reset)
+  pool-a: queue=13.0 rank=1 (waiting for ramp reset)
+  pool-a: queue=13.0 rank=1 (waiting for ramp reset)
+  pool-a: queue=14.0 rank=1 (waiting for ramp reset)
+  pool-a: queue=14.0 rank=1 (waiting for ramp reset)
+  pool-a: queue=14.0 rank=1 (waiting for ramp reset)
+  pool-a: queue=14.0 rank=1 (waiting for ramp reset)
+  pool-a: queue=14.0 rank=1 (waiting for ramp reset)
+  pool-a: queue=14.0 rank=1 (waiting for ramp reset)
+  pool-a: queue=14.0 rank=1 (waiting for ramp reset)
+  pool-a: queue=14.0 rank=1 (waiting for ramp reset)
+  pool-a: queue=14.0 rank=1 (waiting for ramp reset)
+  pool-a: queue=15.0 rank=1 (waiting for ramp reset)
+  pool-a: queue=15.0 rank=1 (waiting for ramp reset)
+  pool-a: queue=15.0 rank=1 (waiting for ramp reset)
+  pool-a: queue=15.0 rank=1 (waiting for ramp reset)
+
+  LLM-D POOL ROUTING DECISION
+  State: BASELINE
+
+                   Queue  Capacity  Pressure  KV Cache   Score  Rank
+       Cluster A     0.0        16      0.00      0.11   10.77     0
+       Cluster B     1.0        16      0.06      0.15    9.01     1
+  Score breakdown (llmd-pool-a-provider): locality=3.00 queue=3.00 kv=1.77 prefix=1.00 latency=1.00 cost=1.00
+  Score breakdown (llmd-pool-b-provider): locality=1.50 queue=2.81 kv=1.70 prefix=1.00 latency=1.00 cost=1.00
+
+  Grid preference: CLUSTER A
+
+  Polling for pool-a pressure and A→B routing flip...
+  pool-a: queue=3.0 kv=0.28 score=9.88 rank=0  pool-b: score=9.01 rank=1 gap=-0.86
+  pool-a: queue=3.0 kv=0.28 score=9.88 rank=0  pool-b: score=9.01 rank=1 gap=-0.86
+  pool-a: queue=3.0 kv=0.28 score=9.88 rank=0  pool-b: score=9.01 rank=1 gap=-0.86
+  pool-a: queue=3.0 kv=0.28 score=9.88 rank=0  pool-b: score=9.01 rank=1 gap=-0.86
+  pool-a: queue=4.0 kv=0.31 score=9.62 rank=0  pool-b: score=9.01 rank=1 gap=-0.61
+  pool-a: queue=4.0 kv=0.31 score=9.62 rank=0  pool-b: score=9.01 rank=1 gap=-0.61
+  pool-a: queue=4.0 kv=0.31 score=9.62 rank=0  pool-b: score=9.01 rank=1 gap=-0.61
+  pool-a: queue=4.0 kv=0.31 score=9.62 rank=0  pool-b: score=9.01 rank=1 gap=-0.61
+  pool-a: queue=4.0 kv=0.31 score=9.62 rank=0  pool-b: score=9.01 rank=1 gap=-0.61
+  pool-a: queue=4.0 kv=0.35 score=9.56 rank=0  pool-b: score=9.01 rank=1 gap=-0.54
+  pool-a: queue=4.0 kv=0.35 score=9.56 rank=0  pool-b: score=9.01 rank=1 gap=-0.54
+  pool-a: queue=4.0 kv=0.35 score=9.56 rank=0  pool-b: score=9.01 rank=1 gap=-0.54
+  pool-a: queue=4.0 kv=0.35 score=9.56 rank=0  pool-b: score=9.01 rank=1 gap=-0.54
+  pool-a: queue=5.0 kv=0.38 score=9.30 rank=0  pool-b: score=9.01 rank=1 gap=-0.29
+  pool-a: queue=5.0 kv=0.38 score=9.30 rank=0  pool-b: score=9.01 rank=1 gap=-0.29
+  pool-a: queue=5.0 kv=0.38 score=9.30 rank=0  pool-b: score=9.01 rank=1 gap=-0.29
+  pool-a: queue=5.0 kv=0.38 score=9.30 rank=0  pool-b: score=9.01 rank=1 gap=-0.29
+  pool-a: queue=6.0 kv=0.41 score=9.05 rank=0  pool-b: score=9.01 rank=1 gap=-0.04
+  pool-a: queue=6.0 kv=0.41 score=9.05 rank=0  pool-b: score=9.01 rank=1 gap=-0.04
+  pool-a: queue=6.0 kv=0.41 score=9.05 rank=0  pool-b: score=9.01 rank=1 gap=-0.04
+  pool-a: queue=6.0 kv=0.41 score=9.05 rank=0  pool-b: score=9.01 rank=1 gap=-0.04
+  pool-a: queue=6.0 kv=0.45 score=8.98 rank=1  pool-b: score=9.01 rank=0 gap=0.03
+  pool-a: queue=6.0 kv=0.45 score=8.98 rank=1  pool-b: score=9.01 rank=0 gap=0.03
+  pool-a: queue=6.0 kv=0.45 score=8.98 rank=1  pool-b: score=9.01 rank=0 gap=0.03
+  pool-a: queue=6.0 kv=0.45 score=8.98 rank=1  pool-b: score=9.01 rank=0 gap=0.03
+  pool-a: queue=7.0 kv=0.48 score=8.73 rank=1  pool-b: score=9.01 rank=0 gap=0.29
+  pool-a: queue=7.0 kv=0.48 score=8.73 rank=1  pool-b: score=9.01 rank=0 gap=0.29
+  pool-a: queue=7.0 kv=0.48 score=8.73 rank=1  pool-b: score=9.01 rank=0 gap=0.29
+  pool-a: queue=7.0 kv=0.48 score=8.73 rank=1  pool-b: score=9.01 rank=0 gap=0.29
+  pool-a: queue=8.0 kv=0.51 score=8.73 rank=1  pool-b: score=9.01 rank=0 gap=0.29
+  pool-a: queue=8.0 kv=0.51 score=8.47 rank=1  pool-b: score=9.01 rank=0 gap=0.54
+  pool-a: queue=8.0 kv=0.51 score=8.47 rank=1  pool-b: score=9.01 rank=0 gap=0.54
+  pool-a: queue=8.0 kv=0.51 score=8.47 rank=1  pool-b: score=9.01 rank=0 gap=0.54
+  pool-a: queue=8.0 kv=0.51 score=8.47 rank=1  pool-b: score=9.01 rank=0 gap=0.54
+  pool-a: queue=8.0 kv=0.55 score=8.41 rank=1  pool-b: score=9.01 rank=0 gap=0.61
+  pool-a: queue=8.0 kv=0.55 score=8.41 rank=1  pool-b: score=9.01 rank=0 gap=0.61
+  pool-a: queue=8.0 kv=0.55 score=8.41 rank=1  pool-b: score=9.01 rank=0 gap=0.61
+  pool-a: queue=8.0 kv=0.55 score=8.41 rank=1  pool-b: score=9.01 rank=0 gap=0.61
+  pool-a: queue=9.0 kv=0.58 score=8.15 rank=1  pool-b: score=9.01 rank=0 gap=0.86
+  pool-a: queue=9.0 kv=0.58 score=8.15 rank=1  pool-b: score=9.01 rank=0 gap=0.86
+  pool-a: queue=9.0 kv=0.58 score=8.15 rank=1  pool-b: score=9.01 rank=0 gap=0.86
+  pool-a: queue=9.0 kv=0.58 score=8.15 rank=1  pool-b: score=9.01 rank=0 gap=0.86
+
+  LLM-D POOL ROUTING DECISION
+  State: CLUSTER A CAPACITY PRESSURE
+
+                   Queue  Capacity  Pressure  KV Cache   Score  Rank
+       Cluster A    10.0        16      0.62      0.61    7.90     1
+       Cluster B     1.0        16      0.06      0.15    9.01     0
+  Score breakdown (llmd-pool-b-provider): locality=1.50 queue=2.81 kv=1.70 prefix=1.00 latency=1.00 cost=1.00
+  Score breakdown (llmd-pool-a-provider): locality=3.00 queue=1.12 kv=0.77 prefix=1.00 latency=1.00 cost=1.00
+
+  Grid preference: CLUSTER B
+
+  Waiting for pool-a ramp reset and recovery...
+
+  LLM-D POOL ROUTING DECISION
+  State: RECOVERED
+
+                   Queue  Capacity  Pressure  KV Cache   Score  Rank
+       Cluster A     0.0        16      0.00      0.11   10.77     0
+       Cluster B     1.0        16      0.06      0.15    9.01     1
+  Score breakdown (llmd-pool-a-provider): locality=3.00 queue=3.00 kv=1.77 prefix=1.00 latency=1.00 cost=1.00
+  Score breakdown (llmd-pool-b-provider): locality=1.50 queue=2.81 kv=1.70 prefix=1.00 latency=1.00 cost=1.00
+
+  Grid preference: CLUSTER A
+
+
+===============================================================================
+TLS PROOF STAGES
+===============================================================================
+
+  [TLS 1/9] Baseline mTLS
+
+  [TLS 2/9] Handshake rejection
+
+  [TLS 3/9] Missing client identity
+secret "metrics-client-tls" deleted from grid-system namespace
+
+  [TLS 4/9] Wrong CA
+secret/metrics-client-tls created
+secret/metrics-ca configured
+
+  [TLS 5/9] Restore valid mTLS
+secret/metrics-ca configured
+secret/metrics-client-tls unchanged
+
+  [TLS 6/9] Stale-cache TTL
+    baseline: pool-a observable, score=9.05
+secret "metrics-client-tls" deleted from grid-system namespace
+    deleted Secret/metrics-client-tls to break TLS (staleMetricsSeconds=20)
+    inside-TTL (2s/20s): pool-a still observable, score=8.98 (cached metrics served)
+    post-TTL (28s/20s): pool-a unobservable (cached metrics expired, UNOBSERVABLE_METRICS applied)
+secret/metrics-client-tls created
+    recovery: pool-a observable after client cert restored, score=7.83
+
+  [TLS 7/9] Client Secret rotation
+secret/metrics-client-tls configured
+
+  [TLS 8/9] Server cert rotation
+secret/metrics-server-tls configured
+deployment.apps/llmd-epp restarted
+Waiting for deployment "llmd-epp" rollout to finish: 1 old replicas are pending termination...
+Waiting for deployment "llmd-epp" rollout to finish: 1 old replicas are pending termination...
+deployment "llmd-epp" successfully rolled out
+
+  [TLS 9/9] Existing routing behavior
+
+  Restart accounting
+    pool-a/operator/grid-operator-5d547d8dd-ltht6: uid unchanged, restart_count=0
+    pool-a/epp/llmd-epp-5f8584b68c-5p75s: new pod after server cert rotation (expected), restart_count=0
+    pool-a/gateway/consumer-gateway-75785956d9-tlwh8: overlay-sync restarts=0
+    pool-a/gateway/consumer-gateway-75785956d9-tlwh8: praxis restarts=0
+    pool-a/gateway/provider-gateway-75db8f4547-bdsc5: praxis restarts=0
+    pool-b/operator/grid-operator-f4f679f-dsmdq: uid unchanged, restart_count=0
+    pool-b/epp/llmd-epp-b9cf6694c-2xsmf: uid unchanged, restart_count=0
+    pool-b/gateway/consumer-gateway-797c5844bb-t8p9l: overlay-sync restarts=0
+    pool-b/gateway/consumer-gateway-797c5844bb-t8p9l: praxis restarts=0
+    pool-b/gateway/provider-gateway-7cf855c4f6-j2kzv: praxis restarts=0
+    server rotation (stage 8) on pool-a: EPP rollout restart is expected — nginx does not reload TLS in-place
+
+[TEARDOWN] Removing Kind clusters
+  [OK] Teardown complete
+
+===============================================================================
+DEMO PASSED  (469.3s)
+Evidence: demos/grid-llmd-pool-metrics/evidence/20260805T041659Z/evidence.json
+===============================================================================

--- a/demos/grid-llmd-pool-metrics/forge.yaml
+++ b/demos/grid-llmd-pool-metrics/forge.yaml
@@ -33,6 +33,7 @@ spec:
         eppImageTag: "llmd-pool-metrics-demo"
         simImageRepo: "llm-d-inference-sim"
         simImageTag: "llmd-pool-metrics-demo"
+        nginxImage: "nginx:metrics-proxy-demo"
         poolName: pool-a
 
     - name: pool-b
@@ -54,6 +55,7 @@ spec:
         eppImageTag: "llmd-pool-metrics-demo"
         simImageRepo: "llm-d-inference-sim"
         simImageTag: "llmd-pool-metrics-demo"
+        nginxImage: "nginx:metrics-proxy-demo"
         poolName: pool-b
 
   stacks:
@@ -151,6 +153,8 @@ spec:
         - type: manifest
           path: resources/common/epp-rbac.yaml
         - type: manifest
+          path: resources/common/metrics-tls-proxy-config.yaml
+        - type: manifest
           path: resources/pool-a/sim-config.yaml
         - type: manifest
           path: resources/pool-a/sim-deployment.yaml
@@ -190,6 +194,8 @@ spec:
           path: resources/common/inferencepool-crd.yaml
         - type: manifest
           path: resources/common/epp-rbac.yaml
+        - type: manifest
+          path: resources/common/metrics-tls-proxy-config.yaml
         - type: manifest
           path: resources/pool-b/sim-config.yaml
         - type: manifest
@@ -282,13 +288,21 @@ spec:
                 metricsConfig:
                   path: /metrics
                   timeout: "2s"
-                  metricsEndpoint: "http://llmd-epp-metrics.grid-system.svc.cluster.local:9090"
+                  staleMetricsSeconds: 20
+                  metricsEndpoint: "https://llmd-epp-metrics.grid-system.svc.cluster.local:9443"
                   poolName: "{{ cluster.properties.poolName }}"
                   queueCapacity: 16
                   signalNames:
                     kvCacheUtilization: llm_d_router_epp_average_kv_cache_utilization
                     queueDepth: llm_d_router_epp_average_queue_size
                     healthy: llm_d_router_epp_ready_endpoints
+                  tls:
+                    caSecretRef:
+                      name: metrics-ca
+                      namespace: grid-system
+                    clientCertificateSecretRef:
+                      name: metrics-client-tls
+                      namespace: grid-system
 
     pool-b-site:
       description: Pool-B combined site with Grid CRs
@@ -351,13 +365,21 @@ spec:
                 metricsConfig:
                   path: /metrics
                   timeout: "2s"
-                  metricsEndpoint: "http://llmd-epp-metrics.grid-system.svc.cluster.local:9090"
+                  staleMetricsSeconds: 20
+                  metricsEndpoint: "https://llmd-epp-metrics.grid-system.svc.cluster.local:9443"
                   poolName: "{{ cluster.properties.poolName }}"
                   queueCapacity: 16
                   signalNames:
                     kvCacheUtilization: llm_d_router_epp_average_kv_cache_utilization
                     queueDepth: llm_d_router_epp_average_queue_size
                     healthy: llm_d_router_epp_ready_endpoints
+                  tls:
+                    caSecretRef:
+                      name: metrics-ca
+                      namespace: grid-system
+                    clientCertificateSecretRef:
+                      name: metrics-client-tls
+                      namespace: grid-system
 
     provider-gateway:
       description: Praxis provider gateway with mTLS and credential mounts

--- a/demos/grid-llmd-pool-metrics/resources/common/metrics-tls-proxy-config.yaml
+++ b/demos/grid-llmd-pool-metrics/resources/common/metrics-tls-proxy-config.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: metrics-tls-proxy-config
+  namespace: grid-system
+  labels:
+    app.kubernetes.io/part-of: grid-llmd-pool-metrics
+data:
+  nginx.conf: |
+    worker_processes 1;
+    error_log /dev/stderr warn;
+    pid /tmp/nginx.pid;
+
+    events {
+        worker_connections 64;
+    }
+
+    http {
+        client_body_temp_path /tmp/client_body_temp;
+        proxy_temp_path /tmp/proxy_temp;
+        fastcgi_temp_path /tmp/fastcgi_temp;
+        uwsgi_temp_path /tmp/uwsgi_temp;
+        scgi_temp_path /tmp/scgi_temp;
+
+        server {
+            listen 9443 ssl;
+
+            ssl_certificate /etc/nginx/server-tls/tls.crt;
+            ssl_certificate_key /etc/nginx/server-tls/tls.key;
+            ssl_client_certificate /etc/nginx/client-ca/ca.crt;
+            ssl_verify_client on;
+            ssl_protocols TLSv1.2 TLSv1.3;
+
+            location /metrics {
+                proxy_pass http://127.0.0.1:9090/metrics;
+            }
+        }
+    }

--- a/demos/grid-llmd-pool-metrics/resources/pool-a/epp-deployment.yaml
+++ b/demos/grid-llmd-pool-metrics/resources/pool-a/epp-deployment.yaml
@@ -65,6 +65,44 @@ spec:
             limits:
               cpu: 500m
               memory: 256Mi
+        - name: metrics-tls-proxy
+          image: "nginx:metrics-proxy-demo"
+          imagePullPolicy: "Never"
+          ports:
+            - name: metrics-tls
+              containerPort: 9443
+          volumeMounts:
+            - name: metrics-proxy-config
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
+            - name: metrics-server-tls
+              mountPath: /etc/nginx/server-tls
+              readOnly: true
+            - name: metrics-client-ca
+              mountPath: /etc/nginx/client-ca
+              readOnly: true
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            runAsNonRoot: true
+          resources:
+            requests:
+              cpu: 50m
+              memory: 32Mi
+            limits:
+              cpu: 200m
+              memory: 64Mi
+      volumes:
+        - name: metrics-proxy-config
+          configMap:
+            name: metrics-tls-proxy-config
+        - name: metrics-server-tls
+          secret:
+            secretName: metrics-server-tls
+        - name: metrics-client-ca
+          secret:
+            secretName: metrics-ca
 ---
 apiVersion: v1
 kind: Service
@@ -99,6 +137,6 @@ spec:
   selector:
     app.kubernetes.io/name: llmd-epp
   ports:
-    - name: metrics
-      port: 9090
-      targetPort: 9090
+    - name: metrics-tls
+      port: 9443
+      targetPort: 9443

--- a/demos/grid-llmd-pool-metrics/resources/pool-b/epp-deployment.yaml
+++ b/demos/grid-llmd-pool-metrics/resources/pool-b/epp-deployment.yaml
@@ -65,6 +65,44 @@ spec:
             limits:
               cpu: 500m
               memory: 256Mi
+        - name: metrics-tls-proxy
+          image: "nginx:metrics-proxy-demo"
+          imagePullPolicy: "Never"
+          ports:
+            - name: metrics-tls
+              containerPort: 9443
+          volumeMounts:
+            - name: metrics-proxy-config
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
+            - name: metrics-server-tls
+              mountPath: /etc/nginx/server-tls
+              readOnly: true
+            - name: metrics-client-ca
+              mountPath: /etc/nginx/client-ca
+              readOnly: true
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            runAsNonRoot: true
+          resources:
+            requests:
+              cpu: 50m
+              memory: 32Mi
+            limits:
+              cpu: 200m
+              memory: 64Mi
+      volumes:
+        - name: metrics-proxy-config
+          configMap:
+            name: metrics-tls-proxy-config
+        - name: metrics-server-tls
+          secret:
+            secretName: metrics-server-tls
+        - name: metrics-client-ca
+          secret:
+            secretName: metrics-ca
 ---
 apiVersion: v1
 kind: Service
@@ -99,6 +137,6 @@ spec:
   selector:
     app.kubernetes.io/name: llmd-epp
   ports:
-    - name: metrics
-      port: 9090
-      targetPort: 9090
+    - name: metrics-tls
+      port: 9443
+      targetPort: 9443

--- a/demos/grid-metrics-mtls/README.md
+++ b/demos/grid-metrics-mtls/README.md
@@ -1,0 +1,74 @@
+# Metrics mTLS Demo
+
+Demonstrates Secret-backed TLS and mutual TLS (mTLS) for
+`InferenceProvider.spec.metricsConfig` scraping.
+
+## Prerequisites
+
+- A running Grid operator
+- `openssl` or `cfssl` for certificate generation
+
+## Create Secrets
+
+Generate a CA and server certificate, then create Kubernetes Secrets.
+The operator reads these at reconcile time to build a TLS client for
+metrics scraping.
+
+```bash
+# One-way TLS: CA secret only
+kubectl create secret generic metrics-ca \
+  --namespace=grid-system \
+  --from-file=ca.crt=ca.pem
+
+# mTLS: CA + client identity
+kubectl create secret generic metrics-ca \
+  --namespace=grid-system \
+  --from-file=ca.crt=ca.pem
+
+kubectl create secret tls metrics-client-cert \
+  --namespace=grid-system \
+  --cert=client.pem \
+  --key=client-key.pem
+```
+
+## Apply example resources
+
+```bash
+# One-way TLS (server verification only)
+kubectl apply -f resources/inferenceprovider-tls.yaml
+
+# Mutual TLS (server + client verification)
+kubectl apply -f resources/inferenceprovider-mtls.yaml
+```
+
+## Verify
+
+```bash
+kubectl get inferenceprovider -o wide
+```
+
+| Phase | Meaning |
+|-------|---------|
+| `Available` | TLS material valid, scraping works |
+| `Degraded` | TLS Secret missing, key absent, or PEM invalid |
+| `Unavailable` | Other config error (endpoint, auth, network) |
+
+Check `status.reason` for the specific failure code:
+`MetricsTlsSecretMissing`, `MetricsTlsKeyMissing`,
+`MetricsTlsMaterialInvalid`, or `MetricsTlsIdentityMismatch`.
+
+## Failure modes
+
+| Scenario | status.reason | Scoring |
+|----------|---------------|---------|
+| Secret does not exist | `MetricsTlsSecretMissing` | excluded |
+| Key absent from Secret | `MetricsTlsKeyMissing` | excluded |
+| PEM cannot be parsed | `MetricsTlsMaterialInvalid` | excluded |
+| Client cert/key mismatch | `MetricsTlsIdentityMismatch` | excluded |
+| TLS handshake fails at scrape time | (none) | stale cache / excluded |
+| Server rejects client cert | (none) | stale cache / excluded |
+
+"Excluded" means the provider is inserted with `healthy: false`,
+causing the scoring engine to remove it from active routing.
+When a valid cached sample exists within `staleMetricsSeconds`,
+the stale cache is used instead.

--- a/demos/grid-metrics-mtls/resources/inferenceprovider-mtls.yaml
+++ b/demos/grid-metrics-mtls/resources/inferenceprovider-mtls.yaml
@@ -1,0 +1,35 @@
+# InferenceProvider with mutual TLS (mTLS) metrics scraping.
+#
+# The operator verifies the metrics endpoint's certificate against the
+# CA, and presents a client certificate for the endpoint to verify.
+# Both caSecretRef and clientCertificateSecretRef are required for mTLS.
+apiVersion: grid.praxis-proxy.io/v1alpha1
+kind: InferenceProvider
+metadata:
+  name: vllm-mtls
+spec:
+  gridNetworkRef: my-network
+  providerKind: self_hosted
+  backendKind: local
+  endpoint: https://vllm.inference:8443
+  models:
+    - name: llama-3.1-8b
+  metricsConfig:
+    path: /metrics
+    timeout: "2s"
+    staleMetricsSeconds: 30
+    signalNames:
+      queueDepth: vllm:num_requests_waiting
+      kvCacheUtilization: vllm:gpu_cache_usage_perc
+      latencyP99Ms: vllm:e2e_request_latency_seconds
+      prefixCacheHitRatio: vllm:prefix_cache_hit_rate
+    tls:
+      caSecretRef:
+        name: metrics-ca
+        namespace: grid-system
+        key: ca.crt
+      clientCertificateSecretRef:
+        name: metrics-client-cert
+        namespace: grid-system
+        certificateKey: tls.crt
+        privateKeyKey: tls.key

--- a/demos/grid-metrics-mtls/resources/inferenceprovider-tls.yaml
+++ b/demos/grid-metrics-mtls/resources/inferenceprovider-tls.yaml
@@ -1,0 +1,26 @@
+# InferenceProvider with one-way TLS metrics scraping.
+#
+# The operator verifies the metrics endpoint's certificate against the
+# CA in the referenced Secret.  No client certificate is presented.
+apiVersion: grid.praxis-proxy.io/v1alpha1
+kind: InferenceProvider
+metadata:
+  name: vllm-tls
+spec:
+  gridNetworkRef: my-network
+  providerKind: self_hosted
+  backendKind: local
+  endpoint: https://vllm.inference:8443
+  models:
+    - name: llama-3.1-8b
+  metricsConfig:
+    path: /metrics
+    timeout: "2s"
+    signalNames:
+      queueDepth: vllm:num_requests_waiting
+      kvCacheUtilization: vllm:gpu_cache_usage_perc
+    tls:
+      caSecretRef:
+        name: metrics-ca
+        namespace: grid-system
+        key: ca.crt

--- a/demos/grid-workload-inference/README.md
+++ b/demos/grid-workload-inference/README.md
@@ -63,6 +63,9 @@ site.
 cargo xtask env run-grid-glb-demo --no-ingress --quick --teardown
 ```
 
+See [e2e-demo-output.txt](e2e-demo-output.txt) for example narrated output
+from a quick cold run.
+
 ## Prerequisites
 
 - Rust stable 1.96+

--- a/demos/grid-workload-inference/e2e-demo-output.txt
+++ b/demos/grid-workload-inference/e2e-demo-output.txt
@@ -1,0 +1,242 @@
+===============================================================================
+ENVIRONMENT SETUP
+===============================================================================
+
+[SETUP 1/7] Staging demo certificates and provider identities
+  reusing existing CA certificate
+  reusing cert for east-edge
+  reusing cert for west-edge
+  reusing cert for edge-untrusted
+  reusing cert for east-provider
+  reusing cert for west-provider
+  reusing wrong-org cert
+
+[SETUP 2/7] Creating four Kind clusters on one shared cross-cluster network
+            Forge will report again after cluster creation completes.
+
+[SETUP 3/7] Resolving and loading runtime images
+  gateway:       praxis-ai:glb-demo
+  operator:      grid-operator:glb-demo
+  mock provider: grid-mock-providers:glb-demo
+  pull policy:   Never
+
+[SETUP 4/7] Installing MetalLB, SWIM services, and Grid operators
+
+[SETUP 5/7] Installing provider trust, credentials, and policy
+secret/edge-gateway-tls created
+secret/edge-gateway-tls created
+configmap/provider-gateway-config created
+secret/provider-gateway-tls created
+secret/mock-inference-credential created
+secret/mock-inference-secondary-credential created
+configmap/provider-gateway-config created
+secret/provider-gateway-tls created
+secret/mock-inference-credential created
+grid-routing: edge identities, provider configs, mTLS material, and credentials installed
+
+[SETUP 6/7] Deploying two provider gateways and three private inference providers
+
+[SETUP 7/7] Configuring edge trust and deploying Praxis edge gateways
+  [OK] east-edge: local edge site configured
+  [OK] west-edge: local edge site configured
+
+  east-edge trust view: authorizing providers discovered through Grid
+  [OK] GridSite "glb-demo-east-provider" auto-created by operator (gridNetworkRef="glb-demo")
+  [OK] GridSite "glb-demo-east-provider": advertised certificate matches the staged identity
+  [OK] GridSite "glb-demo-east-provider": canonicalFingerprints + serverName="east-provider.grid.internal" patched
+  [OK] GridSite "glb-demo-east-provider": phase="Active" (confirmed)
+  [OK] GridSite "glb-demo-west-provider" auto-created by operator (gridNetworkRef="glb-demo")
+  [OK] GridSite "glb-demo-west-provider": advertised certificate matches the staged identity
+  [OK] GridSite "glb-demo-west-provider": canonicalFingerprints + serverName="west-provider.grid.internal" patched
+  [OK] GridSite "glb-demo-west-provider": phase="Active" (confirmed)
+
+  west-edge trust view: authorizing providers discovered through Grid
+  [OK] GridSite "glb-demo-east-provider" auto-created by operator (gridNetworkRef="glb-demo")
+  [OK] GridSite "glb-demo-east-provider": advertised certificate matches the staged identity
+  [OK] GridSite "glb-demo-east-provider": canonicalFingerprints + serverName="east-provider.grid.internal" patched
+  [OK] GridSite "glb-demo-east-provider": phase="Active" (confirmed)
+  [OK] GridSite "glb-demo-west-provider" auto-created by operator (gridNetworkRef="glb-demo")
+  [OK] GridSite "glb-demo-west-provider": advertised certificate matches the staged identity
+  [OK] GridSite "glb-demo-west-provider": canonicalFingerprints + serverName="west-provider.grid.internal" patched
+  [OK] GridSite "glb-demo-west-provider": phase="Active" (confirmed)
+  [OK] east-edge: Praxis edge gateway deployed
+  [OK] west-edge: Praxis edge gateway deployed
+
+[SETUP 8/7] Waiting for both edge-local routing overlays to converge
+            Each edge must receive one complete, versioned provider view.
+            This proves distribution; Praxis acceptance is verified next.
+  distributed → east-edge: revision=2e72db5b51ec21d4…
+  distributed → west-edge: revision=c93cdc56350ee985…
+
+[READY] Environment deployed from demos/grid-glb-demo/.forge.resolved.yaml
+        east-edge=3 candidates, projected `ConfigMap`, west-edge=3 candidates, projected `ConfigMap`
+
+===============================================================================
+PRAXIS GRID WORKLOAD INFERENCE DEMO
+===============================================================================
+
+Mode: QUICK
+Proof policy: Every PASS comes from a runtime assertion; manifest intent is not
+              counted as proof.
+
+EXPECTED PATH
+  workload -> local Praxis consumer gateway
+           -> Grid-selected provider gateway -> private backend
+
+No traffic manager or public endpoint involved.
+
+===============================================================================
+DEMO 1 | GRID ROUTING AND PROVIDER BOUNDARY
+===============================================================================
+
+USER STORY
+  As a platform operator, I need the Grid mesh to converge, discover providers,
+  and enforce the provider security boundary.
+
+DETAILED RUNTIME PROOF
+-------------------------------------------------------------------------------
+  [CHECK] Prerequisites
+  [CHECK] validating forge config
+  [CHECK] checking environment status
+  [CHECK] checking clusters live
+  [CHECK] checking provider gateway IPs
+  [CHECK] checking SWIM LB services
+  [CHECK] checking operator SWIM advertise address
+  [CHECK] checking GridNetwork seeds
+  [CHECK] checking overlay candidate metadata
+  rendered → revision=2e72db5b51ec21d4…
+  distributed → revision=2e72db5b51ec21d4…, resourceVersion=6618
+  [CHECK] checking multiple providers in one site overlay
+  [CHECK] checking provider gateway self-discovery
+  [CHECK] checking remote GridSite egress addresses
+  [CHECK] checking provider service selector
+  [CHECK] checking provider gateway pods
+  [CHECK] checking backend private service
+  [CHECK] checking backend network policy
+  [CHECK] checking provider mTLS trust matrix
+  [CHECK] checking provider peer policy
+  [CHECK] checking provider request boundary
+  [CHECK] checking edge config applied
+  [CHECK] checking edge overlay projections
+  distributed → east-edge: revision=2e72db5b51ec21d4…
+  distributed → west-edge: revision=c93cdc56350ee985…
+  [CHECK] capturing edge gateway pod identity
+  accepted → east-edge: revision=2e72db5b51ec21d4…
+  accepted → west-edge: revision=c93cdc56350ee985…
+  [CHECK] sending inference request
+  serving → revision=2e72db5b51ec21d4…
+  [CHECK] routing to both providers hosted by the east site
+  waiting for mock-inference in east-provider (ns=grid-system)...
+Waiting for deployment "mock-inference" rollout to finish: 1 old replicas are pending termination...
+Waiting for deployment "mock-inference" rollout to finish: 1 old replicas are pending termination...
+deployment "mock-inference" successfully rolled out
+  waiting for mock-inference in east-provider (ns=grid-system)...
+Waiting for deployment "mock-inference" rollout to finish: 0 out of 1 new replicas have been updated...
+Waiting for deployment "mock-inference" rollout to finish: 1 old replicas are pending termination...
+Waiting for deployment "mock-inference" rollout to finish: 1 old replicas are pending termination...
+deployment "mock-inference" successfully rolled out
+
+RUNTIME PROOF RESULTS
+-------------------------------------------------------------------------------
+Grid must update live edge routing from discovered provider state while authenticated provider gateways protect private backends.
+
+
+| Step | Result | Evidence |
+|---|---|---|
+| prerequisites | **PASS** | config validation passed |
+| forge status | **PASS** | forge status returned OK |
+| clusters live | **PASS** | all 4 clusters live |
+| provider gateway IPs | **PASS** | east-provider=172.19.255.232, west-provider=172.19.255.212 |
+| swim lb services | **PASS** | east-edge=172.19.255.191, east-provider=172.19.255.231, west-edge=172.19.255.171, west-provider=172.19.255.211 |
+| swim advertise addr | **PASS** | east-edge=172.19.255.191:7946, east-provider=172.19.255.231:7946, west-edge=172.19.255.171:7946, west-provider=172.19.255.211:7946 |
+| gridnetwork seeds | **PASS** | seeds: east-edge=3, east-provider=3, west-edge=3, west-provider=3 |
+| overlay metadata | **PASS** | dual-key: 3 candidate(s), validated: stable_id, admission_state, selection_tier, rank, generated_at; envelope: schema=1.0.0, revision=2e72db5b51ec21d4…, annotations and Grid status verified |
+| same-site provider candidates | **PASS** | east-edge: east-provider clusters=[sim-east-provider,sim-east-provider-secondary], stable_ids=[84f799fe,eaf38b2d]; west-edge: east-provider clusters=[sim-east-provider,sim-east-provider-secondary], stable_ids=[84f799fe,eaf38b2d] |
+| provider gateway addr | **PASS** | east-provider=172.19.255.232:8443 (self-discovered, broadcast via SWIM), west-provider=172.19.255.212:8443 (self-discovered, broadcast via SWIM) |
+| remote gridsite egress | **PASS** | east-provider=172.19.255.232:8443, west-provider=172.19.255.212:8443 |
+| provider service selector | **PASS** | east-provider: port=8443, selector={"app.kubernetes.io/instance":"provider-gateway","app.kubernetes.io/name":"provider-gateway"}; west-provider: port=8443, selector={"app.kubernetes.io/instance":"provider-gateway","app.kubernetes.io/name":"provider-gateway"} |
+| provider gateway pods | **PASS** | east-provider: Running, image=praxis-ai:glb-demo; west-provider: Running, image=praxis-ai:glb-demo |
+| backend private service | **PASS** | east-provider/mock-inference: type=ClusterIP; east-provider/mock-inference-secondary: type=ClusterIP; west-provider/mock-inference: type=ClusterIP |
+| backend network policy | **PASS** | east-provider/primary: allowed=connected, unlabeled=denied, no_auth=HTTP_401, client_auth=HTTP_403; east-provider/secondary: allowed=connected, unlabeled=denied, no_auth=HTTP_401, client_auth=HTTP_403; west-provider/primary: allowed=connected, unlabeled=denied, no_auth=HTTP_401, client_auth=HTTP_403 |
+| provider mTLS trust matrix | **PASS** | east-provider: valid_edges=2, no_cert/wrong_sni/wrong_ca=TLS_REFUSED; west-provider: valid_edges=2, no_cert/wrong_sni/wrong_ca=TLS_REFUSED |
+| provider peer policy | **PASS** | east-provider: wrong_org=HTTP_403, unknown_digest=HTTP_403; west-provider: wrong_org=HTTP_403, unknown_digest=HTTP_403 |
+| provider request boundary | **PASS** | east-provider: unknown_candidate=HTTP_403, wrong_path=HTTP_404; west-provider: unknown_candidate=HTTP_403, wrong_path=HTTP_404 |
+| edge config applied | **PASS** | GridNetwork 'glb-demo' applied on both edge clusters |
+| edge overlays mounted | **PASS** | east-edge=3 candidates, projected `ConfigMap`, west-edge=3 candidates, projected `ConfigMap` |
+| edge gateways running | **PASS** | east-edge=uid:5db52839-76a…, restarts:0, accepted_revision:2e72db5b51ec21d4…, west-edge=uid:0d4e8cc9-bfc…, restarts:0, accepted_revision:c93cdc56350ee985… |
+| inference routed | **PASS** | HTTP 200, model=sim-model-v1, provider=east-provider, gateway=east-provider, backend_request_id=5844fa9c98a429af…, overlay_revision=2e72db5b51ec21d4…, provider credential replaced client-supplied credential |
+| same-site providers routed | **PASS** | east-provider gateway routed sim-model-v1 to independent providers east-provider and east-provider-secondary; provider=east-provider, queue_depth=0.95, overlay admission_state=existing_only; overlay reload observed: before=3, after=4; queue_depth=0.10, overlay admission_state=new_and_existing; overlay reload observed: before=4, after=5 |
+
+[PASS] All routing and provider-boundary proof points passed.
+
+===============================================================================
+DEMO 2 | IN-CLUSTER WORKLOAD ROUTING
+===============================================================================
+
+USER STORY
+  As a platform workload, I need requests from inside the consumer cluster to
+  reach a Grid-selected provider without any external ingress.
+configmap/workload-request-body created
+job.batch/workload-request-31559 created
+configmap/workload-request-body created
+job.batch/workload-request-36801 created
+
+OBSERVED WORKLOAD ROUTES
+  [PASS] east-edge -> east-provider
+         workload -> east-edge consumer gateway -> east-provider gateway -> east-provider backend
+  [PASS] west-edge -> west-provider
+         workload -> west-edge consumer gateway -> west-provider gateway -> west-provider backend
+
+===============================================================================
+DEMO 3 | SECURE PROVIDER BOUNDARY
+===============================================================================
+
+USER STORY
+  As a provider and security owner, I need authenticated Grid traffic, exact
+  local policy, private backend isolation, and final-hop credential
+  replacement.
+
+[PASS] Both provider gateways required mTLS, accepted both pinned edge
+       identities, rejected missing or invalid TLS identities, and enforced
+       exact candidate/model/path policy for three provider candidates.
+
+[PASS] All three private provider paths are isolated by NetworkPolicy and
+       provider-local credentials; the two east providers use distinct backends
+       and credentials behind one site gateway.
+
+[SKIP] Local preference/fallback runs only in full mode.
+
+===============================================================================
+DEMONSTRATED BOUNDARY
+===============================================================================
+
+[PROVEN] In-cluster workloads reached Grid-selected providers through local
+         consumer gateways without external ingress.
+[PROVEN] Versioned overlays with provider candidates, plus
+         rendered/distributed/accepted/serving revision evidence.
+[PROVEN] Provider mTLS, peer authorization, and credential replacement.
+[NOT APPLICABLE] Edge withdrawal and GTM steering (workload mode has no traffic
+                 manager).
+
+[CLEANUP] Tearing down demo clusters...
+[CLEANUP] Teardown complete.
+
+===============================================================================
+FINAL RESULT
+===============================================================================
+[PASS   ] Observable overlay contract
+          one revision matched rendered/distributed/accepted/serving evidence
+[PASS   ] Secure provider boundary
+          mTLS, peer auth, NetworkPolicy, credential replacement verified
+[PASS   ] In-cluster workload routing
+          2 consumer cluster(s) routed to provider via in-cluster Jobs
+[NOT_APPLICABLE] Edge withdrawal and recovery
+          workload mode has no traffic manager
+[SKIPPED] Local preference and remote fallback
+          quick mode
+
+OVERALL   PASS
+MODE      WORKLOAD-QUICK
+ELAPSED   407.6s
+EVIDENCE  demos/grid-workload-inference/evidence
+[EVIDENCE] Human narration and results.json written to demos/grid-workload-inference/evidence

--- a/demos/grid-workload-inference/evidence/narration.txt
+++ b/demos/grid-workload-inference/evidence/narration.txt
@@ -1,0 +1,87 @@
+
+===============================================================================
+PRAXIS GRID WORKLOAD INFERENCE DEMO
+===============================================================================
+
+Mode: QUICK
+Proof policy: Every PASS comes from a runtime assertion; manifest intent is not
+              counted as proof.
+
+EXPECTED PATH
+  workload -> local Praxis consumer gateway
+           -> Grid-selected provider gateway -> private backend
+
+No traffic manager or public endpoint involved.
+
+===============================================================================
+DEMO 1 | GRID ROUTING AND PROVIDER BOUNDARY
+===============================================================================
+
+USER STORY
+  As a platform operator, I need the Grid mesh to converge, discover providers,
+  and enforce the provider security boundary.
+
+===============================================================================
+DEMO 2 | IN-CLUSTER WORKLOAD ROUTING
+===============================================================================
+
+USER STORY
+  As a platform workload, I need requests from inside the consumer cluster to
+  reach a Grid-selected provider without any external ingress.
+
+OBSERVED WORKLOAD ROUTES
+  [PASS] east-edge -> east-provider
+         workload -> east-edge consumer gateway -> east-provider gateway -> east-provider backend
+  [PASS] west-edge -> west-provider
+         workload -> west-edge consumer gateway -> west-provider gateway -> west-provider backend
+
+===============================================================================
+DEMO 3 | SECURE PROVIDER BOUNDARY
+===============================================================================
+
+USER STORY
+  As a provider and security owner, I need authenticated Grid traffic, exact
+  local policy, private backend isolation, and final-hop credential
+  replacement.
+
+[PASS] Both provider gateways required mTLS, accepted both pinned edge
+       identities, rejected missing or invalid TLS identities, and enforced
+       exact candidate/model/path policy for three provider candidates.
+
+[PASS] All three private provider paths are isolated by NetworkPolicy and
+       provider-local credentials; the two east providers use distinct backends
+       and credentials behind one site gateway.
+
+[SKIP] Local preference/fallback runs only in full mode.
+
+===============================================================================
+DEMONSTRATED BOUNDARY
+===============================================================================
+
+[PROVEN] In-cluster workloads reached Grid-selected providers through local
+         consumer gateways without external ingress.
+[PROVEN] Versioned overlays with provider candidates, plus
+         rendered/distributed/accepted/serving revision evidence.
+[PROVEN] Provider mTLS, peer authorization, and credential replacement.
+[NOT APPLICABLE] Edge withdrawal and GTM steering (workload mode has no traffic
+                 manager).
+[CLEANUP] Teardown complete.
+
+===============================================================================
+FINAL RESULT
+===============================================================================
+[PASS   ] Observable overlay contract
+          one revision matched rendered/distributed/accepted/serving evidence
+[PASS   ] Secure provider boundary
+          mTLS, peer auth, NetworkPolicy, credential replacement verified
+[PASS   ] In-cluster workload routing
+          2 consumer cluster(s) routed to provider via in-cluster Jobs
+[NOT_APPLICABLE] Edge withdrawal and recovery
+          workload mode has no traffic manager
+[SKIPPED] Local preference and remote fallback
+          quick mode
+
+OVERALL   PASS
+MODE      WORKLOAD-QUICK
+ELAPSED   407.6s
+EVIDENCE  demos/grid-workload-inference/evidence

--- a/demos/grid-workload-inference/evidence/results.json
+++ b/demos/grid-workload-inference/evidence/results.json
@@ -1,0 +1,59 @@
+{
+  "schema_version": "1",
+  "run_id": "20260805T040717Z",
+  "mode": "workload-quick",
+  "started_at": "2026-08-05T04:07:17Z",
+  "completed_at": "2026-08-05T04:14:05Z",
+  "duration_secs": 407.605479064,
+  "status": "pass",
+  "error": null,
+  "capabilities": [
+    {
+      "capability": "Observable overlay contract",
+      "result": "pass",
+      "evidence": "one revision matched rendered/distributed/accepted/serving evidence"
+    },
+    {
+      "capability": "Secure provider boundary",
+      "result": "pass",
+      "evidence": "mTLS, peer auth, NetworkPolicy, credential replacement verified"
+    },
+    {
+      "capability": "In-cluster workload routing",
+      "result": "pass",
+      "evidence": "2 consumer cluster(s) routed to provider via in-cluster Jobs"
+    },
+    {
+      "capability": "Edge withdrawal and recovery",
+      "result": "not_applicable",
+      "evidence": "workload mode has no traffic manager"
+    },
+    {
+      "capability": "Local preference and remote fallback",
+      "result": "skipped",
+      "evidence": "quick mode"
+    }
+  ],
+  "observed_paths": [
+    {
+      "edge": "east-edge",
+      "provider": "east-provider",
+      "path": "workload -> east-edge consumer gateway -> east-provider gateway -> east-provider backend"
+    },
+    {
+      "edge": "west-edge",
+      "provider": "west-provider",
+      "path": "workload -> west-edge consumer gateway -> west-provider gateway -> west-provider backend"
+    }
+  ],
+  "lifecycle": {
+    "teardown_requested": true,
+    "teardown_performed": true,
+    "teardown_result": "success",
+    "kept_on_failure": false
+  },
+  "artifacts": {
+    "narration": "demos/grid-workload-inference/evidence/narration.txt",
+    "results": "demos/grid-workload-inference/evidence/results.json"
+  }
+}

--- a/deploy/crds/inferenceprovider.yaml
+++ b/deploy/crds/inferenceprovider.yaml
@@ -12,377 +12,439 @@ spec:
     singular: inferenceprovider
   scope: Cluster
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .spec.providerKind
-          name: Provider
-          type: string
-        - jsonPath: .status.phase
-          name: Phase
-          type: string
-      name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: Auto-generated derived type for InferenceProviderSpec via `CustomResource`
-          properties:
-            spec:
-              description: Specification for an [`InferenceProvider`].
-              properties:
-                accessPolicy:
-                  default:
-                    siteSelector:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.providerKind
+      name: Provider
+      type: string
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Auto-generated derived type for InferenceProviderSpec via `CustomResource`
+        properties:
+          spec:
+            description: Specification for an [`InferenceProvider`].
+            properties:
+              accessPolicy:
+                default:
+                  siteSelector:
+                    matchLabels: {}
+                description: Which sites can consume this provider.
+                properties:
+                  siteSelector:
+                    default:
                       matchLabels: {}
-                  description: Which sites can consume this provider.
-                  properties:
-                    siteSelector:
-                      default:
-                        matchLabels: {}
-                      description: Which sites can route to this provider.
-                      properties:
-                        matchLabels:
-                          additionalProperties:
-                            type: string
-                          default: {}
-                          description: Label key-value pairs that must match.
-                          type: object
-                      type: object
-                  type: object
-                auth:
-                  description: Authentication configuration.
-                  nullable: true
-                  properties:
-                    manual:
-                      default: false
-                      description: |-
-                        Whether the user manages credentials manually.
-
-                        When true, the operator does not inject credentials
-                        and the user is responsible for configuring auth.
-                      type: boolean
-                    secretRef:
-                      description: Reference to a Secret containing the credential.
-                      nullable: true
-                      properties:
-                        key:
-                          description: |-
-                            Key within the Secret's `data` map.
-
-                            Required when the Secret holds multiple keys (e.g. credential references
-                            in `InferenceProvider.spec.auth.secretRef`).  Omit only when the entire
-                            Secret is consumed (e.g. TLS `ca_secret_ref`).
-                          nullable: true
-                          type: string
-                        name:
-                          description: Secret name.
-                          type: string
-                        namespace:
-                          description: Secret namespace.
-                          type: string
-                      required:
-                        - name
-                        - namespace
-                      type: object
-                    strategy:
-                      description: How credentials are presented to the provider.
-                      enum:
-                        - api_key
-                        - bearer_token
-                        - custom
-                        - mtls_only
-                        - oauth2
-                        - service_account
-                        - sigv4
-                      type: string
-                  required:
-                    - strategy
-                  type: object
-                backendKind:
-                  description: Backend deployment category.
-                  type: string
-                cost:
-                  description: Cost information.
-                  nullable: true
-                  properties:
-                    perMillionInputTokens:
-                      default: 0.0
-                      description: Cost per million input tokens (USD).
-                      format: double
-                      type: number
-                    perMillionOutputTokens:
-                      default: 0.0
-                      description: Cost per million output tokens (USD).
-                      format: double
-                      type: number
-                  type: object
-                endpoint:
-                  description: HTTP endpoint URL.
-                  type: string
-                gridNetworkRef:
-                  description: |-
-                    Name of the [`GridNetwork`] this provider belongs to.
-
-                    [`GridNetwork`]: crate::crd::grid_network::GridNetwork
-                  type: string
-                healthCheck:
-                  description: Health check configuration.
-                  nullable: true
-                  properties:
-                    interval:
-                      description: Check interval (e.g. "30s").
-                      nullable: true
-                      type: string
-                    path:
-                      description: HTTP path for health probes.
-                      nullable: true
-                      type: string
-                    timeout:
-                      description: Timeout per check (e.g. "5s").
-                      nullable: true
-                      type: string
-                  type: object
-                metricsConfig:
-                  description: |-
-                    Prometheus metrics scraping configuration.
-
-                    When set, the Grid operator scrapes the provider's metrics endpoint during
-                    each [`GridNetwork`] reconcile and incorporates the parsed signals into the
-                    routing overlay scoring pass.  When absent, the provider uses locality and
-                    cost as the only scoring signals (static ordering).
-
-                    [`GridNetwork`]: crate::crd::grid_network::GridNetwork
-                  nullable: true
-                  properties:
-                    metricsEndpoint:
-                      description: |-
-                        Base URL for the metrics endpoint, independent of `spec.endpoint`.
-
-                        When set, the scrape URL is `{metrics_endpoint}{path}` instead of
-                        `{spec.endpoint}{path}`.  This allows scraping metrics from a separate
-                        service (such as an llm-d EPP) while the provider inference endpoint
-                        points at the pool's request path.
-
-                        When absent, the scrape URL uses `spec.endpoint` as before.
-                      minLength: 1
-                      nullable: true
-                      type: string
-                    path:
-                      default: /metrics
-                      description: |-
-                        HTTP path for the Prometheus metrics endpoint.
-
-                        Appended to `metrics_endpoint` (when set) or `spec.endpoint`.
-                        Defaults to `"/metrics"` when absent.
-                      type: string
-                    poolName:
-                      description: |-
-                        Expected Prometheus `name` label value for pool-level metric selection.
-
-                        When set, the parser only matches metric samples whose `name` label
-                        equals this value.  This is required when scraping an endpoint that
-                        exposes metrics for multiple pools (such as an llm-d EPP), ensuring
-                        the configured pool is selected deterministically.
-
-                        The parser rejects the scrape when the expected pool series is absent
-                        or when a metric sample has no `name` label and this field is set.
-
-                        When absent, labels are stripped before matching as in v1 (backward
-                        compatible).
-                      minLength: 1
-                      nullable: true
-                      type: string
-                    queueCapacity:
-                      description: |-
-                        Maximum queue slot count for normalising a raw queue-size metric to
-                        0.0–1.0.
-
-                        When set, the `queue_depth` signal value is divided by this capacity
-                        and clamped to `[0.0, 1.0]` before scoring.  This allows consuming raw
-                        average queue-size metrics (such as `llm_d_router_epp_average_queue_size`)
-                        without requiring the exporter to pre-normalise.
-
-                        When absent, the `queue_depth` signal must already be normalised to
-                        0.0–1.0 by the exporter (backward compatible).
-                      format: uint32
-                      minimum: 1.0
-                      nullable: true
-                      type: integer
-                    signalNames:
-                      default:
-                        errorRate: null
-                        healthy: null
-                        kvCacheUtilization: null
-                        latencyP99Ms: null
-                        prefixCacheHitRatio: null
-                        queueDepth: null
-                      description: |-
-                        Mapping from scoring signal names to Prometheus metric names.
-
-                        Signals without a configured name are skipped during parsing and receive the
-                        neutral default value (`0.5`) in scoring.
-                      properties:
-                        errorRate:
-                          description: Metric name for normalised error rate (0.0–1.0).
-                          nullable: true
-                          type: string
-                        healthy:
-                          description: Metric name for a health gauge (any positive value = healthy).
-                          nullable: true
-                          type: string
-                        kvCacheUtilization:
-                          description: Metric name for KV-cache utilisation (0.0–1.0).
-                          nullable: true
-                          type: string
-                        latencyP99Ms:
-                          description: Metric name for P99 request latency in milliseconds (pre-computed gauge).
-                          nullable: true
-                          type: string
-                        prefixCacheHitRatio:
-                          description: Metric name for prefix-cache hit ratio (0.0–1.0).
-                          nullable: true
-                          type: string
-                        queueDepth:
-                          description: Metric name for normalised queue depth (0.0–1.0).
-                          nullable: true
-                          type: string
-                      type: object
-                    staleMetricsSeconds:
-                      description: |-
-                        Maximum age in seconds for which a previously-scraped metric sample may be
-                        used when the current scrape fails.
-
-                        When a Prometheus scrape fails (connection refused, timeout, HTTP error) the
-                        operator normally drops the provider's metrics and falls back to neutral
-                        (`0.5`) scoring for all signals.  Setting this field enables a grace period:
-                        if the last *successful* scrape is no older than `stale_metrics_seconds`, that
-                        cached sample is used instead of neutral scoring.
-
-                        After the grace period expires, or when no successful scrape has ever been
-                        recorded for this reconcile epoch, the provider returns to neutral scoring.
-
-                        **Default (absent):** no grace period — scrape failures immediately produce
-                        neutral scoring.  This preserves backward-compatible behaviour.
-
-                        **Minimum value:** `1` second.  The schema rejects `0`; the operator also
-                        treats zero defensively as absent.
-                      format: uint32
-                      minimum: 1.0
-                      nullable: true
-                      type: integer
-                    timeout:
-                      default: 2s
-                      description: |-
-                        Per-request scrape timeout (e.g. `"2s"`, `"500ms"`).
-
-                        Defaults to `"2s"`.  Only `s` and `ms` suffixes are recognised; unrecognised
-                        values fall back to the default.
-                      type: string
-                  type: object
-                models:
-                  default: []
-                  description: Models served by this provider.
-                  items:
-                    description: Model metadata for an inference provider.
+                    description: Which sites can route to this provider.
                     properties:
-                      capabilities:
-                        default: []
-                        description: Supported capabilities.
-                        items:
+                      matchLabels:
+                        additionalProperties:
                           type: string
-                        type: array
-                      contextWindow:
-                        description: Maximum context window size.
-                        format: uint32
-                        minimum: 0.0
+                        default: {}
+                        description: Label key-value pairs that must match.
+                        type: object
+                    type: object
+                type: object
+              auth:
+                description: Authentication configuration.
+                nullable: true
+                properties:
+                  manual:
+                    default: false
+                    description: |-
+                      Whether the user manages credentials manually.
+
+                      When true, the operator does not inject credentials
+                      and the user is responsible for configuring auth.
+                    type: boolean
+                  secretRef:
+                    description: Reference to a Secret containing the credential.
+                    nullable: true
+                    properties:
+                      key:
+                        description: |-
+                          Key within the Secret's `data` map.
+
+                          Required when the Secret holds multiple keys (e.g. credential references
+                          in `InferenceProvider.spec.auth.secretRef`).  Omit only when the entire
+                          Secret is consumed (e.g. TLS `ca_secret_ref`).
+                        minLength: 1
                         nullable: true
-                        type: integer
+                        type: string
                       name:
-                        description: Model name.
+                        description: Secret name.
+                        minLength: 1
+                        type: string
+                      namespace:
+                        description: Secret namespace.
+                        minLength: 1
                         type: string
                     required:
-                      - name
+                    - name
+                    - namespace
                     type: object
-                  type: array
-                providerKind:
-                  description: Inference provider type.
-                  type: string
-                routingClusterRef:
-                  description: |-
-                    Optional routing identity used in overlay candidate `site` and `cluster` fields.
-
-                    When set, routing overlay candidates produced for this provider use this value
-                    instead of `metadata.name`:
-
-                    - In Phase 1 (no [`GridSite`] inventory), both `candidate.site` and `candidate.cluster` are set to this value.
-                    - When [`GridSite`] resources are present, only `candidate.cluster` is overridden; `candidate.site` is derived
-                      from the matched `GridSite`.
-
-                    Use this to align the provider's routing identity with an upstream cluster
-                    name already configured in the consumer gateway, such as a Praxis
-                    `load_balancer` cluster entry.  When absent, `metadata.name` is used.
-
-                    [`GridSite`]: crate::crd::grid_site::GridSite
-                  nullable: true
-                  type: string
-                siteSelector:
-                  default:
-                    matchLabels: {}
-                  description: Which sites host this provider.
-                  properties:
-                    matchLabels:
-                      additionalProperties:
-                        type: string
-                      default: {}
-                      description: Label key-value pairs that must match.
-                      type: object
-                  type: object
-              required:
-                - backendKind
-                - endpoint
-                - gridNetworkRef
-                - providerKind
-              type: object
-            status:
-              description: Observed status of an [`InferenceProvider`].
-              nullable: true
-              properties:
-                matchingSites:
-                  default: []
-                  description: Sites matched by the site selector.
-                  items:
+                  strategy:
+                    description: How credentials are presented to the provider.
+                    enum:
+                    - api_key
+                    - bearer_token
+                    - custom
+                    - mtls_only
+                    - oauth2
+                    - service_account
+                    - sigv4
                     type: string
-                  type: array
-                observedGeneration:
-                  default: 0
-                  description: Last observed generation.
-                  format: int64
-                  type: integer
-                phase:
-                  default: Pending
-                  description: Current phase.
-                  enum:
-                    - Pending
-                    - Available
-                    - Degraded
-                    - Unavailable
-                  type: string
-                reason:
-                  description: |-
-                    Machine-readable reason for the current phase when not `Available`.
+                required:
+                - strategy
+                type: object
+              backendKind:
+                description: Backend deployment category.
+                type: string
+              cost:
+                description: Cost information.
+                nullable: true
+                properties:
+                  perMillionInputTokens:
+                    default: 0.0
+                    description: Cost per million input tokens (USD).
+                    format: double
+                    type: number
+                  perMillionOutputTokens:
+                    default: 0.0
+                    description: Cost per million output tokens (USD).
+                    format: double
+                    type: number
+                type: object
+              endpoint:
+                description: HTTP endpoint URL.
+                type: string
+              gridNetworkRef:
+                description: |-
+                  Name of the [`GridNetwork`] this provider belongs to.
 
-                    Set when the provider cannot reach `Available` due to a configuration
-                    or credential error.  `None` when the provider is `Available`, `Pending`,
-                    or the reason is unknown.
+                  [`GridNetwork`]: crate::crd::grid_network::GridNetwork
+                type: string
+              healthCheck:
+                description: Health check configuration.
+                nullable: true
+                properties:
+                  interval:
+                    description: Check interval (e.g. "30s").
+                    nullable: true
+                    type: string
+                  path:
+                    description: HTTP path for health probes.
+                    nullable: true
+                    type: string
+                  timeout:
+                    description: Timeout per check (e.g. "5s").
+                    nullable: true
+                    type: string
+                type: object
+              metricsConfig:
+                description: |-
+                  Prometheus metrics scraping configuration.
 
-                    Stable reason values: `UnsupportedAuthStrategy`, `CredentialSecretRefInvalid`,
-                    `CredentialSecretMissing`, `CredentialSecretKeyMissing`,
-                    `CredentialSecretValueInvalid`.
-                  nullable: true
+                  When set, the Grid operator scrapes the provider's metrics endpoint during
+                  each [`GridNetwork`] reconcile and incorporates the parsed signals into the
+                  routing overlay scoring pass.  When absent, the provider uses locality and
+                  cost as the only scoring signals (static ordering).
+
+                  [`GridNetwork`]: crate::crd::grid_network::GridNetwork
+                nullable: true
+                properties:
+                  metricsEndpoint:
+                    description: |-
+                      Base URL for the metrics endpoint, independent of `spec.endpoint`.
+
+                      When set, the scrape URL is `{metrics_endpoint}{path}` instead of
+                      `{spec.endpoint}{path}`.  This allows scraping metrics from a separate
+                      service (such as an llm-d EPP) while the provider inference endpoint
+                      points at the pool's request path.
+
+                      When absent, the scrape URL uses `spec.endpoint` as before.
+                    minLength: 1
+                    nullable: true
+                    type: string
+                  path:
+                    default: /metrics
+                    description: |-
+                      HTTP path for the Prometheus metrics endpoint.
+
+                      Appended to `metrics_endpoint` (when set) or `spec.endpoint`.
+                      Defaults to `"/metrics"` when absent.
+                    type: string
+                  poolName:
+                    description: |-
+                      Expected Prometheus `name` label value for pool-level metric selection.
+
+                      When set, the parser only matches metric samples whose `name` label
+                      equals this value.  This is required when scraping an endpoint that
+                      exposes metrics for multiple pools (such as an llm-d EPP), ensuring
+                      the configured pool is selected deterministically.
+
+                      The parser rejects the scrape when the expected pool series is absent
+                      or when a metric sample has no `name` label and this field is set.
+
+                      When absent, labels are stripped before matching as in v1 (backward
+                      compatible).
+                    minLength: 1
+                    nullable: true
+                    type: string
+                  queueCapacity:
+                    description: "Maximum queue slot count for normalising a raw queue-size metric to\n0.0\u20131.0.\n\nWhen set, the `queue_depth` signal value is divided by this capacity\nand clamped\
+                      \ to `[0.0, 1.0]` before scoring.  This allows consuming raw\naverage queue-size metrics (such as `llm_d_router_epp_average_queue_size`)\nwithout requiring the exporter to pre-normalise.\n\
+                      \nWhen absent, the `queue_depth` signal must already be normalised to\n0.0\u20131.0 by the exporter (backward compatible)."
+                    format: uint32
+                    minimum: 1.0
+                    nullable: true
+                    type: integer
+                  signalNames:
+                    default:
+                      errorRate: null
+                      healthy: null
+                      kvCacheUtilization: null
+                      latencyP99Ms: null
+                      prefixCacheHitRatio: null
+                      queueDepth: null
+                    description: |-
+                      Mapping from scoring signal names to Prometheus metric names.
+
+                      Signals without a configured name are skipped during parsing and receive the
+                      neutral default value (`0.5`) in scoring.
+                    properties:
+                      errorRate:
+                        description: "Metric name for normalised error rate (0.0\u20131.0)."
+                        nullable: true
+                        type: string
+                      healthy:
+                        description: Metric name for a health gauge (any positive value = healthy).
+                        nullable: true
+                        type: string
+                      kvCacheUtilization:
+                        description: "Metric name for KV-cache utilisation (0.0\u20131.0)."
+                        nullable: true
+                        type: string
+                      latencyP99Ms:
+                        description: Metric name for P99 request latency in milliseconds (pre-computed gauge).
+                        nullable: true
+                        type: string
+                      prefixCacheHitRatio:
+                        description: "Metric name for prefix-cache hit ratio (0.0\u20131.0)."
+                        nullable: true
+                        type: string
+                      queueDepth:
+                        description: "Metric name for normalised queue depth (0.0\u20131.0)."
+                        nullable: true
+                        type: string
+                    type: object
+                  staleMetricsSeconds:
+                    description: "Maximum age in seconds for which a previously-scraped metric sample may be\nused when the current scrape fails.\n\nWhen a Prometheus scrape fails (connection refused, timeout,\
+                      \ HTTP error) the\noperator normally drops the provider's metrics and falls back to neutral\n(`0.5`) scoring for all signals.  Setting this field enables a grace period:\nif the last\
+                      \ *successful* scrape is no older than `stale_metrics_seconds`, that\ncached sample is used instead of neutral scoring.\n\nAfter the grace period expires, or when no successful scrape\
+                      \ has ever been\nrecorded for this reconcile epoch, the provider returns to neutral scoring.\n\n**Default (absent):** no grace period \u2014 scrape failures immediately produce\nneutral\
+                      \ scoring.  This preserves backward-compatible behaviour.\n\n**Minimum value:** `1` second.  The schema rejects `0`; the operator also\ntreats zero defensively as absent."
+                    format: uint32
+                    minimum: 1.0
+                    nullable: true
+                    type: integer
+                  timeout:
+                    default: 2s
+                    description: |-
+                      Per-request scrape timeout (e.g. `"2s"`, `"500ms"`).
+
+                      Defaults to `"2s"`.  Only `s` and `ms` suffixes are recognised; unrecognised
+                      values fall back to the default.
+                    type: string
+                  tls:
+                    description: |-
+                      TLS configuration for the metrics endpoint.
+
+                      When set, the operator uses the provided CA certificate for TLS server
+                      verification and optionally presents a client certificate for mutual TLS
+                      (mTLS).  When absent, the scraper uses system root certificates
+                      (backward-compatible).
+
+                      **Fail-closed:** when configured but the referenced Secrets cannot be
+                      resolved or contain invalid material, the scrape is skipped entirely.
+                      The scraper never falls back to system roots or plain HTTP.
+                    nullable: true
+                    properties:
+                      caSecretRef:
+                        description: "Reference to a Secret containing the CA certificate PEM for server\nverification.\n\nThe Secret must contain the PEM-encoded CA certificate under the key\n`ca.crt`\
+                          \ (or the key specified by `key`).  When this CA is\nset, the scraper trusts **only** this CA \u2014 system root certificates\nare not consulted."
+                        properties:
+                          key:
+                            description: |-
+                              Key within the Secret's `data` map.
+
+                              Required when the Secret holds multiple keys (e.g. credential references
+                              in `InferenceProvider.spec.auth.secretRef`).  Omit only when the entire
+                              Secret is consumed (e.g. TLS `ca_secret_ref`).
+                            minLength: 1
+                            nullable: true
+                            type: string
+                          name:
+                            description: Secret name.
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: Secret namespace.
+                            minLength: 1
+                            type: string
+                        required:
+                        - name
+                        - namespace
+                        type: object
+                      clientCertificateSecretRef:
+                        description: |-
+                          Reference to a Secret containing the client certificate and private
+                          key for mutual TLS.
+
+                          When set, the scraper presents this identity during the TLS handshake.
+                          The Secret must contain `tls.crt` (or `certificate_key`) and
+                          `tls.key` (or `private_key_key`) in PEM format.
+
+                          When absent, the scraper performs one-way TLS only (server verification
+                          with the CA from `ca_secret_ref`, no client certificate).
+                        nullable: true
+                        properties:
+                          certificateKey:
+                            default: tls.crt
+                            description: Key within `Secret.data` holding the PEM-encoded client certificate.
+                            minLength: 1
+                            type: string
+                          name:
+                            description: Secret name.
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: Secret namespace.
+                            minLength: 1
+                            type: string
+                          privateKeyKey:
+                            default: tls.key
+                            description: Key within `Secret.data` holding the PEM-encoded private key.
+                            minLength: 1
+                            type: string
+                        required:
+                        - name
+                        - namespace
+                        type: object
+                    required:
+                    - caSecretRef
+                    type: object
+                type: object
+              models:
+                default: []
+                description: Models served by this provider.
+                items:
+                  description: Model metadata for an inference provider.
+                  properties:
+                    capabilities:
+                      default: []
+                      description: Supported capabilities.
+                      items:
+                        type: string
+                      type: array
+                    contextWindow:
+                      description: Maximum context window size.
+                      format: uint32
+                      minimum: 0.0
+                      nullable: true
+                      type: integer
+                    name:
+                      description: Model name.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              providerKind:
+                description: Inference provider type.
+                type: string
+              routingClusterRef:
+                description: |-
+                  Optional routing identity used in overlay candidate `site` and `cluster` fields.
+
+                  When set, routing overlay candidates produced for this provider use this value
+                  instead of `metadata.name`:
+
+                  - In Phase 1 (no [`GridSite`] inventory), both `candidate.site` and `candidate.cluster` are set to this value.
+                  - When [`GridSite`] resources are present, only `candidate.cluster` is overridden; `candidate.site` is derived
+                    from the matched `GridSite`.
+
+                  Use this to align the provider's routing identity with an upstream cluster
+                  name already configured in the consumer gateway, such as a Praxis
+                  `load_balancer` cluster entry.  When absent, `metadata.name` is used.
+
+                  [`GridSite`]: crate::crd::grid_site::GridSite
+                nullable: true
+                type: string
+              siteSelector:
+                default:
+                  matchLabels: {}
+                description: Which sites host this provider.
+                properties:
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    default: {}
+                    description: Label key-value pairs that must match.
+                    type: object
+                type: object
+            required:
+            - backendKind
+            - endpoint
+            - gridNetworkRef
+            - providerKind
+            type: object
+          status:
+            description: Observed status of an [`InferenceProvider`].
+            nullable: true
+            properties:
+              matchingSites:
+                default: []
+                description: Sites matched by the site selector.
+                items:
                   type: string
-              type: object
-          required:
-            - spec
-          title: InferenceProvider
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                type: array
+              observedGeneration:
+                default: 0
+                description: Last observed generation.
+                format: int64
+                type: integer
+              phase:
+                default: Pending
+                description: Current phase.
+                enum:
+                - Pending
+                - Available
+                - Degraded
+                - Unavailable
+                type: string
+              reason:
+                description: |-
+                  Machine-readable reason for the current phase when not `Available`.
+
+                  Set when the provider cannot reach `Available` due to a configuration,
+                  credential, or metrics collection error.  `None` when the provider is
+                  `Available`, `Pending`, or the reason is unknown.
+
+                  Stable reason values:
+                  - `UnsupportedAuthStrategy`, `CredentialSecretRefInvalid`, `CredentialSecretMissing`,
+                    `CredentialSecretKeyMissing`, `CredentialSecretValueInvalid`
+                  - `MetricsTlsSecretMissing`, `MetricsTlsKeyMissing`, `MetricsTlsMaterialInvalid`,
+                    `MetricsTlsIdentityMismatch`
+                nullable: true
+                type: string
+            type: object
+        required:
+        - spec
+        title: InferenceProvider
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/deploy/operator/cluster-role-resources.yaml
+++ b/deploy/operator/cluster-role-resources.yaml
@@ -11,15 +11,21 @@ rules:
   #   - TLS site certificate (tls.crt, tls.key for mTLS client auth)
   #   - SWIM encryption key (swimKeyRef)
   #   - Credential Secrets (existence + key validation only)
+  #   - Metrics TLS CA and client certificate Secrets
   #
   # Write paths:
   #   - Grid CA certificate Secret (ca.crt, ca.key)
   #   - Grid site certificate Secret (tls.crt, tls.key)
   #
+  # The operator reads Secrets by explicit namespace/name during
+  # reconciliation — no cluster-wide list or watch.  TLS material
+  # rotation is detected by bounded requeue (60s for TLS-configured
+  # providers).
+  #
   # All writes use server-side apply (patch).  SSA on a non-existent
   # resource requires create permission, so both create and patch are
-  # granted.  delete, list, and watch are not granted.  The namespace
-  # for each Secret is declared in the CRD spec (SecretRef.namespace).
+  # granted.  The namespace for each Secret is declared in the CRD
+  # spec (SecretRef.namespace).
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "create", "patch"]

--- a/docs/architecture/crds.md
+++ b/docs/architecture/crds.md
@@ -471,6 +471,10 @@ spec:
       prefixCacheHitRatio: provider_prefix_cache_hit_ratio
       errorRate: provider_error_rate
       healthy: provider_healthy
+    tls:
+      caSecretRef:
+        name: metrics-ca
+        namespace: grid-system
 ```
 
 **Phases**: Pending → Available → Degraded → Unavailable
@@ -530,6 +534,7 @@ feeds the resulting `BackendMetrics` into overlay scoring.
 | `timeout` | `2s` | Scrape timeout. `s` and `ms` suffixes are recognized. |
 | `signalNames` | all unset | Mapping from scoring signals to Prometheus metric names. |
 | `staleMetricsSeconds` | absent | Grace period (seconds) for using a cached sample when the current scrape fails.  When absent, scrape failures immediately produce neutral scoring.  Minimum: `1`. |
+| `tls` | absent | TLS configuration for metrics scraping.  See [TLS and mTLS](#tls-and-mtls). |
 
 Providers without `metricsConfig`, providers with failed scrapes (outside any
 configured grace period), and signals without configured metric names use neutral
@@ -546,6 +551,77 @@ in the routing architecture for the full semantics.
 | `prefixCacheHitRatio` | Prefix-cache hit ratio from `0.0` to `1.0`. |
 | `errorRate` | Error rate from `0.0` to `1.0`. |
 | `healthy` | Health gauge interpreted by the metrics parser. |
+
+#### TLS and mTLS
+
+`metricsConfig.tls` enables Secret-backed TLS (and optionally mutual TLS)
+for metrics scraping.  When configured, the operator resolves PEM material
+from Kubernetes Secrets at reconcile time and uses it for all scrape
+requests to this provider's metrics endpoint.
+
+| Field | Required | Meaning |
+|-------|----------|---------|
+| `tls.caSecretRef` | yes | Secret containing the CA certificate for server verification. Default key: `ca.crt`. |
+| `tls.clientCertificateSecretRef` | no | Secret containing client certificate and private key for mTLS. |
+| `tls.clientCertificateSecretRef.certificateKey` | no | Key within `Secret.data` for the certificate PEM. Default: `tls.crt`. |
+| `tls.clientCertificateSecretRef.privateKeyKey` | no | Key within `Secret.data` for the private key PEM. Default: `tls.key`. |
+
+`caSecretRef` follows the same [`SecretRef`](#secretref) schema used by
+`spec.auth.secretRef`.  `clientCertificateSecretRef` adds explicit
+`certificateKey` and `privateKeyKey` fields with serde defaults.
+
+**Failure behavior**: when TLS material cannot be resolved or parsed, the
+provider phase is downgraded from `Available` to `Degraded` with a
+machine-readable `status.reason`:
+
+| Reason | Category | Meaning |
+|--------|----------|---------|
+| `MetricsTlsSecretMissing` | reconcile-time | A referenced Secret does not exist. |
+| `MetricsTlsKeyMissing` | reconcile-time | The expected key is absent from `Secret.data`. |
+| `MetricsTlsMaterialInvalid` | reconcile-time | PEM material could not be parsed. |
+| `MetricsTlsIdentityMismatch` | reconcile-time | Client certificate and private key do not match. |
+| `MetricsTlsHandshakeFailed` | scrape-time | TLS handshake failed (wrong CA, expired cert, hostname mismatch). |
+| `MetricsUnauthorized` | scrape-time | Metrics endpoint returned HTTP 401 or 403. |
+| `MetricsScrapeTimeout` | scrape-time | Metrics scrape timed out before receiving a response. |
+
+Scrape-time failures are logged with the classified reason.  The provider
+falls back to the stale metrics cache (if `staleMetricsSeconds` is set) or
+is excluded from routing with `UNOBSERVABLE_METRICS` (`healthy: false`).
+
+There is no `insecureSkipVerify` option.
+
+Example (one-way TLS):
+
+```yaml
+metricsConfig:
+  path: /metrics
+  timeout: 2s
+  signalNames:
+    queueDepth: vllm:num_requests_waiting
+  tls:
+    caSecretRef:
+      name: metrics-ca
+      namespace: grid-system
+```
+
+Example (mTLS):
+
+```yaml
+metricsConfig:
+  path: /metrics
+  timeout: 2s
+  signalNames:
+    queueDepth: vllm:num_requests_waiting
+  tls:
+    caSecretRef:
+      name: metrics-ca
+      namespace: grid-system
+    clientCertificateSecretRef:
+      name: metrics-client-cert
+      namespace: grid-system
+      certificateKey: tls.crt
+      privateKeyKey: tls.key
+```
 
 #### Queue depth normalization
 

--- a/mock-providers/src/openai.rs
+++ b/mock-providers/src/openai.rs
@@ -7,8 +7,6 @@
 //! The `/v1/responses` streaming path uses SSE `data:` events with an embedded
 //! `type` field (e.g. `"response.created"`, `"response.output_text.delta"`,
 //! `"response.completed"`) rather than named SSE events.
-
-
 use axum::{
     Router,
     body::Body,

--- a/operator/Cargo.toml
+++ b/operator/Cargo.toml
@@ -24,6 +24,7 @@ kube = { workspace = true }
 prometheus = { workspace = true }
 schemars = { workspace = true }
 rustls = { workspace = true }
+rustls-pemfile = { workspace = true }
 sha2 = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/operator/src/controller/grid_network.rs
+++ b/operator/src/controller/grid_network.rs
@@ -110,6 +110,13 @@ impl OperatorCtx {
 /// Requeue interval after a successful reconciliation.
 const REQUEUE_INTERVAL: Duration = Duration::from_secs(300);
 
+/// Shorter requeue interval when any provider in the network has
+/// `metricsConfig.tls` configured.  Without a cluster-wide Secret watch,
+/// this bounded interval detects TLS material rotation for the metrics
+/// collection and overlay publication that happen in the `GridNetwork`
+/// reconcile loop.
+const TLS_REQUEUE_INTERVAL: Duration = Duration::from_secs(60);
+
 /// Field manager name for server-side apply.
 const FIELD_MANAGER: &str = "grid-operator";
 
@@ -241,7 +248,8 @@ pub async fn reconcile(network: Arc<GridNetwork>, ctx: Arc<OperatorCtx>) -> Resu
     // List providers once; share between routing overlay rendering and CRDT publishing.
     let providers = list_all_inference_providers(client).await?;
     let raw_metrics =
-        provider_metrics::collect_provider_metrics(name, &providers, &ctx.metrics_cache, Instant::now()).await;
+        provider_metrics::collect_provider_metrics(name, &providers, &ctx.metrics_cache, Instant::now(), Some(client))
+            .await;
 
     let remote_crdt_providers: Vec<crdt::ProviderState> = ctx
         .swim
@@ -312,7 +320,7 @@ pub async fn reconcile(network: Arc<GridNetwork>, ctx: Arc<OperatorCtx>) -> Resu
         reconcile_discovered_sites(name, swim.site_name(), snapshot, client, plaintext).await?;
     }
 
-    Ok(Action::requeue(REQUEUE_INTERVAL))
+    Ok(Action::requeue(requeue_interval_for_network(&providers)))
 }
 
 /// Apply `spec.tls.swimKeyRef` before any reconcile-triggered SWIM send.
@@ -1916,6 +1924,28 @@ async fn reconcile_discovered_sites(
     }
 
     Ok(())
+}
+
+/// Compute the requeue interval for a [`GridNetwork`] reconcile.
+///
+/// When any [`InferenceProvider`] in the network has `metricsConfig.tls`
+/// configured, returns [`TLS_REQUEUE_INTERVAL`] (60 s) so the metrics
+/// collection and overlay publication in this reconcile loop detect
+/// certificate rotation without a cluster-wide Secret watch.
+///
+/// For networks with only plaintext metrics (or no metrics), returns the
+/// default [`REQUEUE_INTERVAL`] (300 s).
+///
+/// [`InferenceProvider`]: crate::crd::inference_provider::InferenceProvider
+fn requeue_interval_for_network(providers: &[InferenceProvider]) -> Duration {
+    let any_has_tls = providers
+        .iter()
+        .any(|p| p.spec.metrics_config.as_ref().is_some_and(|mc| mc.tls.is_some()));
+    if any_has_tls {
+        TLS_REQUEUE_INTERVAL
+    } else {
+        REQUEUE_INTERVAL
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -3957,5 +3987,100 @@ mod tests {
         let first = eligible.first().unwrap_or_else(|| std::process::abort());
         assert_eq!(first.site_id, "site-a", "filter must not alter provider identity");
         assert_eq!(first.network_id, "net", "filter must not alter provider network");
+    }
+
+    // -----------------------------------------------------------------------
+    // requeue_interval_for_network
+    // -----------------------------------------------------------------------
+
+    fn make_provider_with_tls(name: &str, network_ref: &str) -> InferenceProvider {
+        serde_json::from_value(serde_json::json!({
+            "apiVersion": "grid.praxis-proxy.io/v1alpha1",
+            "kind": "InferenceProvider",
+            "metadata": { "name": name },
+            "spec": {
+                "gridNetworkRef": network_ref,
+                "providerKind": "self_hosted",
+                "backendKind": "local",
+                "endpoint": "http://localhost:8000",
+                "models": [],
+                "metricsConfig": {
+                    "endpoint": "https://localhost:9090/metrics",
+                    "tls": {
+                        "caSecretRef": { "namespace": "ns", "name": "ca" }
+                    }
+                }
+            }
+        }))
+        .unwrap_or_else(|_| std::process::abort())
+    }
+
+    fn make_provider_with_tls_and_health_interval(name: &str, network_ref: &str, interval: &str) -> InferenceProvider {
+        serde_json::from_value(serde_json::json!({
+            "apiVersion": "grid.praxis-proxy.io/v1alpha1",
+            "kind": "InferenceProvider",
+            "metadata": { "name": name },
+            "spec": {
+                "gridNetworkRef": network_ref,
+                "providerKind": "self_hosted",
+                "backendKind": "local",
+                "endpoint": "http://localhost:8000",
+                "models": [],
+                "healthCheck": { "interval": interval },
+                "metricsConfig": {
+                    "endpoint": "https://localhost:9090/metrics",
+                    "tls": {
+                        "caSecretRef": { "namespace": "ns", "name": "ca" }
+                    }
+                }
+            }
+        }))
+        .unwrap_or_else(|_| std::process::abort())
+    }
+
+    #[test]
+    fn network_requeue_no_tls_uses_default() {
+        let providers = vec![
+            make_inference_provider("p1", "net"),
+            make_inference_provider("p2", "net"),
+        ];
+        assert_eq!(
+            requeue_interval_for_network(&providers),
+            REQUEUE_INTERVAL,
+            "networks with no TLS providers should use 300s"
+        );
+    }
+
+    #[test]
+    fn network_requeue_tls_provider_uses_tls_interval() {
+        let providers = vec![make_provider_with_tls("p1", "net")];
+        assert_eq!(
+            requeue_interval_for_network(&providers),
+            TLS_REQUEUE_INTERVAL,
+            "network with a TLS provider should use 60s"
+        );
+    }
+
+    #[test]
+    fn network_requeue_mixed_providers_uses_tls_interval() {
+        let providers = vec![
+            make_inference_provider("plain", "net"),
+            make_provider_with_tls("secure", "net"),
+        ];
+        assert_eq!(
+            requeue_interval_for_network(&providers),
+            TLS_REQUEUE_INTERVAL,
+            "mixed plaintext/TLS providers should use 60s"
+        );
+    }
+
+    #[test]
+    fn network_requeue_longer_health_interval_does_not_delay_tls() {
+        let providers = vec![make_provider_with_tls_and_health_interval("p1", "net", "600s")];
+        assert_eq!(
+            requeue_interval_for_network(&providers),
+            TLS_REQUEUE_INTERVAL,
+            "a longer healthCheck.interval must not delay TLS rotation detection"
+        );
     }
 }

--- a/operator/src/controller/inference_provider.rs
+++ b/operator/src/controller/inference_provider.rs
@@ -24,13 +24,16 @@
 //! | `spec.gridNetworkRef` not found | `Unavailable` |
 //! | Config valid, probe returns transport failure | `Unavailable` |
 //! | Config valid, probe returns degraded response | `Degraded` |
+//! | `metricsConfig.tls` Secret missing, key absent, or material invalid | `Degraded` |
 //! | Config valid, probe healthy or not run, no matching sites | `Pending` |
 //! | Config valid, probe healthy or not run, ≥1 matching site | `Available` |
 //!
 //! `Degraded` is emitted by `phase_from_probe` when a health probe
-//! returns a degraded response.  Until live probing is wired into the
-//! reconcile loop, `ProbeOutcome::NotProbed` is always used, which
-//! preserves the pre-OP-05 site-matching behaviour.
+//! returns a degraded response, or by the metrics TLS validation when
+//! Secret references cannot be resolved or PEM material is invalid.
+//! Until live probing is wired into the reconcile loop,
+//! `ProbeOutcome::NotProbed` is always used, which preserves the
+//! pre-OP-05 site-matching behaviour.
 //!
 //! # Watch / reconcile note
 //!
@@ -72,7 +75,7 @@ use crate::{
         },
     },
     error::OperatorError,
-    resources::credentials,
+    resources::{credentials, provider_metrics},
 };
 
 // ---------------------------------------------------------------------------
@@ -82,6 +85,14 @@ use crate::{
 /// Requeue interval after a successful reconciliation when no `healthCheck.interval` is set.
 const REQUEUE_INTERVAL: Duration = Duration::from_secs(300);
 
+/// Shorter requeue interval for providers with `metricsConfig.tls` configured.
+///
+/// Without a cluster-wide Secret watch, the operator detects TLS material
+/// rotation (certificate renewal, CA rollover) by re-reconciling on this
+/// bounded interval.  60 seconds balances rotation detection latency against
+/// API server load.
+const TLS_REQUEUE_INTERVAL: Duration = Duration::from_secs(60);
+
 /// Field manager name for server-side apply.
 const FIELD_MANAGER: &str = "grid-operator";
 
@@ -90,7 +101,6 @@ const DEFAULT_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Default health-check path when `spec.healthCheck.path` is absent.
 const DEFAULT_HEALTH_PATH: &str = "/health";
-
 
 // ---------------------------------------------------------------------------
 // Reconcile
@@ -319,8 +329,10 @@ fn parse_duration_str(s: &str) -> Option<Duration> {
 ///
 /// When `spec.healthCheck.interval` is configured and parseable, the
 /// provider is requeued after that duration so that health probes run
-/// at approximately the requested cadence.  Falls back to
-/// [`REQUEUE_INTERVAL`] (300s) when the field is absent or unparseable.
+/// at approximately the requested cadence.  When `metricsConfig.tls` is
+/// configured, falls back to [`TLS_REQUEUE_INTERVAL`] (60s) so the
+/// operator detects certificate rotation without a cluster-wide Secret
+/// watch.  Otherwise falls back to [`REQUEUE_INTERVAL`] (300s).
 ///
 /// The interval controls **reconcile frequency**, not a separate timer
 /// loop.  The probe runs at the start of each reconcile, so the actual
@@ -330,11 +342,20 @@ fn parse_duration_str(s: &str) -> Option<Duration> {
 ///
 /// [`InferenceProvider`]: crate::crd::inference_provider::InferenceProvider
 pub(crate) fn requeue_interval_for_provider(spec: &InferenceProviderSpec) -> Duration {
-    spec.health_check
+    if let Some(interval) = spec
+        .health_check
         .as_ref()
         .and_then(|hc| hc.interval.as_deref())
         .and_then(parse_duration_str)
-        .unwrap_or(REQUEUE_INTERVAL)
+    {
+        return interval;
+    }
+    let has_tls = spec.metrics_config.as_ref().is_some_and(|mc| mc.tls.is_some());
+    if has_tls {
+        TLS_REQUEUE_INTERVAL
+    } else {
+        REQUEUE_INTERVAL
+    }
 }
 
 /// Probe an `http://` or `https://` endpoint and return a [`ProbeOutcome`].
@@ -412,11 +433,11 @@ pub(crate) async fn probe_endpoint(url: &str, timeout: Duration) -> ProbeOutcome
 #[expect(clippy::large_stack_frames, reason = "async future with kube API types")]
 #[expect(
     clippy::too_many_lines,
-    reason = "reconcile: static checks, credential verification, site matching, probe, and phase merge"
+    reason = "reconcile: static checks, credential verification, site matching, probe, metrics TLS, and phase merge"
 )]
 #[expect(
     clippy::cognitive_complexity,
-    reason = "sequential reconcile steps with early returns"
+    reason = "sequential reconcile steps with early returns and metrics TLS validation"
 )]
 async fn resolve_phase_and_sites(
     provider: &InferenceProvider,
@@ -477,6 +498,19 @@ async fn resolve_phase_and_sites(
         None => ProbeOutcome::NotProbed,
     };
     let phase = phase_from_probe(probe_result, site_phase);
+
+    if phase == ProviderPhase::Available
+        && let Some(mc) = &provider.spec.metrics_config
+        && mc.tls.is_some()
+        && let Some(tls_reason) = provider_metrics::verify_metrics_tls_accessible(client, mc.tls.as_ref()).await?
+    {
+        tracing::warn!(
+            name,
+            reason = tls_reason.as_str(),
+            "InferenceProvider metrics TLS configuration invalid"
+        );
+        return Ok((ProviderPhase::Degraded, matching, Some(tls_reason.as_str().to_owned())));
+    }
 
     Ok((phase, matching, None))
 }
@@ -1423,6 +1457,51 @@ mod tests {
             requeue_interval_for_provider(&spec),
             REQUEUE_INTERVAL,
             "timeout field must not affect the requeue interval"
+        );
+    }
+
+    #[test]
+    fn requeue_uses_tls_interval_when_metrics_tls_configured() {
+        let spec: InferenceProviderSpec = serde_json::from_value(serde_json::json!({
+            "gridNetworkRef": "net",
+            "providerKind": "self_hosted",
+            "backendKind": "local",
+            "endpoint": "https://vllm:8443",
+            "models": [{"name": "model"}],
+            "metricsConfig": {
+                "tls": {
+                    "caSecretRef": { "name": "ca", "namespace": "ns" }
+                }
+            }
+        }))
+        .unwrap_or_else(|_| std::process::abort());
+        assert_eq!(
+            requeue_interval_for_provider(&spec),
+            TLS_REQUEUE_INTERVAL,
+            "provider with metricsConfig.tls must use shorter TLS requeue interval"
+        );
+    }
+
+    #[test]
+    fn requeue_health_check_interval_wins_over_tls_interval() {
+        let spec: InferenceProviderSpec = serde_json::from_value(serde_json::json!({
+            "gridNetworkRef": "net",
+            "providerKind": "self_hosted",
+            "backendKind": "local",
+            "endpoint": "https://vllm:8443",
+            "models": [{"name": "model"}],
+            "healthCheck": { "interval": "30s" },
+            "metricsConfig": {
+                "tls": {
+                    "caSecretRef": { "name": "ca", "namespace": "ns" }
+                }
+            }
+        }))
+        .unwrap_or_else(|_| std::process::abort());
+        assert_eq!(
+            requeue_interval_for_provider(&spec),
+            Duration::from_secs(30),
+            "explicit healthCheck.interval must take precedence over TLS requeue"
         );
     }
 

--- a/operator/src/crd/grid_network.rs
+++ b/operator/src/crd/grid_network.rs
@@ -391,9 +391,11 @@ pub struct TlsConfig {
 #[derive(Clone, Debug, Deserialize, JsonSchema, Serialize)]
 pub struct SecretRef {
     /// Secret name.
+    #[schemars(length(min = 1))]
     pub name: String,
 
     /// Secret namespace.
+    #[schemars(length(min = 1))]
     pub namespace: String,
 
     /// Key within the Secret's `data` map.
@@ -401,6 +403,7 @@ pub struct SecretRef {
     /// Required when the Secret holds multiple keys (e.g. credential references
     /// in `InferenceProvider.spec.auth.secretRef`).  Omit only when the entire
     /// Secret is consumed (e.g. TLS `ca_secret_ref`).
+    #[schemars(length(min = 1))]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub key: Option<String>,
 }

--- a/operator/src/crd/inference_provider.rs
+++ b/operator/src/crd/inference_provider.rs
@@ -9,7 +9,10 @@ use kube::CustomResource;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use super::auth::{AccessPolicy, AuthConfig};
+use super::{
+    auth::{AccessPolicy, AuthConfig},
+    grid_network::SecretRef,
+};
 
 // ---------------------------------------------------------------------------
 // Spec
@@ -184,6 +187,109 @@ pub struct MetricsConfig {
     #[schemars(range(min = 1))]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub stale_metrics_seconds: Option<u32>,
+
+    /// TLS configuration for the metrics endpoint.
+    ///
+    /// When set, the operator uses the provided CA certificate for TLS server
+    /// verification and optionally presents a client certificate for mutual TLS
+    /// (mTLS).  When absent, the scraper uses system root certificates
+    /// (backward-compatible).
+    ///
+    /// **Fail-closed:** when configured but the referenced Secrets cannot be
+    /// resolved or contain invalid material, the scrape is skipped entirely.
+    /// The scraper never falls back to system roots or plain HTTP.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tls: Option<MetricsTlsConfig>,
+}
+
+/// TLS configuration for metrics endpoint scraping.
+///
+/// Controls how the operator verifies the metrics server's identity and,
+/// optionally, authenticates itself to the server via a client certificate
+/// (mutual TLS / mTLS).
+///
+/// Secret references include explicit `namespace` and `name` fields.
+/// The operator reads referenced Secrets during reconciliation —
+/// bounded requeue (60 s for TLS-configured providers) detects
+/// certificate rotation without a cluster-wide Secret watch.
+///
+/// # Secret key conventions
+///
+/// | Secret ref                       | Default keys                | Override field(s)                        |
+/// |----------------------------------|-----------------------------|------------------------------------------|
+/// | `ca_secret_ref`                  | `ca.crt`                    | `key`                                    |
+/// | `client_certificate_secret_ref`  | `tls.crt` / `tls.key`       | `certificate_key` / `private_key_key`    |
+///
+/// # Security invariant
+///
+/// Private key bytes from `client_certificate_secret_ref` are loaded into a
+/// [`rustls::ClientConfig`] and **never** written to logs, events, status
+/// fields, or Prometheus labels.
+///
+/// [`rustls::ClientConfig`]: rustls::ClientConfig
+#[derive(Clone, Debug, Deserialize, JsonSchema, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MetricsTlsConfig {
+    /// Reference to a Secret containing the CA certificate PEM for server
+    /// verification.
+    ///
+    /// The Secret must contain the PEM-encoded CA certificate under the key
+    /// `ca.crt` (or the key specified by `key`).  When this CA is
+    /// set, the scraper trusts **only** this CA — system root certificates
+    /// are not consulted.
+    pub ca_secret_ref: SecretRef,
+
+    /// Reference to a Secret containing the client certificate and private
+    /// key for mutual TLS.
+    ///
+    /// When set, the scraper presents this identity during the TLS handshake.
+    /// The Secret must contain `tls.crt` (or `certificate_key`) and
+    /// `tls.key` (or `private_key_key`) in PEM format.
+    ///
+    /// When absent, the scraper performs one-way TLS only (server verification
+    /// with the CA from `ca_secret_ref`, no client certificate).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub client_certificate_secret_ref: Option<ClientCertificateSecretRef>,
+}
+
+/// Reference to a Kubernetes Secret containing a client certificate and
+/// private key for mutual TLS.
+///
+/// Both `name` and `namespace` are required because [`InferenceProvider`] is
+/// cluster-scoped.
+///
+/// The key fields default to the standard Kubernetes TLS Secret convention
+/// (`tls.crt` / `tls.key`) but can be overridden for non-standard Secrets.
+#[derive(Clone, Debug, Deserialize, JsonSchema, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ClientCertificateSecretRef {
+    /// Secret name.
+    #[schemars(length(min = 1))]
+    pub name: String,
+
+    /// Secret namespace.
+    #[schemars(length(min = 1))]
+    pub namespace: String,
+
+    /// Key within `Secret.data` holding the PEM-encoded client certificate.
+    #[schemars(length(min = 1))]
+    #[serde(default = "default_certificate_key")]
+    pub certificate_key: String,
+
+    /// Key within `Secret.data` holding the PEM-encoded private key.
+    #[schemars(length(min = 1))]
+    #[serde(default = "default_private_key_key")]
+    pub private_key_key: String,
+}
+
+/// Default key for the client certificate PEM in a Secret.
+fn default_certificate_key() -> String {
+    "tls.crt".to_owned()
+}
+
+/// Default key for the private key PEM in a Secret.
+fn default_private_key_key() -> String {
+    "tls.key".to_owned()
 }
 
 /// Mapping from scoring signal names to Prometheus metric names.
@@ -285,13 +391,15 @@ pub struct InferenceProviderStatus {
 
     /// Machine-readable reason for the current phase when not `Available`.
     ///
-    /// Set when the provider cannot reach `Available` due to a configuration
-    /// or credential error.  `None` when the provider is `Available`, `Pending`,
-    /// or the reason is unknown.
+    /// Set when the provider cannot reach `Available` due to a configuration,
+    /// credential, or metrics collection error.  `None` when the provider is
+    /// `Available`, `Pending`, or the reason is unknown.
     ///
-    /// Stable reason values: `UnsupportedAuthStrategy`, `CredentialSecretRefInvalid`,
-    /// `CredentialSecretMissing`, `CredentialSecretKeyMissing`,
-    /// `CredentialSecretValueInvalid`.
+    /// Stable reason values:
+    /// - `UnsupportedAuthStrategy`, `CredentialSecretRefInvalid`, `CredentialSecretMissing`,
+    ///   `CredentialSecretKeyMissing`, `CredentialSecretValueInvalid`
+    /// - `MetricsTlsSecretMissing`, `MetricsTlsKeyMissing`, `MetricsTlsMaterialInvalid`,
+    ///   `MetricsTlsIdentityMismatch`
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reason: Option<String>,
 }
@@ -537,11 +645,93 @@ mod tests {
             metrics_endpoint: None,
             pool_name: None,
             queue_capacity: None,
+            tls: None,
         };
         let serialised = serde_json::to_value(&mc).unwrap_or_else(|_| std::process::abort());
         assert!(
             serialised.get("staleMetricsSeconds").is_none(),
             "absent staleMetricsSeconds must not appear in serialised output"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // CRD schema: minLength validation on Secret reference fields
+    // -----------------------------------------------------------------------
+
+    #[test]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "tests multiple schema paths in one assertion block"
+    )]
+    fn crd_schema_enforces_min_length_on_tls_secret_fields() {
+        let crd = crd_json();
+        let tls_props = crd
+            .pointer(
+                "/spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/metricsConfig/properties/tls/properties",
+            )
+            .and_then(serde_json::Value::as_object)
+            .unwrap_or_else(|| std::process::abort());
+
+        let ca_ref_props = tls_props
+            .get("caSecretRef")
+            .and_then(|v| v.pointer("/properties"))
+            .and_then(serde_json::Value::as_object)
+            .unwrap_or_else(|| std::process::abort());
+
+        assert_eq!(
+            ca_ref_props
+                .get("name")
+                .and_then(|v| v.get("minLength"))
+                .and_then(serde_json::Value::as_u64),
+            Some(1),
+            "caSecretRef.name must have minLength: 1"
+        );
+        assert_eq!(
+            ca_ref_props
+                .get("namespace")
+                .and_then(|v| v.get("minLength"))
+                .and_then(serde_json::Value::as_u64),
+            Some(1),
+            "caSecretRef.namespace must have minLength: 1"
+        );
+
+        let client_ref_props = tls_props
+            .get("clientCertificateSecretRef")
+            .and_then(|v| v.pointer("/properties"))
+            .and_then(serde_json::Value::as_object)
+            .unwrap_or_else(|| std::process::abort());
+
+        assert_eq!(
+            client_ref_props
+                .get("name")
+                .and_then(|v| v.get("minLength"))
+                .and_then(serde_json::Value::as_u64),
+            Some(1),
+            "clientCertificateSecretRef.name must have minLength: 1"
+        );
+        assert_eq!(
+            client_ref_props
+                .get("namespace")
+                .and_then(|v| v.get("minLength"))
+                .and_then(serde_json::Value::as_u64),
+            Some(1),
+            "clientCertificateSecretRef.namespace must have minLength: 1"
+        );
+        assert_eq!(
+            client_ref_props
+                .get("certificateKey")
+                .and_then(|v| v.get("minLength"))
+                .and_then(serde_json::Value::as_u64),
+            Some(1),
+            "clientCertificateSecretRef.certificateKey must have minLength: 1"
+        );
+        assert_eq!(
+            client_ref_props
+                .get("privateKeyKey")
+                .and_then(|v| v.get("minLength"))
+                .and_then(serde_json::Value::as_u64),
+            Some(1),
+            "clientCertificateSecretRef.privateKeyKey must have minLength: 1"
         );
     }
 }

--- a/operator/src/main.rs
+++ b/operator/src/main.rs
@@ -422,13 +422,15 @@ fn hostname_or_default() -> String {
 /// Run the [`GridNetwork`] controller.
 ///
 /// In addition to watching `GridNetwork` resources, this controller watches
-/// `InferenceProvider` and `GridSite` resources.  Changes to either trigger
-/// reconciliation of the owning [`GridNetwork`] (identified by
-/// `spec.gridNetworkRef`), keeping routing overlay `ConfigMap`s consistent
-/// with provider availability and site membership.
+/// `InferenceProvider`, `GridSite`, and `Secret` resources.  Secret changes
+/// trigger reconciliation of affected `GridNetwork`s when providers change.
+///
+/// Metrics TLS rotation is detected by bounded requeue rather than a
+/// cluster-wide Secret watch — the operator only reads referenced
+/// Secrets by explicit namespace/name during reconciliation.
 #[expect(
     clippy::too_many_lines,
-    reason = "declarative controller trigger wiring is clearer in one function"
+    reason = "controller setup with two cross-resource watches and optional SWIM"
 )]
 async fn run_network_controller(
     client: Client,
@@ -486,6 +488,11 @@ async fn run_site_controller(client: Client) -> Result<(), Box<dyn std::error::E
 }
 
 /// Run the [`InferenceProvider`] controller (OP-02).
+///
+/// Watches `InferenceProvider` resources.  Metrics TLS rotation is detected
+/// by bounded requeue rather than a cluster-wide Secret watch — the operator
+/// only reads referenced Secrets by explicit namespace/name during
+/// reconciliation.
 ///
 /// [`InferenceProvider`]: operator::crd::inference_provider::InferenceProvider
 async fn run_provider_controller(client: Client) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {

--- a/operator/src/metrics_scraper.rs
+++ b/operator/src/metrics_scraper.rs
@@ -9,24 +9,50 @@
 //! ## Usage
 //!
 //! ```text
-//! let text = scrape_metrics("http://backend:9090/metrics", Duration::from_secs(5)).await?;
+//! let text = scrape_metrics("http://backend:9090/metrics", Duration::from_secs(5), None).await?;
 //! let signals = parse_prometheus_text(&text, &names);
 //! let metrics = signals.into_backend_metrics();
 //! state.set_metrics(provider_name.to_owned(), metrics);
 //! ```
 //!
-//! ## v1 scope
+//! ## TLS and mTLS
 //!
-//! This module only fetches text via plain `http://` and `https://` requests.
-//! mTLS client-certificate probing (required for remote grid peers) is not
-//! implemented here; that requires the grid CA and site cert which are managed
-//! separately.
+//! When a [`rustls::ClientConfig`] is provided via the `tls_config` parameter,
+//! the scraper uses it for server verification and (when configured) client
+//! certificate presentation.  When `tls_config` is `None`, native root
+//! certificates are used (backward-compatible).  There is no
+//! `insecureSkipVerify` option.
+//!
+//! [`rustls::ClientConfig`]: rustls::ClientConfig
 
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
 use bytes::Bytes;
-use http_body_util::{BodyExt as _, Empty};
+use http_body_util::{BodyExt as _, Empty, Limited};
 use hyper_util::{client::legacy::Client as HyperClient, rt::TokioExecutor};
+
+// ---------------------------------------------------------------------------
+// Bounded input limits
+// ---------------------------------------------------------------------------
+
+/// Maximum size for a CA PEM bundle (256 KiB).
+const MAX_CA_PEM_BYTES: usize = 256 * 1024;
+
+/// Maximum size for a client certificate PEM (64 KiB).
+const MAX_CLIENT_CERT_PEM_BYTES: usize = 64 * 1024;
+
+/// Maximum size for a client private key PEM (64 KiB).
+const MAX_CLIENT_KEY_PEM_BYTES: usize = 64 * 1024;
+
+/// Maximum number of certificates in a CA or client chain.
+const MAX_CERT_CHAIN_LENGTH: usize = 10;
+
+/// Maximum size for a metrics response body (1 MiB).
+const MAX_RESPONSE_BODY_BYTES: usize = 1024 * 1024;
+
+// ---------------------------------------------------------------------------
+// Error type
+// ---------------------------------------------------------------------------
 
 /// Error returned by [`scrape_metrics`].
 #[derive(Debug, thiserror::Error)]
@@ -34,6 +60,10 @@ pub enum MetricsScrapeError {
     /// The URL could not be parsed.
     #[error("invalid metrics URL: {0}")]
     InvalidUrl(String),
+
+    /// TLS is configured but the URL does not use HTTPS.
+    #[error("metrics TLS configured but URL scheme is not https: {0}")]
+    HttpWithTls(String),
 
     /// The scrape request timed out.
     #[error("metrics scrape timed out after {0:?}")]
@@ -55,13 +85,26 @@ pub enum MetricsScrapeError {
     /// The response body could not be decoded as UTF-8.
     #[error("metrics response body is not valid UTF-8: {0}")]
     Encoding(std::string::FromUtf8Error),
+
+    /// TLS material could not be parsed or assembled into a valid configuration.
+    #[error("metrics TLS material error: {0}")]
+    TlsMaterial(String),
 }
+
+// ---------------------------------------------------------------------------
+// Scrape
+// ---------------------------------------------------------------------------
 
 /// Scrape the Prometheus text exposition from `url`.
 ///
 /// Makes an HTTP GET request to `url` and returns the response body as a
 /// `String` if the status is 2xx.  The caller is responsible for parsing
 /// the returned text with [`crate::metrics_parser::parse_prometheus_text`].
+///
+/// When `tls_config` is `Some`, the connector uses the provided
+/// [`rustls::ClientConfig`] for server verification and optional client
+/// certificate presentation.  When `None`, native root certificates are
+/// used (backward-compatible).
 ///
 /// # Errors
 ///
@@ -72,7 +115,11 @@ pub enum MetricsScrapeError {
     clippy::too_many_lines,
     reason = "URL parse + scheme check + client build + request + body read: sequential steps"
 )]
-pub async fn scrape_metrics(url: &str, timeout: Duration) -> Result<String, MetricsScrapeError> {
+pub async fn scrape_metrics(
+    url: &str,
+    timeout: Duration,
+    tls_config: Option<Arc<rustls::ClientConfig>>,
+) -> Result<String, MetricsScrapeError> {
     let uri = url
         .parse::<http::Uri>()
         .map_err(|e| MetricsScrapeError::Transport(e.into()))
@@ -84,7 +131,15 @@ pub async fn scrape_metrics(url: &str, timeout: Duration) -> Result<String, Metr
             }
         })?;
 
-    let connector = build_connector()?;
+    if tls_config.is_some() && uri.scheme_str() != Some("https") {
+        return Err(MetricsScrapeError::HttpWithTls(url.to_owned()));
+    }
+
+    let connector = if let Some(config) = &tls_config {
+        build_custom_tls_connector(config)
+    } else {
+        build_native_connector()?
+    };
     let client: HyperClient<_, Empty<Bytes>> = HyperClient::builder(TokioExecutor::new()).build(connector);
 
     let req = http::Request::builder()
@@ -106,22 +161,149 @@ pub async fn scrape_metrics(url: &str, timeout: Duration) -> Result<String, Metr
         });
     }
 
-    let body_bytes = response
+    let body_bytes = Limited::new(response.into_body(), MAX_RESPONSE_BODY_BYTES)
         .collect()
         .await
-        .map_err(|e| MetricsScrapeError::Transport(e.into()))?
+        .map_err(|e| {
+            if e.downcast_ref::<http_body_util::LengthLimitError>().is_some() {
+                MetricsScrapeError::Transport(
+                    format!("metrics response body exceeds {MAX_RESPONSE_BODY_BYTES} byte limit").into(),
+                )
+            } else {
+                MetricsScrapeError::Transport(e)
+            }
+        })?
         .to_bytes();
 
     String::from_utf8(body_bytes.to_vec()).map_err(MetricsScrapeError::Encoding)
 }
 
+// ---------------------------------------------------------------------------
+// TLS client config builder
+// ---------------------------------------------------------------------------
+
+/// Build a [`rustls::ClientConfig`] from raw PEM bytes.
+///
+/// `ca_pem` is the CA certificate chain (required).  `client_cert_pem` and
+/// `client_key_pem` are the client identity for mTLS (both required together,
+/// or both absent for one-way TLS).
+///
+/// # Security invariant
+///
+/// Private key bytes are consumed by `rustls` and never written to logs,
+/// events, status fields, or Prometheus labels.
+///
+/// # Errors
+///
+/// Returns [`MetricsScrapeError::TlsMaterial`] when PEM parsing fails or the
+/// material is structurally invalid.
+#[expect(
+    clippy::too_many_lines,
+    reason = "sequential PEM parsing for CA, client cert, and client key with validation"
+)]
+pub fn build_tls_client_config(
+    ca_pem: &[u8],
+    client_cert_pem: Option<&[u8]>,
+    client_key_pem: Option<&[u8]>,
+) -> Result<rustls::ClientConfig, MetricsScrapeError> {
+    if ca_pem.len() > MAX_CA_PEM_BYTES {
+        return Err(MetricsScrapeError::TlsMaterial(format!(
+            "CA PEM exceeds maximum size ({} bytes > {MAX_CA_PEM_BYTES})",
+            ca_pem.len()
+        )));
+    }
+
+    let mut root_store = rustls::RootCertStore::empty();
+    let ca_certs = rustls_pemfile::certs(&mut std::io::BufReader::new(ca_pem))
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| MetricsScrapeError::TlsMaterial(format!("CA PEM parse failed: {e}")))?;
+    if ca_certs.is_empty() {
+        return Err(MetricsScrapeError::TlsMaterial(
+            "CA PEM contains no certificates".to_owned(),
+        ));
+    }
+    if ca_certs.len() > MAX_CERT_CHAIN_LENGTH {
+        return Err(MetricsScrapeError::TlsMaterial(format!(
+            "CA PEM contains too many certificates ({} > {MAX_CERT_CHAIN_LENGTH})",
+            ca_certs.len()
+        )));
+    }
+    for cert in &ca_certs {
+        root_store
+            .add(cert.clone())
+            .map_err(|e| MetricsScrapeError::TlsMaterial(format!("CA certificate invalid: {e}")))?;
+    }
+
+    let builder = rustls::ClientConfig::builder().with_root_certificates(root_store);
+
+    let config = match (client_cert_pem, client_key_pem) {
+        (Some(cert_pem), Some(key_pem)) => {
+            if cert_pem.len() > MAX_CLIENT_CERT_PEM_BYTES {
+                return Err(MetricsScrapeError::TlsMaterial(format!(
+                    "client cert PEM exceeds maximum size ({} bytes > {MAX_CLIENT_CERT_PEM_BYTES})",
+                    cert_pem.len()
+                )));
+            }
+            if key_pem.len() > MAX_CLIENT_KEY_PEM_BYTES {
+                return Err(MetricsScrapeError::TlsMaterial(format!(
+                    "client key PEM exceeds maximum size ({} bytes > {MAX_CLIENT_KEY_PEM_BYTES})",
+                    key_pem.len()
+                )));
+            }
+            let certs = rustls_pemfile::certs(&mut std::io::BufReader::new(cert_pem))
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|e| MetricsScrapeError::TlsMaterial(format!("client cert PEM parse failed: {e}")))?;
+            if certs.is_empty() {
+                return Err(MetricsScrapeError::TlsMaterial(
+                    "client cert PEM contains no certificates".to_owned(),
+                ));
+            }
+            if certs.len() > MAX_CERT_CHAIN_LENGTH {
+                return Err(MetricsScrapeError::TlsMaterial(format!(
+                    "client cert PEM contains too many certificates ({} > {MAX_CERT_CHAIN_LENGTH})",
+                    certs.len()
+                )));
+            }
+            let key = rustls_pemfile::private_key(&mut std::io::BufReader::new(key_pem))
+                .map_err(|e| MetricsScrapeError::TlsMaterial(format!("client key PEM parse failed: {e}")))?
+                .ok_or_else(|| MetricsScrapeError::TlsMaterial("client key PEM contains no private key".to_owned()))?;
+            builder
+                .with_client_auth_cert(certs, key)
+                .map_err(|e| MetricsScrapeError::TlsMaterial(format!("client identity construction failed: {e}")))?
+        },
+        (None, None) => builder.with_no_client_auth(),
+        _ => {
+            return Err(MetricsScrapeError::TlsMaterial(
+                "client cert and key must both be present or both absent".to_owned(),
+            ));
+        },
+    };
+
+    Ok(config)
+}
+
+// ---------------------------------------------------------------------------
+// Connector builders
+// ---------------------------------------------------------------------------
+
 /// Build an HTTPS connector using native root certificates.
-fn build_connector()
+fn build_native_connector()
 -> Result<hyper_rustls::HttpsConnector<hyper_util::client::legacy::connect::HttpConnector>, MetricsScrapeError> {
     hyper_rustls::HttpsConnectorBuilder::new()
         .with_native_roots()
         .map(|b| b.https_or_http().enable_http1().build())
         .map_err(|e| MetricsScrapeError::Transport(e.into()))
+}
+
+/// Build an HTTPS-only connector using a custom [`rustls::ClientConfig`].
+fn build_custom_tls_connector(
+    config: &rustls::ClientConfig,
+) -> hyper_rustls::HttpsConnector<hyper_util::client::legacy::connect::HttpConnector> {
+    hyper_rustls::HttpsConnectorBuilder::new()
+        .with_tls_config(config.clone())
+        .https_only()
+        .enable_http1()
+        .build()
 }
 
 // ---------------------------------------------------------------------------
@@ -157,7 +339,7 @@ mod tests {
         let body = b"# HELP test_metric Test\ntest_metric 1.0\n";
         let response = b"HTTP/1.0 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 39\r\n\r\n# HELP test_metric Test\ntest_metric 1.0\n";
         let url = start_test_server(response).await;
-        let result = scrape_metrics(&url, Duration::from_secs(5)).await;
+        let result = scrape_metrics(&url, Duration::from_secs(5), None).await;
         assert!(result.is_ok(), "HTTP 200 must succeed: {result:?}");
         let text = result.unwrap_or_else(|_| std::process::abort());
         assert!(text.contains("test_metric"), "body must be in scrape result");
@@ -168,7 +350,7 @@ mod tests {
     async fn scrape_returns_error_for_non_2xx() {
         let response = b"HTTP/1.0 503 Service Unavailable\r\nContent-Length: 0\r\n\r\n";
         let url = start_test_server(response).await;
-        let result = scrape_metrics(&url, Duration::from_secs(5)).await;
+        let result = scrape_metrics(&url, Duration::from_secs(5), None).await;
         assert!(result.is_err(), "HTTP 503 must return an error");
         assert!(
             matches!(result.unwrap_err(), MetricsScrapeError::NonOkStatus { status: 503, .. }),
@@ -193,7 +375,7 @@ mod tests {
             }
         });
         let url = format!("http://127.0.0.1:{port}/metrics");
-        let result = scrape_metrics(&url, Duration::from_millis(100)).await;
+        let result = scrape_metrics(&url, Duration::from_millis(100), None).await;
         assert!(result.is_err(), "silent server must time out");
         assert!(
             matches!(result.unwrap_err(), MetricsScrapeError::Timeout(_)),
@@ -204,7 +386,7 @@ mod tests {
     #[tokio::test]
     async fn scrape_returns_error_for_connection_refused() {
         // Port 1 is never open on any standard OS.
-        let result = scrape_metrics("http://127.0.0.1:1/metrics", Duration::from_secs(5)).await;
+        let result = scrape_metrics("http://127.0.0.1:1/metrics", Duration::from_secs(5), None).await;
         assert!(result.is_err(), "connection refused must return an error");
         assert!(
             matches!(result.unwrap_err(), MetricsScrapeError::Transport(_)),
@@ -214,7 +396,7 @@ mod tests {
 
     #[tokio::test]
     async fn scrape_returns_invalid_url_for_unsupported_scheme() {
-        let result = scrape_metrics("ftp://example.com/metrics", Duration::from_secs(5)).await;
+        let result = scrape_metrics("ftp://example.com/metrics", Duration::from_secs(5), None).await;
         assert!(result.is_err(), "ftp:// must return an error");
         assert!(
             matches!(result.unwrap_err(), MetricsScrapeError::InvalidUrl(_)),
@@ -235,5 +417,520 @@ mod tests {
 
         let url_err = MetricsScrapeError::InvalidUrl("ftp://bad".to_owned());
         assert!(url_err.to_string().contains("ftp://bad"), "url format");
+    }
+
+    // -----------------------------------------------------------------------
+    // build_tls_client_config — PEM material validation
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn build_tls_config_valid_ca_only() {
+        let ca = certs::generate_ca("test-ca").unwrap();
+        let result = build_tls_client_config(ca.cert_pem.as_bytes(), None, None);
+        assert!(result.is_ok(), "valid CA PEM must produce a ClientConfig: {result:?}");
+    }
+
+    #[test]
+    fn build_tls_config_valid_mtls() {
+        let ca = certs::generate_ca("test-ca").unwrap();
+        let client = certs::generate_dns_cert(&ca, "client", "localhost").unwrap();
+        let result = build_tls_client_config(
+            ca.cert_pem.as_bytes(),
+            Some(client.cert_pem.as_bytes()),
+            Some(client.key_pem.as_bytes()),
+        );
+        assert!(result.is_ok(), "valid CA + client cert + key must succeed: {result:?}");
+    }
+
+    #[test]
+    fn build_tls_config_empty_ca_pem_fails() {
+        let result = build_tls_client_config(b"", None, None);
+        assert!(result.is_err(), "empty CA PEM must fail");
+        assert!(
+            matches!(result.unwrap_err(), MetricsScrapeError::TlsMaterial(_)),
+            "error must be TlsMaterial"
+        );
+    }
+
+    #[test]
+    fn build_tls_config_garbage_ca_pem_fails() {
+        let result = build_tls_client_config(b"not valid pem data", None, None);
+        assert!(result.is_err(), "garbage CA PEM must fail");
+        assert!(
+            matches!(result.unwrap_err(), MetricsScrapeError::TlsMaterial(_)),
+            "error must be TlsMaterial"
+        );
+    }
+
+    #[test]
+    fn build_tls_config_client_cert_without_key_fails() {
+        let ca = certs::generate_ca("test-ca").unwrap();
+        let client = certs::generate_dns_cert(&ca, "client", "localhost").unwrap();
+        let result = build_tls_client_config(ca.cert_pem.as_bytes(), Some(client.cert_pem.as_bytes()), None);
+        assert!(result.is_err(), "client cert without key must fail");
+        assert!(
+            matches!(result.unwrap_err(), MetricsScrapeError::TlsMaterial(_)),
+            "error must be TlsMaterial"
+        );
+    }
+
+    #[test]
+    fn build_tls_config_client_key_without_cert_fails() {
+        let ca = certs::generate_ca("test-ca").unwrap();
+        let client = certs::generate_dns_cert(&ca, "client", "localhost").unwrap();
+        let result = build_tls_client_config(ca.cert_pem.as_bytes(), None, Some(client.key_pem.as_bytes()));
+        assert!(result.is_err(), "client key without cert must fail");
+        assert!(
+            matches!(result.unwrap_err(), MetricsScrapeError::TlsMaterial(_)),
+            "error must be TlsMaterial"
+        );
+    }
+
+    #[test]
+    fn build_tls_config_mismatched_client_cert_and_key_fails() {
+        let ca = certs::generate_ca("test-ca").unwrap();
+        let cert_a = certs::generate_dns_cert(&ca, "client-a", "a.localhost").unwrap();
+        let cert_b = certs::generate_dns_cert(&ca, "client-b", "b.localhost").unwrap();
+        let result = build_tls_client_config(
+            ca.cert_pem.as_bytes(),
+            Some(cert_a.cert_pem.as_bytes()),
+            Some(cert_b.key_pem.as_bytes()),
+        );
+        assert!(result.is_err(), "mismatched client cert and key must fail");
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("identity construction failed"),
+            "error must indicate identity mismatch: {err_msg}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Bounded input limits
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn build_tls_config_rejects_oversized_ca_pem() {
+        let oversized = vec![b'A'; MAX_CA_PEM_BYTES + 1];
+        let result = build_tls_client_config(&oversized, None, None);
+        assert!(result.is_err(), "oversized CA PEM must fail");
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("exceeds maximum size"),
+            "error must mention size limit: {msg}"
+        );
+    }
+
+    #[test]
+    fn build_tls_config_rejects_oversized_client_cert_pem() {
+        let ca = certs::generate_ca("test-ca").unwrap();
+        let oversized = vec![b'A'; MAX_CLIENT_CERT_PEM_BYTES + 1];
+        let client_cert = certs::generate_dns_cert(&ca, "client", "localhost").unwrap();
+        let result = build_tls_client_config(
+            ca.cert_pem.as_bytes(),
+            Some(&oversized),
+            Some(client_cert.key_pem.as_bytes()),
+        );
+        assert!(result.is_err(), "oversized client cert PEM must fail");
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("exceeds maximum size"),
+            "error must mention size limit: {msg}"
+        );
+    }
+
+    #[test]
+    fn build_tls_config_rejects_oversized_client_key_pem() {
+        let ca = certs::generate_ca("test-ca").unwrap();
+        let client_cert = certs::generate_dns_cert(&ca, "client", "localhost").unwrap();
+        let oversized = vec![b'A'; MAX_CLIENT_KEY_PEM_BYTES + 1];
+        let result = build_tls_client_config(
+            ca.cert_pem.as_bytes(),
+            Some(client_cert.cert_pem.as_bytes()),
+            Some(&oversized),
+        );
+        assert!(result.is_err(), "oversized client key PEM must fail");
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("exceeds maximum size"),
+            "error must mention size limit: {msg}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // TLS server helper
+    // -----------------------------------------------------------------------
+
+    /// Start a one-shot TLS server on localhost and return the URL.
+    ///
+    /// `client_ca_pem`: when `Some`, the server requires client certificate
+    /// authentication (mTLS).  When `None`, one-way TLS only.
+    #[expect(
+        clippy::too_many_lines,
+        reason = "TLS server setup: certs + verifier + acceptor + one-shot handler"
+    )]
+    async fn start_tls_test_server(
+        server_cert_pem: &str,
+        server_key_pem: &str,
+        client_ca_pem: Option<&str>,
+        response: Vec<u8>,
+    ) -> String {
+        let server_certs = rustls_pemfile::certs(&mut std::io::BufReader::new(server_cert_pem.as_bytes()))
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        let server_key = rustls_pemfile::private_key(&mut std::io::BufReader::new(server_key_pem.as_bytes()))
+            .unwrap()
+            .unwrap();
+
+        let server_config = if let Some(ca) = client_ca_pem {
+            let mut root_store = rustls::RootCertStore::empty();
+            let ca_certs = rustls_pemfile::certs(&mut std::io::BufReader::new(ca.as_bytes()))
+                .collect::<Result<Vec<_>, _>>()
+                .unwrap();
+            for cert in &ca_certs {
+                root_store.add(cert.clone()).unwrap();
+            }
+            let verifier = rustls::server::WebPkiClientVerifier::builder(Arc::new(root_store))
+                .build()
+                .unwrap();
+            rustls::ServerConfig::builder()
+                .with_client_cert_verifier(verifier)
+                .with_single_cert(server_certs, server_key)
+                .unwrap()
+        } else {
+            rustls::ServerConfig::builder()
+                .with_no_client_auth()
+                .with_single_cert(server_certs, server_key)
+                .unwrap()
+        };
+
+        let acceptor = tokio_rustls::TlsAcceptor::from(Arc::new(server_config));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        tokio::spawn(async move {
+            if let Ok((stream, _)) = listener.accept().await
+                && let Ok(tls_stream) = acceptor.accept(stream).await
+            {
+                let (mut reader, mut writer) = tokio::io::split(tls_stream);
+                let mut buf = [0_u8; 4096];
+                drop(reader.read(&mut buf).await);
+                drop(writer.write_all(&response).await);
+            }
+        });
+
+        format!("https://localhost:{port}")
+    }
+
+    // -----------------------------------------------------------------------
+    // End-to-end TLS scrape tests (real certificates, real handshakes)
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn scrape_tls_with_matching_ca_succeeds() {
+        let ca = certs::generate_ca("test-ca").unwrap();
+        let server_cert = certs::generate_dns_cert(&ca, "test-server", "localhost").unwrap();
+
+        let url = start_tls_test_server(
+            &server_cert.cert_pem,
+            &server_cert.key_pem,
+            None,
+            b"HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 16\r\n\r\ntest_metric 1.0\n".to_vec(),
+        )
+        .await;
+
+        let tls_config = build_tls_client_config(ca.cert_pem.as_bytes(), None, None).unwrap();
+        let result = scrape_metrics(&url, Duration::from_secs(5), Some(Arc::new(tls_config))).await;
+        assert!(result.is_ok(), "TLS scrape with matching CA must succeed: {result:?}");
+        assert!(
+            result.unwrap().contains("test_metric"),
+            "response body must contain the scraped metric"
+        );
+    }
+
+    #[tokio::test]
+    async fn scrape_tls_with_wrong_ca_fails() {
+        let ca_server = certs::generate_ca("server-ca").unwrap();
+        let ca_client = certs::generate_ca("wrong-ca").unwrap();
+        let server_cert = certs::generate_dns_cert(&ca_server, "test-server", "localhost").unwrap();
+
+        let url = start_tls_test_server(
+            &server_cert.cert_pem,
+            &server_cert.key_pem,
+            None,
+            b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n".to_vec(),
+        )
+        .await;
+
+        let tls_config = build_tls_client_config(ca_client.cert_pem.as_bytes(), None, None).unwrap();
+        let result = scrape_metrics(&url, Duration::from_secs(5), Some(Arc::new(tls_config))).await;
+        assert!(result.is_err(), "TLS scrape with wrong CA must fail");
+        assert!(
+            matches!(result.unwrap_err(), MetricsScrapeError::Transport(_)),
+            "error must be Transport (TLS verification failure)"
+        );
+    }
+
+    #[tokio::test]
+    async fn scrape_mtls_with_valid_client_cert_succeeds() {
+        let ca = certs::generate_ca("test-ca").unwrap();
+        let server_cert = certs::generate_dns_cert(&ca, "test-server", "localhost").unwrap();
+        let client_cert = certs::generate_dns_cert(&ca, "test-client", "client.local").unwrap();
+
+        let url = start_tls_test_server(
+            &server_cert.cert_pem,
+            &server_cert.key_pem,
+            Some(&ca.cert_pem),
+            b"HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 16\r\n\r\ntest_metric 2.0\n".to_vec(),
+        )
+        .await;
+
+        let tls_config = build_tls_client_config(
+            ca.cert_pem.as_bytes(),
+            Some(client_cert.cert_pem.as_bytes()),
+            Some(client_cert.key_pem.as_bytes()),
+        )
+        .unwrap();
+        let result = scrape_metrics(&url, Duration::from_secs(5), Some(Arc::new(tls_config))).await;
+        assert!(
+            result.is_ok(),
+            "mTLS scrape with valid client cert must succeed: {result:?}"
+        );
+        assert!(
+            result.unwrap().contains("test_metric"),
+            "response body must contain the scraped metric"
+        );
+    }
+
+    #[tokio::test]
+    async fn scrape_mtls_without_client_cert_fails() {
+        let ca = certs::generate_ca("test-ca").unwrap();
+        let server_cert = certs::generate_dns_cert(&ca, "test-server", "localhost").unwrap();
+
+        let url = start_tls_test_server(
+            &server_cert.cert_pem,
+            &server_cert.key_pem,
+            Some(&ca.cert_pem),
+            b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n".to_vec(),
+        )
+        .await;
+
+        let tls_config = build_tls_client_config(ca.cert_pem.as_bytes(), None, None).unwrap();
+        let result = scrape_metrics(&url, Duration::from_secs(5), Some(Arc::new(tls_config))).await;
+        assert!(result.is_err(), "mTLS scrape without client cert must fail");
+        assert!(
+            matches!(result.unwrap_err(), MetricsScrapeError::Transport(_)),
+            "error must be Transport (server rejected missing client cert)"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // TLS negative test coverage (Item 6)
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn scrape_tls_hostname_mismatch_fails() {
+        let ca = certs::generate_ca("test-ca").unwrap();
+        let server_cert = certs::generate_dns_cert(&ca, "test-server", "wrong.example.com").unwrap();
+
+        let url = start_tls_test_server(
+            &server_cert.cert_pem,
+            &server_cert.key_pem,
+            None,
+            b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n".to_vec(),
+        )
+        .await;
+
+        let tls_config = build_tls_client_config(ca.cert_pem.as_bytes(), None, None).unwrap();
+        let result = scrape_metrics(&url, Duration::from_secs(5), Some(Arc::new(tls_config))).await;
+        assert!(
+            result.is_err(),
+            "TLS scrape with hostname mismatch must fail (SAN has wrong.example.com, connecting to localhost)"
+        );
+        assert!(
+            matches!(result.unwrap_err(), MetricsScrapeError::Transport(_)),
+            "error must be Transport (hostname verification failure)"
+        );
+    }
+
+    #[tokio::test]
+    async fn scrape_tls_expired_server_cert_fails() {
+        let ca = certs::generate_ca("test-ca").unwrap();
+        let expired_cert = certs::generate_expired_dns_cert(&ca, "test-server", "localhost").unwrap();
+
+        let url = start_tls_test_server(
+            &expired_cert.cert_pem,
+            &expired_cert.key_pem,
+            None,
+            b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n".to_vec(),
+        )
+        .await;
+
+        let tls_config = build_tls_client_config(ca.cert_pem.as_bytes(), None, None).unwrap();
+        let result = scrape_metrics(&url, Duration::from_secs(5), Some(Arc::new(tls_config))).await;
+        assert!(result.is_err(), "TLS scrape with expired server cert must fail");
+        assert!(
+            matches!(result.unwrap_err(), MetricsScrapeError::Transport(_)),
+            "error must be Transport (expired certificate)"
+        );
+    }
+
+    #[tokio::test]
+    async fn scrape_tls_not_yet_valid_server_cert_fails() {
+        let ca = certs::generate_ca("test-ca").unwrap();
+        let future_cert = certs::generate_not_yet_valid_dns_cert(&ca, "test-server", "localhost").unwrap();
+
+        let url = start_tls_test_server(
+            &future_cert.cert_pem,
+            &future_cert.key_pem,
+            None,
+            b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n".to_vec(),
+        )
+        .await;
+
+        let tls_config = build_tls_client_config(ca.cert_pem.as_bytes(), None, None).unwrap();
+        let result = scrape_metrics(&url, Duration::from_secs(5), Some(Arc::new(tls_config))).await;
+        assert!(result.is_err(), "TLS scrape with not-yet-valid server cert must fail");
+        assert!(
+            matches!(result.unwrap_err(), MetricsScrapeError::Transport(_)),
+            "error must be Transport (certificate not yet valid)"
+        );
+    }
+
+    #[tokio::test]
+    async fn scrape_401_returns_non_ok_status() {
+        let response = b"HTTP/1.0 401 Unauthorized\r\nContent-Length: 0\r\n\r\n";
+        let url = start_test_server(response).await;
+        let result = scrape_metrics(&url, Duration::from_secs(5), None).await;
+        assert!(result.is_err(), "HTTP 401 must return an error");
+        assert!(
+            matches!(result.unwrap_err(), MetricsScrapeError::NonOkStatus { status: 401, .. }),
+            "error must be NonOkStatus(401)"
+        );
+    }
+
+    #[tokio::test]
+    async fn scrape_403_returns_non_ok_status() {
+        let response = b"HTTP/1.0 403 Forbidden\r\nContent-Length: 0\r\n\r\n";
+        let url = start_test_server(response).await;
+        let result = scrape_metrics(&url, Duration::from_secs(5), None).await;
+        assert!(result.is_err(), "HTTP 403 must return an error");
+        assert!(
+            matches!(result.unwrap_err(), MetricsScrapeError::NonOkStatus { status: 403, .. }),
+            "error must be NonOkStatus(403)"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Bounded response body (streaming rejection)
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn scrape_rejects_oversized_response_body_during_streaming() {
+        let body_size = MAX_RESPONSE_BODY_BYTES + 1;
+        let header = format!("HTTP/1.0 200 OK\r\nContent-Type: text/plain\r\nContent-Length: {body_size}\r\n\r\n");
+        let mut response_bytes = header.into_bytes();
+        response_bytes.resize(response_bytes.len() + body_size, b'x');
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .unwrap_or_else(|_| std::process::abort());
+        let port = listener.local_addr().unwrap_or_else(|_| std::process::abort()).port();
+        tokio::spawn(async move {
+            if let Ok((mut stream, _)) = listener.accept().await {
+                let mut buf = [0_u8; 4096];
+                drop(stream.read(&mut buf).await);
+                drop(stream.write_all(&response_bytes).await);
+            }
+        });
+
+        let url = format!("http://127.0.0.1:{port}/metrics");
+        let result = scrape_metrics(&url, Duration::from_secs(10), None).await;
+        assert!(result.is_err(), "oversized response body must be rejected");
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("limit"), "error must mention size limit: {msg}");
+    }
+
+    // -----------------------------------------------------------------------
+    // Error message safety: no secret bytes in diagnostics
+    // -----------------------------------------------------------------------
+
+    #[test]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "exhaustive PEM-leak check across multiple error paths"
+    )]
+    fn error_messages_never_contain_pem_material() {
+        let ca = certs::generate_ca("test-ca").unwrap();
+        let client = certs::generate_dns_cert(&ca, "client", "localhost").unwrap();
+
+        let cases: Vec<(&str, Result<rustls::ClientConfig, MetricsScrapeError>)> = vec![
+            ("empty CA", build_tls_client_config(b"", None, None)),
+            ("garbage CA", build_tls_client_config(b"not valid", None, None)),
+            ("mismatched cert/key", {
+                let other = certs::generate_dns_cert(&ca, "other", "other.local").unwrap();
+                build_tls_client_config(
+                    ca.cert_pem.as_bytes(),
+                    Some(client.cert_pem.as_bytes()),
+                    Some(other.key_pem.as_bytes()),
+                )
+            }),
+        ];
+
+        for (label, result) in cases {
+            if let Err(e) = result {
+                let msg = e.to_string();
+                assert!(
+                    !msg.contains("BEGIN CERTIFICATE"),
+                    "{label}: error message must not contain PEM certificate data"
+                );
+                assert!(
+                    !msg.contains("BEGIN PRIVATE KEY"),
+                    "{label}: error message must not contain PEM private key data"
+                );
+                assert!(
+                    !msg.contains("BEGIN RSA"),
+                    "{label}: error message must not contain RSA key data"
+                );
+                assert!(
+                    !msg.contains("BEGIN EC"),
+                    "{label}: error message must not contain EC key data"
+                );
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // HTTPS enforcement when TLS is configured
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn scrape_rejects_http_url_with_tls_config() {
+        let ca = certs::generate_ca("test-ca").unwrap();
+        let config = Arc::new(build_tls_client_config(ca.cert_pem.as_bytes(), None, None).unwrap());
+        let result = scrape_metrics("http://127.0.0.1:9090/metrics", Duration::from_secs(5), Some(config)).await;
+        assert!(result.is_err(), "HTTP URL with TLS config must fail");
+        assert!(
+            matches!(result.unwrap_err(), MetricsScrapeError::HttpWithTls(_)),
+            "error must be HttpWithTls"
+        );
+    }
+
+    #[tokio::test]
+    async fn scrape_allows_https_url_with_tls_config() {
+        let ca = certs::generate_ca("test-ca").unwrap();
+        let server = certs::generate_dns_cert(&ca, "server", "localhost").unwrap();
+        let response = b"HTTP/1.0 200 OK\r\nContent-Length: 5\r\n\r\nhello";
+        let url = start_tls_test_server(&server.cert_pem, &server.key_pem, None, response.to_vec()).await;
+        let config = Arc::new(build_tls_client_config(ca.cert_pem.as_bytes(), None, None).unwrap());
+        let result = scrape_metrics(&url, Duration::from_secs(5), Some(config)).await;
+        assert!(result.is_ok(), "HTTPS URL with TLS config must succeed: {result:?}");
+    }
+
+    #[tokio::test]
+    async fn scrape_allows_http_url_without_tls_config() {
+        let response = b"HTTP/1.0 200 OK\r\nContent-Length: 5\r\n\r\nhello";
+        let url = start_test_server(response).await;
+        let result = scrape_metrics(&url, Duration::from_secs(5), None).await;
+        assert!(result.is_ok(), "HTTP URL without TLS config must succeed: {result:?}");
     }
 }

--- a/operator/src/resources/provider_metrics.rs
+++ b/operator/src/resources/provider_metrics.rs
@@ -5,23 +5,27 @@
 //! names, and returns a map keyed by provider routing identity for use with
 //! `render_routing_overlay`.
 //!
-//! Scrape failures are non-fatal: the provider is omitted from the returned map
-//! and falls back to static scoring unless a configured stale-metrics grace
-//! period can reuse a recent cached sample.
+//! Scrape failures are non-fatal: when a valid cached sample exists within the
+//! `staleMetricsSeconds` grace period, it is reused.  When no cache entry is
+//! available (or the grace period has expired), the provider is inserted with
+//! `UNOBSERVABLE_METRICS` (`healthy: false`), which causes the scoring engine
+//! to exclude it from active routing.  Providers without `metricsConfig` are
+//! unaffected — they receive neutral default scoring as before.
 //!
 //! [`GridNetwork`]: crate::crd::grid_network::GridNetwork
 
 use std::{
     collections::HashMap,
+    sync::Arc,
     time::{Duration, Instant},
 };
 
 use tokio::sync::Mutex;
 
 use crate::{
-    crd::inference_provider::{InferenceProvider, MetricSignalNames},
+    crd::inference_provider::{ClientCertificateSecretRef, InferenceProvider, MetricSignalNames, MetricsTlsConfig},
     metrics_parser::{MetricNames, parse_prometheus_text},
-    metrics_scraper::scrape_metrics,
+    metrics_scraper::{self, scrape_metrics},
     resources::routing_overlay::routing_identity,
 };
 
@@ -31,6 +35,24 @@ use crate::{
 
 /// Scrape timeout used when the provider's `metricsConfig.timeout` cannot be parsed.
 const DEFAULT_SCRAPE_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Metrics inserted for a provider whose configured metrics endpoint cannot be
+/// observed (scrape failed and no valid cache entry).
+///
+/// `healthy: false` causes the scoring engine's `is_healthy` filter to exclude
+/// the provider from active routing.  This prevents an unobservable secure
+/// metrics endpoint from receiving favorable neutral default scores.
+///
+/// Providers without `metricsConfig` are unaffected — they have no metrics
+/// entry in the map and receive neutral scoring as before.
+const UNOBSERVABLE_METRICS: scoring::BackendMetrics = scoring::BackendMetrics {
+    error_rate: 1.0,
+    healthy: false,
+    kv_cache_utilization: 1.0,
+    latency_p99_ms: 5000.0,
+    prefix_cache_hit_ratio: 0.0,
+    queue_depth: 1.0,
+};
 
 // ---------------------------------------------------------------------------
 // Timestamped metrics and cache
@@ -145,6 +167,12 @@ pub(crate) fn parse_metrics_timeout(s: &str) -> Duration {
 /// not present in the returned map.  Scrape failures are logged at `warn`
 /// level unless a cached sample is used.
 ///
+/// When `metricsConfig.tls` is configured, the TLS material is resolved from
+/// Kubernetes Secrets via `client` and used for server verification (and
+/// optional mTLS client authentication).  TLS resolution failures are
+/// fail-closed: the scrape is skipped and the provider falls back to stale
+/// cache or neutral scoring.
+///
 /// # Stale metrics grace period
 ///
 /// When `metricsConfig.stale_metrics_seconds` is set and a scrape fails, the
@@ -162,13 +190,15 @@ pub(crate) fn parse_metrics_timeout(s: &str) -> Duration {
 #[expect(
     clippy::cognitive_complexity,
     clippy::too_many_lines,
-    reason = "sequential per-provider scrape loop with early-continue guards, cache read/write, and error logging"
+    clippy::large_stack_frames,
+    reason = "sequential per-provider scrape loop with early-continue guards, cache read/write, TLS resolution, and error logging"
 )]
 pub(crate) async fn collect_provider_metrics(
     network_name: &str,
     providers: &[InferenceProvider],
     cache: &Mutex<MetricsCache>,
     now: Instant,
+    client: Option<&kube::Client>,
 ) -> HashMap<String, scoring::BackendMetrics> {
     // Snapshot only the relevant cache entries (for this network) so the lock
     // is held for microseconds rather than across network I/O.
@@ -221,8 +251,40 @@ pub(crate) async fn collect_provider_metrics(
         let timeout = parse_metrics_timeout(&mc.timeout);
         let names = metric_names_from_config(&mc.signal_names, mc.pool_name.as_deref(), mc.queue_capacity);
 
-        let parse_result = match scrape_metrics(&url, timeout).await {
-            Ok(text) => parse_prometheus_text(&text, &names),
+        let tls_config = match resolve_tls_config(mc.tls.as_ref(), client, identity).await {
+            Ok(cfg) => cfg,
+            Err(e) => {
+                let used_cache =
+                    try_cached_metrics(identity, mc.stale_metrics_seconds, &cache_snapshot, now, &mut result);
+                if used_cache {
+                    tracing::debug!(
+                        provider = identity,
+                        error = %e,
+                        "metrics TLS resolution failed; using cached sample within stale_metrics_seconds grace period"
+                    );
+                } else {
+                    if mc.tls.is_some() {
+                        tracing::warn!(
+                            provider = identity,
+                            error = %e,
+                            "metrics TLS resolution failed; provider excluded from routing"
+                        );
+                        result.insert(identity.to_owned(), UNOBSERVABLE_METRICS);
+                    } else {
+                        tracing::warn!(
+                            provider = identity,
+                            error = %e,
+                            "metrics scrape setup failed; provider metrics absent (neutral scoring)"
+                        );
+                    }
+                }
+                continue;
+            },
+        };
+
+        let scrape_result = scrape_metrics(&url, timeout, tls_config).await;
+        let parse_result = match &scrape_result {
+            Ok(text) => parse_prometheus_text(text, &names),
             Err(e) => Err(e.to_string()),
         };
         match parse_result {
@@ -238,22 +300,39 @@ pub(crate) async fn collect_provider_metrics(
                 result.insert(identity.to_owned(), bm);
             },
             Err(e) => {
+                let reason_str = scrape_result
+                    .as_ref()
+                    .err()
+                    .map_or("MetricsScrapeError", |e| classify_scrape_error(e));
                 let used_cache =
                     try_cached_metrics(identity, mc.stale_metrics_seconds, &cache_snapshot, now, &mut result);
                 if used_cache {
                     tracing::debug!(
                         provider = identity,
                         url = %url,
+                        reason = reason_str,
                         error = %e,
                         "metrics scrape failed; using cached sample within stale_metrics_seconds grace period"
                     );
                 } else {
-                    tracing::warn!(
-                        provider = identity,
-                        url = %url,
-                        error = %e,
-                        "metrics scrape failed; provider will use neutral scoring"
-                    );
+                    if mc.tls.is_some() {
+                        tracing::warn!(
+                            provider = identity,
+                            url = %url,
+                            reason = reason_str,
+                            error = %e,
+                            "metrics scrape failed; provider excluded from routing"
+                        );
+                        result.insert(identity.to_owned(), UNOBSERVABLE_METRICS);
+                    } else {
+                        tracing::warn!(
+                            provider = identity,
+                            url = %url,
+                            reason = reason_str,
+                            error = %e,
+                            "metrics scrape failed; provider metrics absent (neutral scoring)"
+                        );
+                    }
                 }
             },
         }
@@ -296,6 +375,308 @@ fn try_cached_metrics(
     }
     result.insert(identity.to_owned(), cached.metrics);
     true
+}
+
+// ---------------------------------------------------------------------------
+// TLS material resolution
+// ---------------------------------------------------------------------------
+
+/// Build a [`SecretRef`](crate::crd::grid_network::SecretRef) from a [`ClientCertificateSecretRef`] for Secret reads.
+fn secret_ref_from_client_cert(client_ref: &ClientCertificateSecretRef) -> crate::crd::grid_network::SecretRef {
+    crate::crd::grid_network::SecretRef {
+        name: client_ref.name.clone(),
+        namespace: client_ref.namespace.clone(),
+        key: None,
+    }
+}
+
+/// Resolve a [`rustls::ClientConfig`] from a provider's metrics TLS configuration.
+///
+/// When `tls_config` is `None`, returns `Ok(None)` (use native roots).
+/// When `tls_config` is `Some`, reads the referenced Kubernetes Secrets,
+/// parses the PEM material, and builds a `ClientConfig`.
+///
+/// # Fail-closed
+///
+/// Any resolution failure returns `Err` — the caller must NOT fall back to
+/// native root certificates.  The scrape is skipped entirely.
+///
+/// # Security invariant
+///
+/// Private key bytes are passed to [`metrics_scraper::build_tls_client_config`]
+/// and are never written to logs, events, status fields, or Prometheus labels.
+#[expect(
+    clippy::large_stack_frames,
+    clippy::too_many_lines,
+    reason = "async future with kube API types and PEM buffers; sequential Secret reads for CA, client cert, and client key"
+)]
+async fn resolve_tls_config(
+    tls_config: Option<&MetricsTlsConfig>,
+    client: Option<&kube::Client>,
+    provider_identity: &str,
+) -> Result<Option<Arc<rustls::ClientConfig>>, String> {
+    let Some(tls) = tls_config else {
+        return Ok(None);
+    };
+    let Some(kube_client) = client else {
+        return Err("metrics TLS configured but no Kubernetes client available".to_owned());
+    };
+
+    let ca_key = tls.ca_secret_ref.key.as_deref().unwrap_or("ca.crt");
+    let ca_pem = read_secret_bytes_for_tls(kube_client, &tls.ca_secret_ref, ca_key, provider_identity, "CA")
+        .await
+        .map_err(|e| format!("CA secret resolution failed: {e}"))?;
+
+    let (client_cert_pem, client_key_pem) = if let Some(client_ref) = &tls.client_certificate_secret_ref {
+        let cert_ref = secret_ref_from_client_cert(client_ref);
+        let cert = read_secret_bytes_for_tls(
+            kube_client,
+            &cert_ref,
+            &client_ref.certificate_key,
+            provider_identity,
+            "client cert",
+        )
+        .await?;
+        let key = read_secret_bytes_for_tls(
+            kube_client,
+            &cert_ref,
+            &client_ref.private_key_key,
+            provider_identity,
+            "client key",
+        )
+        .await?;
+        (Some(cert), Some(key))
+    } else {
+        (None, None)
+    };
+
+    let config =
+        metrics_scraper::build_tls_client_config(&ca_pem, client_cert_pem.as_deref(), client_key_pem.as_deref())
+            .map_err(|e| format!("{e}"))?;
+
+    Ok(Some(Arc::new(config)))
+}
+
+/// Read raw bytes from a Kubernetes Secret for TLS material resolution.
+///
+/// Returns an error string suitable for logging (never includes the byte
+/// content itself).
+async fn read_secret_bytes_for_tls(
+    client: &kube::Client,
+    secret_ref: &crate::crd::grid_network::SecretRef,
+    key_name: &str,
+    provider_identity: &str,
+    material_desc: &str,
+) -> Result<Vec<u8>, String> {
+    use crate::resources::secret::read_secret_bytes;
+
+    match read_secret_bytes(client, secret_ref, key_name).await {
+        Ok(Some(bytes)) if !bytes.is_empty() => Ok(bytes),
+        Ok(Some(_)) => Err(format!(
+            "{material_desc} key {key_name:?} in Secret {}/{} is empty for provider {provider_identity}",
+            secret_ref.namespace, secret_ref.name
+        )),
+        Ok(None) => Err(format!(
+            "{material_desc} Secret {}/{} or key {key_name:?} not found for provider {provider_identity}",
+            secret_ref.namespace, secret_ref.name
+        )),
+        Err(e) => Err(format!(
+            "{material_desc} Secret {}/{} read failed for provider {provider_identity}: {e}",
+            secret_ref.namespace, secret_ref.name
+        )),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Metrics TLS validation
+// ---------------------------------------------------------------------------
+
+/// Machine-readable reason for a metrics TLS configuration failure.
+///
+/// Surfaced in [`InferenceProvider`] `status.reason` so administrators can
+/// diagnose material and configuration errors without inspecting operator
+/// logs.  Values are stable across releases and safe for automation to parse.
+///
+/// Only material/configuration failures that the controller can observe
+/// during reconciliation appear here.  Scrape-time failures (TLS handshake,
+/// HTTP 401/403, timeout) are classified by [`classify_scrape_error`] and
+/// surfaced as structured log fields only — they cannot be reproduced
+/// deterministically by the controller and should not appear in status.
+///
+/// Never includes raw certificate or key content.
+///
+/// [`InferenceProvider`]: crate::crd::inference_provider::InferenceProvider
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[expect(
+    clippy::enum_variant_names,
+    reason = "variants are stable status reason strings matching the bounded failure categories"
+)]
+pub(crate) enum MetricsFailureReason {
+    /// A referenced Secret does not exist or has no `data` section.
+    MetricsTlsSecretMissing,
+    /// The expected key is absent from `Secret.data` or its value is empty.
+    MetricsTlsKeyMissing,
+    /// PEM material could not be parsed or contains no certificates/keys.
+    MetricsTlsMaterialInvalid,
+    /// The client certificate and private key do not form a valid identity.
+    MetricsTlsIdentityMismatch,
+}
+
+impl MetricsFailureReason {
+    /// Machine-readable string for `InferenceProvider.status.reason`.
+    ///
+    /// Only material and configuration failures appear in status — the
+    /// controller can observe these during reconciliation without
+    /// performing a live scrape.  Scrape-time failures (handshake,
+    /// auth, timeout) are surfaced as structured logs only.
+    #[must_use]
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::MetricsTlsSecretMissing => "MetricsTlsSecretMissing",
+            Self::MetricsTlsKeyMissing => "MetricsTlsKeyMissing",
+            Self::MetricsTlsMaterialInvalid => "MetricsTlsMaterialInvalid",
+            Self::MetricsTlsIdentityMismatch => "MetricsTlsIdentityMismatch",
+        }
+    }
+}
+
+/// Classify a [`MetricsScrapeError`](crate::metrics_scraper::MetricsScrapeError) into a
+/// bounded log-level reason string.
+///
+/// These categories are used for structured logging only — they do not
+/// appear in `InferenceProvider.status.reason`.  Status reasons are
+/// reserved for material/configuration failures that the controller
+/// can observe during reconciliation (see [`MetricsFailureReason`]).
+pub(crate) fn classify_scrape_error(err: &metrics_scraper::MetricsScrapeError) -> &'static str {
+    match err {
+        metrics_scraper::MetricsScrapeError::Timeout(_) => "MetricsScrapeTimeout",
+        metrics_scraper::MetricsScrapeError::NonOkStatus { status, .. } if *status == 401 || *status == 403 => {
+            "MetricsUnauthorized"
+        },
+        metrics_scraper::MetricsScrapeError::Transport(e) => {
+            let msg = e.to_string().to_lowercase();
+            if msg.contains("tls") || msg.contains("certificate") || msg.contains("handshake") || msg.contains("ssl") {
+                "MetricsTlsHandshakeFailed"
+            } else {
+                "MetricsScrapeError"
+            }
+        },
+        metrics_scraper::MetricsScrapeError::TlsMaterial(_) | metrics_scraper::MetricsScrapeError::HttpWithTls(_) => {
+            "MetricsTlsMaterialInvalid"
+        },
+        _ => "MetricsScrapeError",
+    }
+}
+
+/// Result of reading a TLS Secret key for validation.
+enum TlsSecretCheck {
+    /// The key was found and contains non-empty bytes.
+    Ok(Vec<u8>),
+    /// The Secret does not exist or has no `data` section.
+    SecretMissing,
+    /// The expected key is absent or its value is empty.
+    KeyMissing,
+}
+
+/// Verify that the metrics TLS Secrets exist, contain the expected keys, and
+/// the PEM material can be assembled into a valid [`rustls::ClientConfig`].
+///
+/// This runs during reconcile to surface configuration errors early.
+/// The same material is resolved again at scrape time; this check catches
+/// misconfigurations before the first scrape attempt.
+///
+/// # Returns
+///
+/// - `Ok(None)` — TLS material is accessible and valid (or no TLS configured).
+/// - `Ok(Some(reason))` — failure; the provider should be marked [`Degraded`] with the returned reason in
+///   `status.reason`.
+///
+/// [`Degraded`]: crate::crd::inference_provider::ProviderPhase::Degraded
+///
+/// # Errors
+///
+/// Returns [`OperatorError`] on Kubernetes API failures (network, server error,
+/// authorization denied).  These are transient; the controller should requeue.
+///
+/// [`OperatorError`]: crate::error::OperatorError
+#[expect(
+    clippy::too_many_lines,
+    clippy::large_stack_frames,
+    reason = "sequential Secret reads for CA, client cert, and client key with match arms"
+)]
+pub(crate) async fn verify_metrics_tls_accessible(
+    client: &kube::Client,
+    tls_config: Option<&MetricsTlsConfig>,
+) -> Result<Option<MetricsFailureReason>, crate::error::OperatorError> {
+    let Some(tls) = tls_config else {
+        return Ok(None);
+    };
+
+    let ca_key = tls.ca_secret_ref.key.as_deref().unwrap_or("ca.crt");
+    let ca_pem = match read_tls_secret_for_verify(client, &tls.ca_secret_ref, ca_key).await? {
+        TlsSecretCheck::Ok(bytes) => bytes,
+        TlsSecretCheck::SecretMissing => return Ok(Some(MetricsFailureReason::MetricsTlsSecretMissing)),
+        TlsSecretCheck::KeyMissing => return Ok(Some(MetricsFailureReason::MetricsTlsKeyMissing)),
+    };
+
+    let (client_cert_pem, client_key_pem) = if let Some(client_ref) = &tls.client_certificate_secret_ref {
+        let sref = secret_ref_from_client_cert(client_ref);
+        let cert = match read_tls_secret_for_verify(client, &sref, &client_ref.certificate_key).await? {
+            TlsSecretCheck::Ok(bytes) => bytes,
+            TlsSecretCheck::SecretMissing => return Ok(Some(MetricsFailureReason::MetricsTlsSecretMissing)),
+            TlsSecretCheck::KeyMissing => return Ok(Some(MetricsFailureReason::MetricsTlsKeyMissing)),
+        };
+        let key = match read_tls_secret_for_verify(client, &sref, &client_ref.private_key_key).await? {
+            TlsSecretCheck::Ok(bytes) => bytes,
+            TlsSecretCheck::SecretMissing => return Ok(Some(MetricsFailureReason::MetricsTlsSecretMissing)),
+            TlsSecretCheck::KeyMissing => return Ok(Some(MetricsFailureReason::MetricsTlsKeyMissing)),
+        };
+        (Some(cert), Some(key))
+    } else {
+        (None, None)
+    };
+
+    match metrics_scraper::build_tls_client_config(&ca_pem, client_cert_pem.as_deref(), client_key_pem.as_deref()) {
+        Ok(_) => Ok(None),
+        Err(e) => {
+            let msg = e.to_string();
+            let reason = if msg.contains("identity construction failed") {
+                MetricsFailureReason::MetricsTlsIdentityMismatch
+            } else {
+                MetricsFailureReason::MetricsTlsMaterialInvalid
+            };
+            Ok(Some(reason))
+        },
+    }
+}
+
+/// Read raw bytes from a Kubernetes Secret for TLS validation.
+///
+/// Distinguishes between "Secret not found" and "key not found" to map to
+/// the correct [`MetricsFailureReason`] variant.
+///
+/// # Errors
+///
+/// Returns [`OperatorError`] on Kubernetes API failures.
+///
+/// [`OperatorError`]: crate::error::OperatorError
+async fn read_tls_secret_for_verify(
+    client: &kube::Client,
+    secret_ref: &crate::crd::grid_network::SecretRef,
+    key_name: &str,
+) -> Result<TlsSecretCheck, crate::error::OperatorError> {
+    let api: kube::Api<k8s_openapi::api::core::v1::Secret> =
+        kube::Api::namespaced(client.clone(), &secret_ref.namespace);
+    let Some(secret) = api.get_opt(&secret_ref.name).await? else {
+        return Ok(TlsSecretCheck::SecretMissing);
+    };
+    let Some(data) = &secret.data else {
+        return Ok(TlsSecretCheck::KeyMissing);
+    };
+    match data.get(key_name) {
+        Some(bytes) if !bytes.0.is_empty() => Ok(TlsSecretCheck::Ok(bytes.0.clone())),
+        _ => Ok(TlsSecretCheck::KeyMissing),
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -382,6 +763,7 @@ mod tests {
             metrics_endpoint: None,
             pool_name: None,
             queue_capacity: None,
+            tls: None,
         }
     }
 
@@ -397,6 +779,7 @@ mod tests {
             metrics_endpoint: None,
             pool_name: None,
             queue_capacity: None,
+            tls: None,
         }
     }
 
@@ -526,7 +909,7 @@ mod tests {
     #[tokio::test]
     async fn collect_metrics_no_config_returns_empty_map() {
         let provider = provider_fixture("prov-a", "http://127.0.0.1:9999", None);
-        let result = collect_provider_metrics("net", &[provider], &empty_cache(), Instant::now()).await;
+        let result = collect_provider_metrics("net", &[provider], &empty_cache(), Instant::now(), None).await;
         assert!(
             result.is_empty(),
             "provider without metricsConfig must not appear in metrics map"
@@ -536,7 +919,7 @@ mod tests {
     #[tokio::test]
     async fn collect_metrics_blank_endpoint_is_skipped() {
         let provider = provider_fixture("prov-a", "", Some(mc_with_queue("my_queue")));
-        let result = collect_provider_metrics("net", &[provider], &empty_cache(), Instant::now()).await;
+        let result = collect_provider_metrics("net", &[provider], &empty_cache(), Instant::now(), None).await;
         assert!(result.is_empty(), "provider with blank endpoint must not be scraped");
     }
 
@@ -546,7 +929,7 @@ mod tests {
         let base_url = start_test_server(ok_response(body)).await;
         let provider = provider_fixture("prov-a", &base_url, Some(mc_with_queue("my_queue")));
 
-        let result = collect_provider_metrics("net", &[provider], &empty_cache(), Instant::now()).await;
+        let result = collect_provider_metrics("net", &[provider], &empty_cache(), Instant::now(), None).await;
         assert!(
             result.contains_key("prov-a"),
             "provider must appear in metrics map after successful scrape"
@@ -583,7 +966,7 @@ mod tests {
         }))
         .unwrap_or_else(|_| std::process::abort());
 
-        let result = collect_provider_metrics("net", &[provider], &empty_cache(), Instant::now()).await;
+        let result = collect_provider_metrics("net", &[provider], &empty_cache(), Instant::now(), None).await;
         assert!(
             result.contains_key("site-x"),
             "metrics must be keyed by routingClusterRef, not metadata.name"
@@ -595,24 +978,23 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn collect_metrics_scrape_failure_logs_and_omits_provider() {
-        // Port 1 is never open — connection will be refused.
+    async fn collect_metrics_scrape_failure_plaintext_omits_entry() {
         let provider = provider_fixture("prov-a", "http://127.0.0.1:1", Some(mc_with_queue("my_queue")));
-        let result = collect_provider_metrics("net", &[provider], &empty_cache(), Instant::now()).await;
+        let result = collect_provider_metrics("net", &[provider], &empty_cache(), Instant::now(), None).await;
         assert!(
-            result.is_empty(),
-            "failed scrape must not panic and must omit provider from map"
+            !result.contains_key("prov-a"),
+            "plaintext provider scrape failure must not insert unobservable metrics"
         );
     }
 
     #[tokio::test]
-    async fn collect_metrics_non_2xx_omits_provider() {
+    async fn collect_metrics_non_2xx_plaintext_omits_entry() {
         let base_url = start_test_server(err_response(503)).await;
         let provider = provider_fixture("prov-a", &base_url, Some(mc_with_queue("my_queue")));
-        let result = collect_provider_metrics("net", &[provider], &empty_cache(), Instant::now()).await;
+        let result = collect_provider_metrics("net", &[provider], &empty_cache(), Instant::now(), None).await;
         assert!(
-            result.is_empty(),
-            "non-2xx response must omit provider from metrics map"
+            !result.contains_key("prov-a"),
+            "plaintext provider non-2xx response must not insert unobservable metrics"
         );
     }
 
@@ -623,7 +1005,7 @@ mod tests {
         let base_url = start_test_server(ok_response(body)).await;
         let provider = provider_fixture("prov-a", &base_url, Some(mc_with_queue("my_queue")));
 
-        let result = collect_provider_metrics("net", &[provider], &empty_cache(), Instant::now()).await;
+        let result = collect_provider_metrics("net", &[provider], &empty_cache(), Instant::now(), None).await;
         assert!(
             result.contains_key("prov-a"),
             "malformed body must still produce a metrics entry"
@@ -653,7 +1035,7 @@ mod tests {
         let prov_a = provider_fixture("prov-a", &url_a, Some(mc_with_queue("my_queue")));
         let prov_b = provider_fixture("prov-b", &url_b, Some(mc_with_queue("my_queue")));
 
-        let result = collect_provider_metrics("net", &[prov_a, prov_b], &empty_cache(), Instant::now()).await;
+        let result = collect_provider_metrics("net", &[prov_a, prov_b], &empty_cache(), Instant::now(), None).await;
         assert!(result.contains_key("prov-a"), "prov-a must be in metrics map");
         assert!(result.contains_key("prov-b"), "prov-b must be in metrics map");
         assert!(
@@ -677,7 +1059,7 @@ mod tests {
         let base_url = start_test_server(ok_response(body)).await;
         let provider = provider_fixture("prov-a", &base_url, Some(mc_with_queue("my_queue")));
 
-        let result = collect_provider_metrics("other-net", &[provider], &empty_cache(), Instant::now()).await;
+        let result = collect_provider_metrics("other-net", &[provider], &empty_cache(), Instant::now(), None).await;
         assert!(
             result.is_empty(),
             "provider from a different GridNetwork must not be scraped"
@@ -712,7 +1094,7 @@ mod tests {
             );
         }
         // Scrape fails (port 1 is always refused); cache is within 60 s TTL.
-        let result = collect_provider_metrics("net", &[provider], &cache, t0).await;
+        let result = collect_provider_metrics("net", &[provider], &cache, t0, None).await;
         assert!(
             result.contains_key("prov-a"),
             "failed scrape within TTL must use cached metrics"
@@ -748,21 +1130,19 @@ mod tests {
                 },
             );
         }
-        // Clock advanced past TTL → cache entry is expired → neutral scoring.
-        let result = collect_provider_metrics("net", &[provider], &cache, t_after_ttl).await;
+        // Clock advanced past TTL → cache entry is expired → plaintext provider omitted.
+        let result = collect_provider_metrics("net", &[provider], &cache, t_after_ttl, None).await;
         assert!(
             !result.contains_key("prov-a"),
-            "expired cache must not be used; provider must be absent (neutral scoring)"
+            "expired cache on plaintext provider must not insert unobservable metrics"
         );
     }
 
     #[tokio::test]
-    async fn no_ttl_configured_scrape_failure_gives_neutral() {
-        // No stale_metrics_seconds → backward-compatible: scrape failure = absent.
+    async fn no_ttl_configured_scrape_failure_plaintext_omits_entry() {
         let provider = provider_fixture("prov-a", "http://127.0.0.1:1", Some(mc_with_queue("q")));
         let cache = empty_cache();
         {
-            // Put something in the cache — it must NOT be used when TTL is absent.
             let mut guard = cache.lock().await;
             guard.insert(
                 ("net".to_owned(), "prov-a".to_owned()),
@@ -779,10 +1159,10 @@ mod tests {
                 },
             );
         }
-        let result = collect_provider_metrics("net", &[provider], &cache, Instant::now()).await;
+        let result = collect_provider_metrics("net", &[provider], &cache, Instant::now(), None).await;
         assert!(
             !result.contains_key("prov-a"),
-            "without stale_metrics_seconds, scrape failure must produce absent (neutral) metrics"
+            "plaintext provider without stale_metrics_seconds must not insert unobservable metrics"
         );
     }
 
@@ -794,7 +1174,7 @@ mod tests {
         let cache = empty_cache();
         let t0 = Instant::now();
 
-        let _unused = collect_provider_metrics("net", &[provider], &cache, t0).await;
+        let _unused = collect_provider_metrics("net", &[provider], &cache, t0, None).await;
 
         // Read from the cache: extract the queue_depth while holding the lock,
         // then release the guard so the MutexGuard does not live across the assert.
@@ -811,9 +1191,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn zero_ttl_treated_as_absent_no_cache_used() {
-        // stale_metrics_seconds = 0 is defensively treated as absent (same as None).
-        // Schema rejects 0, but we guard internally too.
+    async fn zero_ttl_treated_as_absent_plaintext_omits_entry() {
         let provider = provider_fixture("prov-a", "http://127.0.0.1:1", Some(mc_with_queue_and_ttl("q", 0)));
         let cache = empty_cache();
         {
@@ -833,10 +1211,111 @@ mod tests {
                 },
             );
         }
-        let result = collect_provider_metrics("net", &[provider], &cache, Instant::now()).await;
+        let result = collect_provider_metrics("net", &[provider], &cache, Instant::now(), None).await;
         assert!(
             !result.contains_key("prov-a"),
-            "zero TTL must be treated as absent: no cache use on failure"
+            "plaintext provider with zero TTL must not insert unobservable metrics"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // MetricsFailureReason
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn metrics_failure_reason_as_str_stable_values() {
+        assert_eq!(
+            MetricsFailureReason::MetricsTlsSecretMissing.as_str(),
+            "MetricsTlsSecretMissing",
+            "stable status reason code"
+        );
+        assert_eq!(
+            MetricsFailureReason::MetricsTlsKeyMissing.as_str(),
+            "MetricsTlsKeyMissing",
+            "stable status reason code"
+        );
+        assert_eq!(
+            MetricsFailureReason::MetricsTlsMaterialInvalid.as_str(),
+            "MetricsTlsMaterialInvalid",
+            "stable status reason code"
+        );
+        assert_eq!(
+            MetricsFailureReason::MetricsTlsIdentityMismatch.as_str(),
+            "MetricsTlsIdentityMismatch",
+            "stable status reason code"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // classify_scrape_error — log-level classification
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn classify_timeout_returns_scrape_timeout() {
+        let err = metrics_scraper::MetricsScrapeError::Timeout(Duration::from_secs(2));
+        assert_eq!(
+            classify_scrape_error(&err),
+            "MetricsScrapeTimeout",
+            "timeout must classify as MetricsScrapeTimeout"
+        );
+    }
+
+    #[test]
+    fn classify_401_returns_unauthorized() {
+        let err = metrics_scraper::MetricsScrapeError::NonOkStatus {
+            status: 401,
+            url: "http://x".to_owned(),
+        };
+        assert_eq!(
+            classify_scrape_error(&err),
+            "MetricsUnauthorized",
+            "HTTP 401 must classify as MetricsUnauthorized"
+        );
+    }
+
+    #[test]
+    fn classify_403_returns_unauthorized() {
+        let err = metrics_scraper::MetricsScrapeError::NonOkStatus {
+            status: 403,
+            url: "http://x".to_owned(),
+        };
+        assert_eq!(
+            classify_scrape_error(&err),
+            "MetricsUnauthorized",
+            "HTTP 403 must classify as MetricsUnauthorized"
+        );
+    }
+
+    #[test]
+    fn classify_500_returns_generic() {
+        let err = metrics_scraper::MetricsScrapeError::NonOkStatus {
+            status: 500,
+            url: "http://x".to_owned(),
+        };
+        assert_eq!(
+            classify_scrape_error(&err),
+            "MetricsScrapeError",
+            "HTTP 500 has no specific failure category"
+        );
+    }
+
+    #[test]
+    fn classify_tls_material_error_returns_material_invalid() {
+        let err = metrics_scraper::MetricsScrapeError::TlsMaterial("bad PEM".to_owned());
+        assert_eq!(
+            classify_scrape_error(&err),
+            "MetricsTlsMaterialInvalid",
+            "TLS material error must classify as MetricsTlsMaterialInvalid"
+        );
+    }
+
+    #[test]
+    fn classify_invalid_url_returns_generic() {
+        let err = metrics_scraper::MetricsScrapeError::InvalidUrl("ftp://bad".to_owned());
+        assert_eq!(
+            classify_scrape_error(&err),
+            "MetricsScrapeError",
+            "invalid URL has no specific failure category"
         );
     }
 }

--- a/xtask/src/env/certs.rs
+++ b/xtask/src/env/certs.rs
@@ -5,7 +5,9 @@ use std::{
     process::Command,
 };
 
-use certs::{DEFAULT_ORGANIZATION, generate_ca, generate_cert_with_org, generate_site_cert, load_ca};
+use certs::{
+    DEFAULT_ORGANIZATION, generate_ca, generate_cert_with_org, generate_dns_cert, generate_site_cert, load_ca,
+};
 use sha2::{Digest as _, Sha256};
 
 // ---------------------------------------------------------------------------
@@ -68,6 +70,95 @@ pub(crate) fn generate_all(cluster_names: &[String]) -> Result<PathBuf, Box<dyn 
     ensure_wrong_org_identity(&dir, &ca, cluster_names, ca_was_complete)?;
 
     Ok(dir)
+}
+
+/// Generate a dedicated CA and certificates for metrics endpoint mTLS.
+///
+/// Produces files under `{CERTS_DIR}/`:
+/// - `metrics-ca.pem` / `metrics-ca-key.pem` — metrics-only CA
+/// - `metrics-server-cert.pem` / `metrics-server-key.pem` — TLS proxy cert
+/// - `metrics-client-cert.pem` / `metrics-client-key.pem` — operator client cert
+///
+/// # Errors
+///
+/// Returns an error if certificate generation or file writes fail.
+pub(crate) fn generate_metrics_certs(ca_cn: &str, server_dns: &str) -> Result<PathBuf, Box<dyn std::error::Error>> {
+    let dir = PathBuf::from(CERTS_DIR);
+    std::fs::create_dir_all(&dir)?;
+
+    let metrics_ca = generate_ca(ca_cn)?;
+    write_pem(&dir.join("metrics-ca.pem"), &metrics_ca.cert_pem)?;
+    write_pem(&dir.join("metrics-ca-key.pem"), &metrics_ca.key_pem)?;
+
+    let server = generate_dns_cert(&metrics_ca, "metrics-server", server_dns)?;
+    write_pem(&dir.join("metrics-server-cert.pem"), &server.cert_pem)?;
+    write_pem(&dir.join("metrics-server-key.pem"), &server.key_pem)?;
+
+    let client = generate_dns_cert(&metrics_ca, "metrics-client", "grid-operator.grid-system")?;
+    write_pem(&dir.join("metrics-client-cert.pem"), &client.cert_pem)?;
+    write_pem(&dir.join("metrics-client-key.pem"), &client.key_pem)?;
+
+    Ok(dir)
+}
+
+/// Load the metrics CA from disk for signing new certificates.
+///
+/// # Errors
+///
+/// Returns an error if the files are missing or contain invalid PEM.
+pub(crate) fn load_metrics_ca(ca_cn: &str) -> Result<certs::CaCert, Box<dyn std::error::Error>> {
+    let dir = PathBuf::from(CERTS_DIR);
+    let cert_pem = std::fs::read_to_string(dir.join("metrics-ca.pem"))?;
+    let key_pem = std::fs::read_to_string(dir.join("metrics-ca-key.pem"))?;
+    Ok(load_ca(ca_cn, &key_pem, &cert_pem)?)
+}
+
+/// Regenerate the metrics client certificate (for rotation proofs).
+///
+/// Overwrites `metrics-client-cert.pem` and `metrics-client-key.pem`
+/// with a freshly generated cert signed by the same metrics CA.
+///
+/// # Errors
+///
+/// Returns an error if signing or file writes fail.
+pub(crate) fn rotate_metrics_client_cert(ca_cn: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let dir = PathBuf::from(CERTS_DIR);
+    let metrics_ca = load_metrics_ca(ca_cn)?;
+    let client = generate_dns_cert(&metrics_ca, "metrics-client-rotated", "grid-operator.grid-system")?;
+    write_pem(&dir.join("metrics-client-cert.pem"), &client.cert_pem)?;
+    write_pem(&dir.join("metrics-client-key.pem"), &client.key_pem)?;
+    Ok(())
+}
+
+/// Regenerate the metrics server certificate (for rotation proofs).
+///
+/// Overwrites `metrics-server-cert.pem` and `metrics-server-key.pem`
+/// with a freshly generated cert signed by the same metrics CA.
+///
+/// # Errors
+///
+/// Returns an error if signing or file writes fail.
+pub(crate) fn rotate_metrics_server_cert(ca_cn: &str, server_dns: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let dir = PathBuf::from(CERTS_DIR);
+    let metrics_ca = load_metrics_ca(ca_cn)?;
+    let server = generate_dns_cert(&metrics_ca, "metrics-server-rotated", server_dns)?;
+    write_pem(&dir.join("metrics-server-cert.pem"), &server.cert_pem)?;
+    write_pem(&dir.join("metrics-server-key.pem"), &server.key_pem)?;
+    Ok(())
+}
+
+/// Generate a wrong-CA cert for metrics TLS negative testing.
+///
+/// Creates a self-signed CA and writes its cert to `metrics-wrong-ca.pem`.
+///
+/// # Errors
+///
+/// Returns an error if generation or file writes fail.
+pub(crate) fn generate_wrong_metrics_ca() -> Result<(), Box<dyn std::error::Error>> {
+    let dir = PathBuf::from(CERTS_DIR);
+    let wrong_ca = generate_ca("Wrong Metrics CA")?;
+    write_pem(&dir.join("metrics-wrong-ca.pem"), &wrong_ca.cert_pem)?;
+    Ok(())
 }
 
 /// Remove the generated certificates directory.

--- a/xtask/src/env/consumer.rs
+++ b/xtask/src/env/consumer.rs
@@ -2119,8 +2119,6 @@ pub(crate) fn verify_credential_injection(
 // ---------------------------------------------------------------------------
 // Shared helpers
 // ---------------------------------------------------------------------------
-
-
 /// Indent each line of a YAML string by `spaces` spaces.
 fn indent_yaml(yaml: &str, spaces: usize) -> String {
     let prefix = " ".repeat(spaces);
@@ -2143,7 +2141,6 @@ fn indent_yaml(yaml: &str, spaces: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-
     // -----------------------------------------------------------------------
     // Test utilities
     // -----------------------------------------------------------------------
@@ -2477,7 +2474,6 @@ mod tests {
             "overlay mode must include intelligent_route"
         );
     }
-
 
     // -----------------------------------------------------------------------
     // API-provider credential injection

--- a/xtask/src/env/kind.rs
+++ b/xtask/src/env/kind.rs
@@ -18,8 +18,6 @@ const CLUSTER_PREFIX: &str = "grid-";
 
 /// Container image for llm-d inference simulator.
 const INFERENCE_SIM_IMAGE: &str = "ghcr.io/llm-d/llm-d-inference-sim:latest";
-
-
 /// Kubernetes Deployment and Service name for the `openai` provider backend.
 pub(crate) const MOCK_OPENAI_SVC: &str = "mock-openai-provider";
 

--- a/xtask/src/env/llmd_pool_metrics_demo.rs
+++ b/xtask/src/env/llmd_pool_metrics_demo.rs
@@ -16,7 +16,7 @@
 )]
 
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, HashMap},
     fs,
     path::{Path, PathBuf},
     process::Command,
@@ -59,7 +59,7 @@ const OUTPUT_RULE: &str = "=====================================================
 const EVIDENCE_SCHEMA_VERSION: &str = "1";
 
 /// Number of setup phases.
-const SETUP_PHASES: usize = 10;
+const SETUP_PHASES: usize = 11;
 
 /// Primary model name served by inference simulators.
 const SIM_MODEL: &str = "llmd-sim-model";
@@ -105,6 +105,23 @@ const DEFAULT_SIM_IMAGE: &str = "llm-d-inference-sim:llmd-pool-metrics-demo";
 /// Default overlay-sync sidecar image tag.
 const DEFAULT_OVERLAY_SYNC_IMAGE: &str = "grid-overlay-sync:llmd-pool-metrics-demo";
 
+/// Default nginx image for the metrics TLS reverse proxy sidecar.
+const DEFAULT_NGINX_IMAGE: &str = "nginx:metrics-proxy-demo";
+
+/// Metrics TLS CA common name (separate from gateway CA).
+const METRICS_CA_CN: &str = "Grid Metrics Test CA";
+
+/// DNS SAN for the metrics TLS server certificate.
+const METRICS_SERVER_DNS: &str = "llmd-epp-metrics.grid-system.svc.cluster.local";
+
+/// Secret name holding the metrics CA certificate.
+const METRICS_CA_SECRET: &str = "metrics-ca";
+
+/// Secret name holding the metrics server TLS certificate and key.
+const METRICS_SERVER_TLS_SECRET: &str = "metrics-server-tls";
+
+/// Secret name holding the metrics client TLS certificate and key.
+const METRICS_CLIENT_TLS_SECRET: &str = "metrics-client-tls";
 
 // ---------------------------------------------------------------------------
 // Context
@@ -132,6 +149,8 @@ struct ResolvedImages {
     sim: String,
     /// Grid overlay-sync sidecar image.
     overlay_sync: String,
+    /// nginx image for metrics TLS reverse proxy sidecar.
+    nginx: String,
 }
 
 // ---------------------------------------------------------------------------
@@ -393,6 +412,7 @@ fn resolve_images() -> Result<ResolvedImages, Box<dyn std::error::Error>> {
     let sim = std::env::var("GRID_XTASK_SIM_IMAGE").unwrap_or_else(|_| DEFAULT_SIM_IMAGE.to_owned());
     let overlay_sync =
         std::env::var("GRID_XTASK_OVERLAY_SYNC_IMAGE").unwrap_or_else(|_| DEFAULT_OVERLAY_SYNC_IMAGE.to_owned());
+    let nginx = std::env::var("GRID_XTASK_NGINX_IMAGE").unwrap_or_else(|_| DEFAULT_NGINX_IMAGE.to_owned());
 
     eprintln!("  Images:");
     eprintln!("    gateway:      {gateway}");
@@ -400,6 +420,7 @@ fn resolve_images() -> Result<ResolvedImages, Box<dyn std::error::Error>> {
     eprintln!("    epp:          {epp}");
     eprintln!("    sim:          {sim}");
     eprintln!("    overlay-sync: {overlay_sync}");
+    eprintln!("    nginx:        {nginx}");
 
     Ok(ResolvedImages {
         gateway,
@@ -407,6 +428,7 @@ fn resolve_images() -> Result<ResolvedImages, Box<dyn std::error::Error>> {
         epp,
         sim,
         overlay_sync,
+        nginx,
     })
 }
 
@@ -418,6 +440,7 @@ fn verify_images(images: &ResolvedImages) -> Result<(), Box<dyn std::error::Erro
         ("epp", &images.epp, "EPP"),
         ("sim", &images.sim, "SIM"),
         ("overlay-sync", &images.overlay_sync, "OVERLAY_SYNC"),
+        ("nginx", &images.nginx, "NGINX"),
     ] {
         let status = Command::new("docker")
             .args(["image", "inspect", image])
@@ -523,7 +546,21 @@ fn deploy_setup(context: &DemoContext) -> Result<(), Box<dyn std::error::Error>>
     eprintln!("[SETUP {}/{}] Seeding SWIM cross-cluster membership", next(), total);
     seed_swim_membership()?;
 
-    // Phase 7: Deploy llm-d simulators and EPP
+    // Phase 7: Install metrics TLS secrets (before EPP deployment needs them)
+    eprintln!();
+    eprintln!(
+        "[SETUP {}/{}] Installing metrics TLS secrets for EPP sidecar",
+        next(),
+        total
+    );
+    let metrics_certs_dir = Path::new(CERTS_DIR);
+    for cluster in CLUSTERS {
+        let ctx = kind_context(cluster);
+        install_metrics_tls_secrets(&ctx, metrics_certs_dir)?;
+        eprintln!("  [OK] {cluster}: metrics TLS secrets installed");
+    }
+
+    // Phase 8: Deploy llm-d simulators and EPP
     eprintln!();
     eprintln!("[SETUP {}/{}] Deploying llm-d simulators and EPP", next(), total);
     for cluster in CLUSTERS {
@@ -532,7 +569,7 @@ fn deploy_setup(context: &DemoContext) -> Result<(), Box<dyn std::error::Error>>
         eprintln!("  [OK] {cluster}: sim-1, sim-2, and EPP running");
     }
 
-    // Phase 8: Install provider trust and credentials
+    // Phase 9: Install provider trust and credentials
     eprintln!();
     eprintln!("[SETUP {}/{}] Installing provider trust and credentials", next(), total);
     install_provider_trust()?;
@@ -600,10 +637,11 @@ fn run_proof_scenarios(context: &DemoContext, mode: DemoMode) -> BTreeMap<String
 
         // Proof 4: Recovery — poll until ramp resets
         results.insert("recovery".to_owned(), proof_recovery(context));
-
-        // Proof 5: Zero restarts — no container restarts during the proof sequence
-        results.insert("zero_restarts".to_owned(), proof_zero_restarts());
     }
+
+    // TLS proof stages — always run (these are the core mTLS acceptance criteria)
+    let tls_results = run_tls_proof_stages();
+    results.extend(tls_results);
 
     results
 }
@@ -618,10 +656,7 @@ fn proof_provenance() -> ProofResult {
         let mut metrics_ok = false;
         let deadline = Instant::now() + Duration::from_secs(30);
         while Instant::now() < deadline {
-            if let Ok(metrics_text) = kubectl_exec_curl(
-                &ctx,
-                "http://llmd-epp-metrics.grid-system.svc.cluster.local:9090/metrics",
-            ) {
+            if let Ok(metrics_text) = kubectl_exec_epp_metrics(cluster) {
                 let has_kv = metrics_text.contains("llm_d_router_epp_average_kv_cache_utilization");
                 let has_queue = metrics_text.contains("llm_d_router_epp_average_queue_size");
                 let has_ready = metrics_text.contains("llm_d_router_epp_ready_endpoints");
@@ -913,63 +948,6 @@ fn proof_recovery(_context: &DemoContext) -> ProofResult {
     }
 }
 
-/// Proof 5: Verify that no consumer-gateway containers restarted during the proofs.
-fn proof_zero_restarts() -> ProofResult {
-    let mut observations = Vec::new();
-    let mut success = true;
-
-    for cluster in CLUSTERS {
-        let ctx = kind_context(cluster);
-        let output = Command::new("kubectl")
-            .args([
-                "--context",
-                &ctx,
-                "-n",
-                GRID_SYSTEM_NS,
-                "get",
-                "pods",
-                "-l",
-                "app.kubernetes.io/name=praxis-gateway",
-                "-o",
-                "jsonpath={range .items[*]}{.metadata.name}{\" \"}{range .status.containerStatuses[*]}{.name}={.restartCount}{\" \"}{end}{\"\\n\"}{end}",
-            ])
-            .output();
-
-        match output {
-            Ok(o) => {
-                let text = String::from_utf8_lossy(&o.stdout);
-                let mut any_nonzero = false;
-                for line in text.lines().filter(|l| !l.is_empty()) {
-                    let parts: Vec<&str> = line.split_whitespace().collect();
-                    let pod_name = parts.first().unwrap_or(&"unknown");
-                    for part in parts.iter().skip(1) {
-                        if let Some((container, count_str)) = part.split_once('=') {
-                            let count: u32 = count_str.parse().unwrap_or(0);
-                            observations.push(format!("{cluster}/{pod_name}: {container} restarts={count}"));
-                            if count > 0 {
-                                any_nonzero = true;
-                            }
-                        }
-                    }
-                }
-                if any_nonzero {
-                    success = false;
-                }
-            },
-            Err(e) => {
-                observations.push(format!("{cluster}: kubectl failed: {e}"));
-                success = false;
-            },
-        }
-    }
-
-    ProofResult {
-        success,
-        description: "Zero restarts: no container restarts during proof sequence".to_owned(),
-        observations,
-    }
-}
-
 // ---------------------------------------------------------------------------
 // EPP metrics helpers
 // ---------------------------------------------------------------------------
@@ -982,14 +960,12 @@ struct EppMetrics {
     kv_cache: f64,
 }
 
-/// Scrape EPP metrics from a cluster's EPP service.
+/// Scrape EPP metrics by exec-ing into the nginx sidecar.
+///
+/// The metrics Service requires mTLS, so demo probes access the EPP's
+/// plain HTTP port (9090) via localhost inside the pod.
 fn scrape_epp_metrics(cluster: &str) -> EppMetrics {
-    let ctx = kind_context(cluster);
-    let text = kubectl_exec_curl(
-        &ctx,
-        "http://llmd-epp-metrics.grid-system.svc.cluster.local:9090/metrics",
-    )
-    .unwrap_or_default();
+    let text = kubectl_exec_epp_metrics(cluster).unwrap_or_default();
 
     EppMetrics {
         queue_size: extract_prom_value(&text, "llm_d_router_epp_average_queue_size").unwrap_or(0.0),
@@ -1175,9 +1151,34 @@ fn send_inference_request(kube_context: &str, model: &str) -> Result<InferenceRe
     })
 }
 
-/// Run a curl command inside a temporary pod in the given cluster.
-fn kubectl_exec_curl(kube_context: &str, url: &str) -> Result<String, Box<dyn std::error::Error>> {
-    kubectl_exec_curl_raw(kube_context, &format!("curl -sf {url}"))
+/// Exec into the nginx sidecar to fetch EPP metrics via localhost.
+fn kubectl_exec_epp_metrics(cluster: &str) -> Result<String, Box<dyn std::error::Error>> {
+    let ctx = kind_context(cluster);
+    let output = Command::new("kubectl")
+        .args([
+            "--context",
+            &ctx,
+            "-n",
+            GRID_SYSTEM_NS,
+            "exec",
+            "deploy/llmd-epp",
+            "-c",
+            "metrics-tls-proxy",
+            "--",
+            "wget",
+            "-qO-",
+            "--timeout=5",
+            "http://127.0.0.1:9090/metrics",
+        ])
+        .output()?;
+    if !output.status.success() {
+        return Err(format!(
+            "kubectl exec metrics failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        )
+        .into());
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
 }
 
 /// Run an arbitrary command via `kubectl run` in a temporary pod.
@@ -1360,15 +1361,21 @@ fn seed_swim_membership() -> Result<(), Box<dyn std::error::Error>> {
 // Certificate and trust staging
 // ---------------------------------------------------------------------------
 
-/// Generate TLS certificates for both clusters.
+/// Generate TLS certificates for both clusters and metrics TLS.
 fn stage_certificates() -> Result<(), Box<dyn std::error::Error>> {
     let clusters: Vec<String> = CLUSTERS.iter().map(|s| (*s).to_owned()).collect();
     certs::generate_all(&clusters)?;
     eprintln!("  [OK] TLS certificates generated for pool-a, pool-b");
+
+    certs::generate_metrics_certs(METRICS_CA_CN, METRICS_SERVER_DNS)?;
+    eprintln!("  [OK] Metrics TLS certificates generated (separate CA)");
     Ok(())
 }
 
 /// Install provider trust secrets into both clusters.
+///
+/// Metrics TLS secrets are installed earlier in phase 7 (before EPP
+/// deployment) since the nginx sidecar mounts them at startup.
 fn install_provider_trust() -> Result<(), Box<dyn std::error::Error>> {
     let certs_dir = Path::new(CERTS_DIR);
 
@@ -1383,6 +1390,112 @@ fn install_provider_trust() -> Result<(), Box<dyn std::error::Error>> {
         eprintln!("  [OK] {cluster}: TLS secrets and credentials installed");
     }
     Ok(())
+}
+
+/// Install the three metrics TLS secrets (CA, server, client) into a cluster.
+fn install_metrics_tls_secrets(context: &str, certs_dir: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    apply_metrics_ca_secret(context, certs_dir)?;
+    apply_metrics_server_secret(context, certs_dir)?;
+    apply_metrics_client_secret(context, certs_dir)?;
+    Ok(())
+}
+
+/// Create the metrics CA Secret (holds only ca.crt).
+fn apply_metrics_ca_secret(context: &str, certs_dir: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    let output = Command::new("kubectl")
+        .args([
+            "--context",
+            context,
+            "-n",
+            GRID_SYSTEM_NS,
+            "create",
+            "secret",
+            "generic",
+            METRICS_CA_SECRET,
+            &format!("--from-file=ca.crt={}", certs_dir.join("metrics-ca.pem").display()),
+            "--dry-run=client",
+            "-o",
+            "yaml",
+        ])
+        .output()?;
+    if !output.status.success() {
+        return Err(format!(
+            "failed to render Secret/{METRICS_CA_SECRET}: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        )
+        .into());
+    }
+    kubectl::apply_manifest(context, &String::from_utf8(output.stdout)?)
+}
+
+/// Create the metrics server TLS Secret (tls.crt + tls.key for nginx).
+fn apply_metrics_server_secret(context: &str, certs_dir: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    let output = Command::new("kubectl")
+        .args([
+            "--context",
+            context,
+            "-n",
+            GRID_SYSTEM_NS,
+            "create",
+            "secret",
+            "generic",
+            METRICS_SERVER_TLS_SECRET,
+            &format!(
+                "--from-file=tls.crt={}",
+                certs_dir.join("metrics-server-cert.pem").display()
+            ),
+            &format!(
+                "--from-file=tls.key={}",
+                certs_dir.join("metrics-server-key.pem").display()
+            ),
+            "--dry-run=client",
+            "-o",
+            "yaml",
+        ])
+        .output()?;
+    if !output.status.success() {
+        return Err(format!(
+            "failed to render Secret/{METRICS_SERVER_TLS_SECRET}: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        )
+        .into());
+    }
+    kubectl::apply_manifest(context, &String::from_utf8(output.stdout)?)
+}
+
+/// Create the metrics client TLS Secret (tls.crt + tls.key for the operator).
+fn apply_metrics_client_secret(context: &str, certs_dir: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    let output = Command::new("kubectl")
+        .args([
+            "--context",
+            context,
+            "-n",
+            GRID_SYSTEM_NS,
+            "create",
+            "secret",
+            "generic",
+            METRICS_CLIENT_TLS_SECRET,
+            &format!(
+                "--from-file=tls.crt={}",
+                certs_dir.join("metrics-client-cert.pem").display()
+            ),
+            &format!(
+                "--from-file=tls.key={}",
+                certs_dir.join("metrics-client-key.pem").display()
+            ),
+            "--dry-run=client",
+            "-o",
+            "yaml",
+        ])
+        .output()?;
+    if !output.status.success() {
+        return Err(format!(
+            "failed to render Secret/{METRICS_CLIENT_TLS_SECRET}: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        )
+        .into());
+    }
+    kubectl::apply_manifest(context, &String::from_utf8(output.stdout)?)
 }
 
 /// Create a TLS secret from the generated cert, key, and CA files.
@@ -1497,6 +1610,7 @@ fn load_images_into_clusters(_context: &DemoContext) -> Result<(), Box<dyn std::
         "praxis-ai:llmd-pool-metrics-demo",
         "llm-d-epp:llmd-pool-metrics-demo",
         "llm-d-inference-sim:llmd-pool-metrics-demo",
+        "nginx:metrics-proxy-demo",
     ];
     for cluster in CLUSTERS {
         let kind_name = format!("grid-llmd-pm-{cluster}");
@@ -1522,6 +1636,7 @@ fn collect_image_evidence(resolved: &ResolvedImages) -> Result<BTreeMap<String, 
         ("epp", &resolved.epp),
         ("sim", &resolved.sim),
         ("overlay-sync", &resolved.overlay_sync),
+        ("nginx", &resolved.nginx),
     ] {
         let digest = Command::new("docker")
             .args(["inspect", "--format", "{{.Id}}", tag])
@@ -1730,6 +1845,1022 @@ fn resolve_evidence_dir(
         .clone()
         .unwrap_or_else(|| forge_config.parent().unwrap_or_else(|| Path::new(".")).join("evidence"));
     Ok(base.join(run_id))
+}
+
+// ---------------------------------------------------------------------------
+// TLS proof stages
+// ---------------------------------------------------------------------------
+
+/// Timeout for a single TLS state transition.
+const TLS_TRANSITION_TIMEOUT: Duration = Duration::from_secs(90);
+
+/// Interval between overlay checks during TLS proofs.
+const TLS_POLL_INTERVAL: Duration = Duration::from_secs(3);
+
+/// Value of `staleMetricsSeconds` in the demo InferenceProvider.
+const STALE_METRICS_TTL_SECS: u64 = 20;
+
+/// Check whether a provider is observable in the overlay.
+///
+/// Returns `true` when a candidate containing `provider_suffix` is present
+/// with a score above zero — meaning the operator successfully scraped its
+/// metrics via TLS. When scraping fails, `UNOBSERVABLE_METRICS` sets
+/// `healthy: false`, which results in a zero score.
+fn is_provider_observable(cluster: &str, provider_suffix: &str) -> bool {
+    let candidates = read_overlay_candidates(cluster);
+    candidates
+        .iter()
+        .any(|c| c.cluster.contains(provider_suffix) && c.score > 0.0)
+}
+
+/// Wait until a provider becomes observable in the overlay.
+fn wait_for_observable(cluster: &str, provider_suffix: &str, timeout: Duration) -> bool {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        trigger_gridnetwork_reconcile(cluster);
+        if is_provider_observable(cluster, provider_suffix) {
+            return true;
+        }
+        std::thread::sleep(TLS_POLL_INTERVAL);
+    }
+    false
+}
+
+/// Wait until a provider becomes unobservable in the overlay.
+fn wait_for_unobservable(cluster: &str, provider_suffix: &str, timeout: Duration) -> bool {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        trigger_gridnetwork_reconcile(cluster);
+        if !is_provider_observable(cluster, provider_suffix) {
+            return true;
+        }
+        std::thread::sleep(TLS_POLL_INTERVAL);
+    }
+    false
+}
+
+/// Delete a Kubernetes Secret.
+fn delete_secret(context: &str, name: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let status = Command::new("kubectl")
+        .args([
+            "--context",
+            context,
+            "-n",
+            GRID_SYSTEM_NS,
+            "delete",
+            "secret",
+            name,
+            "--ignore-not-found",
+        ])
+        .status()?;
+    if !status.success() {
+        return Err(format!("failed to delete Secret/{name}").into());
+    }
+    Ok(())
+}
+
+/// Rollout-restart a Deployment and wait for it to become available.
+fn rollout_restart(context: &str, deployment: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let status = Command::new("kubectl")
+        .args([
+            "--context",
+            context,
+            "-n",
+            GRID_SYSTEM_NS,
+            "rollout",
+            "restart",
+            &format!("deployment/{deployment}"),
+        ])
+        .status()?;
+    if !status.success() {
+        return Err(format!("failed to rollout restart {deployment}").into());
+    }
+    let wait = Command::new("kubectl")
+        .args([
+            "--context",
+            context,
+            "-n",
+            GRID_SYSTEM_NS,
+            "rollout",
+            "status",
+            &format!("deployment/{deployment}"),
+            "--timeout=120s",
+        ])
+        .status()?;
+    if !wait.success() {
+        return Err(format!("{deployment} rollout timed out").into());
+    }
+    Ok(())
+}
+
+/// Snapshot of a pod's identity and restart counts.
+struct PodSnapshot {
+    /// Pod name.
+    name: String,
+    /// Pod UID.
+    uid: String,
+    /// Container restart counts: `(container_name, restart_count)`.
+    restarts: Vec<(String, u32)>,
+}
+
+/// Capture pod snapshots for a given label selector in one cluster.
+fn capture_pod_snapshots(cluster: &str, label: &str) -> Vec<PodSnapshot> {
+    let ctx = kind_context(cluster);
+    let output = Command::new("kubectl")
+        .args([
+            "--context",
+            &ctx,
+            "-n",
+            GRID_SYSTEM_NS,
+            "get",
+            "pods",
+            "-l",
+            label,
+            "-o",
+            "jsonpath={range .items[*]}{.metadata.name}|{.metadata.uid}|{range .status.containerStatuses[*]}{.name}={.restartCount},{end}{\"\\n\"}{end}",
+        ])
+        .output();
+    let Ok(o) = output else { return Vec::new() };
+    let text = String::from_utf8_lossy(&o.stdout);
+    text.lines()
+        .filter(|l| !l.is_empty())
+        .filter_map(|line| {
+            let mut parts = line.splitn(3, '|');
+            let name = parts.next()?.to_owned();
+            let uid = parts.next()?.to_owned();
+            let containers = parts.next().unwrap_or("");
+            let restarts: Vec<(String, u32)> = containers
+                .split(',')
+                .filter(|s| !s.is_empty())
+                .filter_map(|entry| {
+                    let (cname, count_str) = entry.split_once('=')?;
+                    Some((cname.to_owned(), count_str.parse().unwrap_or(0)))
+                })
+                .collect();
+            Some(PodSnapshot { name, uid, restarts })
+        })
+        .collect()
+}
+
+/// Snapshot of all workload pods relevant for restart accounting.
+struct RestartSnapshot {
+    /// Grid operator pods.
+    operator: Vec<PodSnapshot>,
+    /// EPP + metrics proxy pods.
+    epp: Vec<PodSnapshot>,
+    /// Gateway and overlay-sync pods.
+    gateway: Vec<PodSnapshot>,
+}
+
+/// Capture restart snapshots for all relevant workloads on one cluster.
+fn capture_restart_snapshot(cluster: &str) -> RestartSnapshot {
+    RestartSnapshot {
+        operator: capture_pod_snapshots(cluster, "app.kubernetes.io/name=grid-operator"),
+        epp: capture_pod_snapshots(cluster, "app.kubernetes.io/name=llmd-epp"),
+        gateway: capture_pod_snapshots(cluster, "app.kubernetes.io/name=praxis-gateway"),
+    }
+}
+
+/// Compare restart snapshots and emit observations.
+///
+/// Returns `(success, observations)`.
+fn compare_restart_snapshots(
+    cluster: &str,
+    before: &RestartSnapshot,
+    after: &RestartSnapshot,
+    server_rotation_performed: bool,
+) -> (bool, Vec<String>) {
+    let mut observations = Vec::new();
+    let mut success = true;
+
+    // Operator: pod identity must be unchanged, zero restarts
+    for bp in &before.operator {
+        let matching_after = after.operator.iter().find(|ap| ap.uid == bp.uid);
+        if let Some(ap) = matching_after {
+            let total: u32 = ap.restarts.iter().map(|(_, c)| c).sum();
+            observations.push(format!(
+                "{cluster}/operator/{}: uid unchanged, restart_count={total}",
+                ap.name
+            ));
+            if total > 0 {
+                observations.push(format!("{cluster}: operator restarted unexpectedly"));
+                success = false;
+            }
+        } else {
+            observations.push(format!(
+                "{cluster}: operator pod {} (uid={}) replaced — unexpected restart",
+                bp.name, bp.uid
+            ));
+            success = false;
+        }
+    }
+
+    // EPP: if server rotation was performed, expect a new pod (rollout restart)
+    if server_rotation_performed {
+        let before_uids: Vec<&str> = before.epp.iter().map(|p| p.uid.as_str()).collect();
+        let new_pods: Vec<&PodSnapshot> = after
+            .epp
+            .iter()
+            .filter(|p| !before_uids.contains(&p.uid.as_str()))
+            .collect();
+        if new_pods.is_empty() {
+            observations.push(format!(
+                "{cluster}: EPP pod was not replaced after server rotation — expected rollout restart"
+            ));
+        } else {
+            for np in &new_pods {
+                let total: u32 = np.restarts.iter().map(|(_, c)| c).sum();
+                observations.push(format!(
+                    "{cluster}/epp/{}: new pod after server cert rotation (expected), restart_count={total}",
+                    np.name
+                ));
+            }
+        }
+    } else {
+        for bp in &before.epp {
+            let matching_after = after.epp.iter().find(|ap| ap.uid == bp.uid);
+            if let Some(ap) = matching_after {
+                let total: u32 = ap.restarts.iter().map(|(_, c)| c).sum();
+                observations.push(format!(
+                    "{cluster}/epp/{}: uid unchanged, restart_count={total}",
+                    ap.name
+                ));
+                if total > 0 {
+                    observations.push(format!("{cluster}: EPP restarted unexpectedly"));
+                    success = false;
+                }
+            }
+        }
+    }
+
+    // Gateway: no restarts expected
+    for bp in &before.gateway {
+        let matching_after = after.gateway.iter().find(|ap| ap.uid == bp.uid);
+        if let Some(ap) = matching_after {
+            for (cname, count) in &ap.restarts {
+                observations.push(format!("{cluster}/gateway/{}: {cname} restarts={count}", ap.name));
+                if *count > 0 {
+                    success = false;
+                }
+            }
+        } else {
+            observations.push(format!("{cluster}: gateway pod {} replaced unexpectedly", bp.name));
+            success = false;
+        }
+    }
+
+    (success, observations)
+}
+
+/// Prove that TLS proof stages did not cause unexpected restarts.
+///
+/// Compares before/after pod snapshots across operator, EPP, and gateway
+/// workloads. The intentional EPP rollout restart from server certificate
+/// rotation is documented and excluded from the failure check — but only
+/// on the cluster where rotation was actually performed (pool-a).
+fn proof_restart_accounting(
+    before: &HashMap<String, RestartSnapshot>,
+    after: &HashMap<String, RestartSnapshot>,
+    rotation_cluster: Option<&str>,
+) -> ProofResult {
+    let mut observations = Vec::new();
+    let mut success = true;
+
+    for cluster in CLUSTERS {
+        let cluster_had_rotation = rotation_cluster.is_some_and(|c| c == *cluster);
+        if let (Some(b), Some(a)) = (before.get(*cluster), after.get(*cluster)) {
+            let (ok, obs) = compare_restart_snapshots(cluster, b, a, cluster_had_rotation);
+            for o in &obs {
+                eprintln!("    {o}");
+            }
+            observations.extend(obs);
+            if !ok {
+                success = false;
+            }
+        } else {
+            let msg = format!("{cluster}: snapshot missing");
+            eprintln!("    {msg}");
+            observations.push(msg);
+            success = false;
+        }
+    }
+
+    if let Some(rc) = rotation_cluster {
+        let msg = format!(
+            "server rotation (stage 8) on {rc}: EPP rollout restart is expected — nginx does not reload TLS in-place"
+        );
+        eprintln!("    {msg}");
+        observations.push(msg);
+    }
+
+    ProofResult {
+        success,
+        description: "Restart accounting: operator/gateway zero restarts, EPP restart only from server rotation"
+            .to_owned(),
+        observations,
+    }
+}
+
+/// Run all TLS proof stages in sequence.
+///
+/// Returns the proof results keyed by stage name. Stages build on each
+/// other (each manipulates Secrets, so ordering matters). Captures
+/// before/after restart snapshots and includes restart accounting.
+fn run_tls_proof_stages() -> BTreeMap<String, ProofResult> {
+    let mut results = BTreeMap::new();
+
+    eprintln!();
+    eprintln!("{OUTPUT_RULE}");
+    eprintln!("TLS PROOF STAGES");
+    eprintln!("{OUTPUT_RULE}");
+
+    // Capture restart snapshots before TLS stages
+    let before_snapshots: HashMap<String, RestartSnapshot> = CLUSTERS
+        .iter()
+        .map(|c| ((*c).to_owned(), capture_restart_snapshot(c)))
+        .collect();
+
+    // Stage 1: Baseline mTLS — verify operator scrapes through TLS
+    eprintln!();
+    eprintln!("  [TLS 1/9] Baseline mTLS");
+    results.insert("tls_01_baseline".to_owned(), proof_tls_baseline());
+
+    // Stage 2: Handshake rejection — TLS proxy rejects connection without client cert
+    eprintln!();
+    eprintln!("  [TLS 2/9] Handshake rejection");
+    results.insert("tls_02_handshake_rejection".to_owned(), proof_tls_handshake_rejection());
+
+    // Stage 3: Missing client identity — delete client cert Secret
+    eprintln!();
+    eprintln!("  [TLS 3/9] Missing client identity");
+    results.insert("tls_03_missing_client".to_owned(), proof_tls_missing_client());
+
+    // Stage 4: Wrong CA — replace CA Secret with untrusted CA
+    eprintln!();
+    eprintln!("  [TLS 4/9] Wrong CA");
+    results.insert("tls_04_wrong_ca".to_owned(), proof_tls_wrong_ca());
+
+    // Stage 5: Restore valid mTLS — recreate correct Secrets
+    eprintln!();
+    eprintln!("  [TLS 5/9] Restore valid mTLS");
+    results.insert("tls_05_restore".to_owned(), proof_tls_restore());
+
+    // Stage 6: Stale-cache behavior — independent TTL verification
+    eprintln!();
+    eprintln!("  [TLS 6/9] Stale-cache TTL");
+    results.insert("tls_06_stale_cache".to_owned(), proof_tls_stale_cache());
+
+    // Stage 7: Client Secret rotation — new cert, same CA
+    eprintln!();
+    eprintln!("  [TLS 7/9] Client Secret rotation");
+    results.insert("tls_07_client_rotation".to_owned(), proof_tls_client_rotation());
+
+    // Stage 8: Server cert/CA rotation — new server cert + nginx restart
+    eprintln!();
+    eprintln!("  [TLS 8/9] Server cert rotation");
+    let server_rotation = proof_tls_server_rotation();
+    let rotation_cluster = server_rotation.success.then_some("pool-a");
+    results.insert("tls_08_server_rotation".to_owned(), server_rotation);
+
+    // Stage 9: Existing routing behavior — verify routing after TLS manipulations
+    eprintln!();
+    eprintln!("  [TLS 9/9] Existing routing behavior");
+    results.insert("tls_09_routing".to_owned(), proof_tls_routing());
+
+    // Restart accounting — compare before/after snapshots
+    eprintln!();
+    eprintln!("  Restart accounting");
+    let after_snapshots: HashMap<String, RestartSnapshot> = CLUSTERS
+        .iter()
+        .map(|c| ((*c).to_owned(), capture_restart_snapshot(c)))
+        .collect();
+    results.insert(
+        "restart_accounting".to_owned(),
+        proof_restart_accounting(&before_snapshots, &after_snapshots, rotation_cluster),
+    );
+
+    results
+}
+
+/// TLS Stage 1: Verify baseline mTLS scraping produces valid overlay scores.
+fn proof_tls_baseline() -> ProofResult {
+    let mut observations = Vec::new();
+
+    for cluster in CLUSTERS {
+        if is_provider_observable(cluster, cluster) {
+            let candidates = read_overlay_candidates(cluster);
+            let score = overlay_score_for_cluster(&candidates, cluster);
+            observations.push(format!("{cluster}: observable, score={score:.2} (mTLS working)"));
+        } else {
+            observations.push(format!("{cluster}: NOT observable — mTLS scraping may have failed"));
+            return ProofResult {
+                success: false,
+                description: "Baseline mTLS: operator scrapes metrics through TLS".to_owned(),
+                observations,
+            };
+        }
+    }
+
+    ProofResult {
+        success: true,
+        description: "Baseline mTLS: operator scrapes metrics through TLS".to_owned(),
+        observations,
+    }
+}
+
+/// TLS Stage 2: Prove the TLS proxy rejects connections without a client certificate.
+///
+/// Connects to the metrics endpoint from inside the cluster without presenting
+/// a client identity. The nginx proxy has `ssl_verify_client on`, so it must
+/// reject the handshake or return an error. This tests the server-side mTLS
+/// enforcement path directly (independent of Secret-watch behavior).
+fn proof_tls_handshake_rejection() -> ProofResult {
+    let mut observations = Vec::new();
+    let cluster = "pool-a";
+    let ctx = kind_context(cluster);
+
+    // Connect to the metrics TLS endpoint without a client certificate.
+    // We use `wget` inside the nginx sidecar — it has network access to
+    // localhost:9443 but does not present a client cert.
+    let output = Command::new("kubectl")
+        .args([
+            "--context",
+            &ctx,
+            "-n",
+            GRID_SYSTEM_NS,
+            "exec",
+            "deployment/llmd-epp",
+            "-c",
+            "metrics-tls-proxy",
+            "--",
+            "wget",
+            "-q",
+            "--timeout=5",
+            "-O",
+            "/dev/null",
+            "https://localhost:9443/metrics",
+        ])
+        .output();
+
+    match output {
+        Ok(o) => {
+            if o.status.success() {
+                observations.push(format!(
+                    "{cluster}: metrics endpoint accepted connection WITHOUT client cert — mTLS NOT enforced"
+                ));
+                return ProofResult {
+                    success: false,
+                    description: "Handshake rejection: TLS proxy requires client certificate".to_owned(),
+                    observations,
+                };
+            }
+            let stderr = String::from_utf8_lossy(&o.stderr);
+            let category = if stderr.contains("SSL") || stderr.contains("ssl") || stderr.contains("handshake") {
+                "MetricsTlsHandshakeFailed"
+            } else if stderr.contains("400") || stderr.contains("certificate") {
+                "MetricsTlsClientCertRequired"
+            } else {
+                "MetricsTlsConnectionRejected"
+            };
+            observations.push(format!(
+                "{cluster}: connection without client cert rejected (category={category})"
+            ));
+        },
+        Err(e) => {
+            observations.push(format!("{cluster}: kubectl exec failed: {e}"));
+            return ProofResult {
+                success: false,
+                description: "Handshake rejection: TLS proxy requires client certificate".to_owned(),
+                observations,
+            };
+        },
+    }
+
+    ProofResult {
+        success: true,
+        description: "Handshake rejection: TLS proxy requires client certificate".to_owned(),
+        observations,
+    }
+}
+
+/// TLS Stage 3: Delete client cert Secret → provider becomes unobservable.
+fn proof_tls_missing_client() -> ProofResult {
+    let mut observations = Vec::new();
+    let cluster = "pool-a";
+    let ctx = kind_context(cluster);
+
+    if let Err(e) = delete_secret(&ctx, METRICS_CLIENT_TLS_SECRET) {
+        observations.push(format!("failed to delete {METRICS_CLIENT_TLS_SECRET}: {e}"));
+        return ProofResult {
+            success: false,
+            description: "Missing client identity: scrape fails without client cert".to_owned(),
+            observations,
+        };
+    }
+    observations.push(format!("deleted Secret/{METRICS_CLIENT_TLS_SECRET} from {cluster}"));
+
+    let became_unobservable = wait_for_unobservable(cluster, cluster, TLS_TRANSITION_TIMEOUT);
+    if became_unobservable {
+        observations.push(format!(
+            "{cluster}: provider became unobservable after client cert removal (Secret-watch fail-closed)"
+        ));
+    } else {
+        observations.push(format!(
+            "{cluster}: provider still observable after client cert removal — fail-closed NOT working"
+        ));
+        return ProofResult {
+            success: false,
+            description: "Missing client identity: scrape fails without client cert".to_owned(),
+            observations,
+        };
+    }
+
+    ProofResult {
+        success: true,
+        description: "Missing client identity: scrape fails without client cert".to_owned(),
+        observations,
+    }
+}
+
+/// TLS Stage 3: Replace CA Secret with wrong CA → scrape fails.
+fn proof_tls_wrong_ca() -> ProofResult {
+    let mut observations = Vec::new();
+    let cluster = "pool-a";
+    let ctx = kind_context(cluster);
+    let certs_dir = Path::new(CERTS_DIR);
+
+    // First restore client secret (deleted in stage 2) so only CA is wrong
+    if let Err(e) = apply_metrics_client_secret(&ctx, certs_dir) {
+        observations.push(format!("failed to restore client secret: {e}"));
+    }
+
+    // Generate a wrong CA and replace the Secret
+    if let Err(e) = certs::generate_wrong_metrics_ca() {
+        observations.push(format!("failed to generate wrong CA: {e}"));
+        return ProofResult {
+            success: false,
+            description: "Wrong CA: scrape fails with untrusted CA".to_owned(),
+            observations,
+        };
+    }
+
+    let wrong_ca_path = certs_dir.join("metrics-wrong-ca.pem");
+    let result = Command::new("kubectl")
+        .args([
+            "--context",
+            &ctx,
+            "-n",
+            GRID_SYSTEM_NS,
+            "create",
+            "secret",
+            "generic",
+            METRICS_CA_SECRET,
+            &format!("--from-file=ca.crt={}", wrong_ca_path.display()),
+            "--dry-run=client",
+            "-o",
+            "yaml",
+        ])
+        .output();
+    match result {
+        Ok(output) if output.status.success() => {
+            if let Err(e) = kubectl::apply_manifest(&ctx, &String::from_utf8_lossy(&output.stdout)) {
+                observations.push(format!("failed to apply wrong CA secret: {e}"));
+                return ProofResult {
+                    success: false,
+                    description: "Wrong CA: scrape fails with untrusted CA".to_owned(),
+                    observations,
+                };
+            }
+        },
+        _ => {
+            observations.push("failed to render wrong CA secret".to_owned());
+            return ProofResult {
+                success: false,
+                description: "Wrong CA: scrape fails with untrusted CA".to_owned(),
+                observations,
+            };
+        },
+    }
+    observations.push(format!(
+        "replaced Secret/{METRICS_CA_SECRET} with wrong CA on {cluster}"
+    ));
+
+    let became_unobservable = wait_for_unobservable(cluster, cluster, TLS_TRANSITION_TIMEOUT);
+    if became_unobservable {
+        observations.push(format!(
+            "{cluster}: provider unobservable with wrong CA (server cert rejected)"
+        ));
+    } else {
+        observations.push(format!(
+            "{cluster}: provider still observable with wrong CA — CA validation NOT working"
+        ));
+        return ProofResult {
+            success: false,
+            description: "Wrong CA: scrape fails with untrusted CA".to_owned(),
+            observations,
+        };
+    }
+
+    ProofResult {
+        success: true,
+        description: "Wrong CA: scrape fails with untrusted CA".to_owned(),
+        observations,
+    }
+}
+
+/// TLS Stage 4: Restore correct Secrets → provider recovers.
+fn proof_tls_restore() -> ProofResult {
+    let mut observations = Vec::new();
+    let cluster = "pool-a";
+    let ctx = kind_context(cluster);
+    let certs_dir = Path::new(CERTS_DIR);
+
+    if let Err(e) = apply_metrics_ca_secret(&ctx, certs_dir) {
+        observations.push(format!("failed to restore CA secret: {e}"));
+        return ProofResult {
+            success: false,
+            description: "Restore: provider recovers with correct Secrets".to_owned(),
+            observations,
+        };
+    }
+    if let Err(e) = apply_metrics_client_secret(&ctx, certs_dir) {
+        observations.push(format!("failed to restore client secret: {e}"));
+        return ProofResult {
+            success: false,
+            description: "Restore: provider recovers with correct Secrets".to_owned(),
+            observations,
+        };
+    }
+    observations.push(format!(
+        "restored correct {METRICS_CA_SECRET} and {METRICS_CLIENT_TLS_SECRET} on {cluster}"
+    ));
+
+    let recovered = wait_for_observable(cluster, cluster, TLS_TRANSITION_TIMEOUT);
+    if recovered {
+        let candidates = read_overlay_candidates(cluster);
+        let score = overlay_score_for_cluster(&candidates, cluster);
+        observations.push(format!("{cluster}: provider recovered, score={score:.2}"));
+    } else {
+        observations.push(format!("{cluster}: provider did not recover within timeout"));
+        return ProofResult {
+            success: false,
+            description: "Restore: provider recovers with correct Secrets".to_owned(),
+            observations,
+        };
+    }
+
+    ProofResult {
+        success: true,
+        description: "Restore: provider recovers with correct Secrets".to_owned(),
+        observations,
+    }
+}
+
+/// TLS Stage 5: Rotate client cert (new cert, same CA) → scrape continues.
+fn proof_tls_client_rotation() -> ProofResult {
+    let mut observations = Vec::new();
+    let cluster = "pool-a";
+    let ctx = kind_context(cluster);
+    let certs_dir = Path::new(CERTS_DIR);
+
+    if !is_provider_observable(cluster, cluster) {
+        observations.push("precondition failed: provider not observable at entry".to_owned());
+        return ProofResult {
+            success: false,
+            description: "Client rotation: new cert from same CA works".to_owned(),
+            observations,
+        };
+    }
+    observations.push("precondition: provider observable at entry".to_owned());
+
+    if let Err(e) = certs::rotate_metrics_client_cert(METRICS_CA_CN) {
+        observations.push(format!("failed to generate rotated client cert: {e}"));
+        return ProofResult {
+            success: false,
+            description: "Client rotation: new cert from same CA works".to_owned(),
+            observations,
+        };
+    }
+    observations.push("generated new client cert signed by same metrics CA".to_owned());
+
+    if let Err(e) = apply_metrics_client_secret(&ctx, certs_dir) {
+        observations.push(format!("failed to apply rotated client secret: {e}"));
+        return ProofResult {
+            success: false,
+            description: "Client rotation: new cert from same CA works".to_owned(),
+            observations,
+        };
+    }
+    observations.push(format!("updated Secret/{METRICS_CLIENT_TLS_SECRET} with rotated cert"));
+
+    // Wait a few reconcile cycles to confirm the operator picks up the new cert
+    std::thread::sleep(Duration::from_secs(10));
+    for _ in 0..3 {
+        trigger_gridnetwork_reconcile(cluster);
+        std::thread::sleep(TLS_POLL_INTERVAL);
+    }
+
+    let still_observable = wait_for_observable(cluster, cluster, TLS_TRANSITION_TIMEOUT);
+    if still_observable {
+        let candidates = read_overlay_candidates(cluster);
+        let score = overlay_score_for_cluster(&candidates, cluster);
+        observations.push(format!(
+            "{cluster}: provider still observable after client rotation, score={score:.2}"
+        ));
+    } else {
+        observations.push(format!(
+            "{cluster}: provider became unobservable after client rotation — rotation failed"
+        ));
+        return ProofResult {
+            success: false,
+            description: "Client rotation: new cert from same CA works".to_owned(),
+            observations,
+        };
+    }
+
+    ProofResult {
+        success: true,
+        description: "Client rotation: new cert from same CA works".to_owned(),
+        observations,
+    }
+}
+
+/// TLS Stage 6: Rotate server cert + restart nginx → scrape continues.
+///
+/// **Limitation:** nginx does not reload TLS material automatically.
+/// A `rollout restart` of the EPP Deployment is required. This is
+/// documented honestly — the operator handles Secret rotation, but
+/// the metrics proxy (nginx) needs a pod restart to load new certs.
+fn proof_tls_server_rotation() -> ProofResult {
+    let mut observations = Vec::new();
+    let cluster = "pool-a";
+    let ctx = kind_context(cluster);
+    let certs_dir = Path::new(CERTS_DIR);
+
+    if !is_provider_observable(cluster, cluster) {
+        observations.push("precondition failed: provider not observable at entry".to_owned());
+        return ProofResult {
+            success: false,
+            description: "Server rotation: new cert + nginx restart works".to_owned(),
+            observations,
+        };
+    }
+    observations.push("precondition: provider observable at entry".to_owned());
+
+    if let Err(e) = certs::rotate_metrics_server_cert(METRICS_CA_CN, METRICS_SERVER_DNS) {
+        observations.push(format!("failed to generate rotated server cert: {e}"));
+        return ProofResult {
+            success: false,
+            description: "Server rotation: new cert + nginx restart works".to_owned(),
+            observations,
+        };
+    }
+    observations.push("generated new server cert signed by same metrics CA".to_owned());
+
+    if let Err(e) = apply_metrics_server_secret(&ctx, certs_dir) {
+        observations.push(format!("failed to apply rotated server secret: {e}"));
+        return ProofResult {
+            success: false,
+            description: "Server rotation: new cert + nginx restart works".to_owned(),
+            observations,
+        };
+    }
+    observations.push(format!("updated Secret/{METRICS_SERVER_TLS_SECRET} with rotated cert"));
+
+    observations.push("LIMITATION: nginx does not reload TLS in-place; rollout restart required".to_owned());
+    if let Err(e) = rollout_restart(&ctx, "llmd-epp") {
+        observations.push(format!("rollout restart failed: {e}"));
+        return ProofResult {
+            success: false,
+            description: "Server rotation: new cert + nginx restart works".to_owned(),
+            observations,
+        };
+    }
+    observations.push("rollout restart of llmd-epp completed".to_owned());
+
+    let recovered = wait_for_observable(cluster, cluster, TLS_TRANSITION_TIMEOUT);
+    if recovered {
+        let candidates = read_overlay_candidates(cluster);
+        let score = overlay_score_for_cluster(&candidates, cluster);
+        observations.push(format!(
+            "{cluster}: provider observable after server rotation, score={score:.2}"
+        ));
+    } else {
+        observations.push(format!(
+            "{cluster}: provider not observable after server rotation — rotation failed"
+        ));
+        return ProofResult {
+            success: false,
+            description: "Server rotation: new cert + nginx restart works".to_owned(),
+            observations,
+        };
+    }
+
+    ProofResult {
+        success: true,
+        description: "Server rotation: new cert + nginx restart works".to_owned(),
+        observations,
+    }
+}
+
+/// TLS Stage 6: Independent stale-cache TTL verification.
+///
+/// Proves that `staleMetricsSeconds` (set to [`STALE_METRICS_TTL_SECS`])
+/// allows the operator to serve cached metrics during a brief TLS outage,
+/// and that the cached sample expires after the TTL.
+///
+/// Sequence:
+/// 1. Record baseline score (provider must be observable).
+/// 2. Trigger a reconcile to establish a fresh metrics sample.
+/// 3. Delete the client cert Secret to break TLS.
+/// 4. Before TTL expires: assert the provider is still observable (cached).
+/// 5. After TTL expires: assert the provider becomes unobservable.
+/// 6. Restore the client cert Secret and verify recovery.
+fn proof_tls_stale_cache() -> ProofResult {
+    let mut observations = Vec::new();
+    let cluster = "pool-a";
+    let ctx = kind_context(cluster);
+    let certs_dir = Path::new(CERTS_DIR);
+
+    // 1. Precondition: provider must be observable.
+    if !is_provider_observable(cluster, cluster) {
+        observations.push("precondition failed: provider not observable at entry".to_owned());
+        return ProofResult {
+            success: false,
+            description: "Stale-cache TTL: cached metrics served before expiry, rejected after".to_owned(),
+            observations,
+        };
+    }
+    let candidates = read_overlay_candidates(cluster);
+    let baseline_score = overlay_score_for_cluster(&candidates, cluster);
+    observations.push(format!("baseline: {cluster} observable, score={baseline_score:.2}"));
+    eprintln!("    baseline: {cluster} observable, score={baseline_score:.2}");
+
+    // 2. Force a fresh scrape so the cache timestamp is recent.
+    trigger_gridnetwork_reconcile(cluster);
+    std::thread::sleep(Duration::from_secs(3));
+    let pre_break = Instant::now();
+
+    // 3. Break TLS by deleting the client cert Secret.
+    if let Err(e) = delete_secret(&ctx, METRICS_CLIENT_TLS_SECRET) {
+        observations.push(format!("failed to delete {METRICS_CLIENT_TLS_SECRET}: {e}"));
+        return ProofResult {
+            success: false,
+            description: "Stale-cache TTL: cached metrics served before expiry, rejected after".to_owned(),
+            observations,
+        };
+    }
+    let msg = format!(
+        "deleted Secret/{METRICS_CLIENT_TLS_SECRET} to break TLS (staleMetricsSeconds={STALE_METRICS_TTL_SECS})"
+    );
+    eprintln!("    {msg}");
+    observations.push(msg);
+
+    // 4. Inside-TTL check: provider should still be observable (cached metrics). Poll within the first half of the TTL
+    //    window.
+    let inside_ttl_deadline = pre_break + Duration::from_secs(STALE_METRICS_TTL_SECS / 2);
+    let mut inside_ttl_observable = false;
+    while Instant::now() < inside_ttl_deadline {
+        trigger_gridnetwork_reconcile(cluster);
+        std::thread::sleep(Duration::from_secs(2));
+        if is_provider_observable(cluster, cluster) {
+            inside_ttl_observable = true;
+            let elapsed = pre_break.elapsed().as_secs();
+            let candidates = read_overlay_candidates(cluster);
+            let score = overlay_score_for_cluster(&candidates, cluster);
+            let msg = format!(
+                "inside-TTL ({elapsed}s/{STALE_METRICS_TTL_SECS}s): {cluster} still observable, \
+                 score={score:.2} (cached metrics served)"
+            );
+            eprintln!("    {msg}");
+            observations.push(msg);
+            break;
+        }
+    }
+    if !inside_ttl_observable {
+        let elapsed = pre_break.elapsed().as_secs();
+        observations.push(format!(
+            "inside-TTL ({elapsed}s/{STALE_METRICS_TTL_SECS}s): {cluster} became unobservable \
+             before TTL expired — cached metrics not served"
+        ));
+        // Restore before returning
+        drop(apply_metrics_client_secret(&ctx, certs_dir));
+        wait_for_observable(cluster, cluster, TLS_TRANSITION_TIMEOUT);
+        return ProofResult {
+            success: false,
+            description: "Stale-cache TTL: cached metrics served before expiry, rejected after".to_owned(),
+            observations,
+        };
+    }
+
+    // 5. Post-TTL check: wait for the TTL to expire, then assert unobservable.
+    let remaining_ttl = STALE_METRICS_TTL_SECS.saturating_sub(pre_break.elapsed().as_secs());
+    if remaining_ttl > 0 {
+        std::thread::sleep(Duration::from_secs(remaining_ttl + 5));
+    }
+    // Force a reconcile so the operator evaluates the expired cache.
+    trigger_gridnetwork_reconcile(cluster);
+    std::thread::sleep(Duration::from_secs(3));
+
+    let post_ttl_unobservable =
+        !is_provider_observable(cluster, cluster) || wait_for_unobservable(cluster, cluster, Duration::from_secs(30));
+    let elapsed = pre_break.elapsed().as_secs();
+    if post_ttl_unobservable {
+        let msg = format!(
+            "post-TTL ({elapsed}s/{STALE_METRICS_TTL_SECS}s): {cluster} unobservable \
+             (cached metrics expired, UNOBSERVABLE_METRICS applied)"
+        );
+        eprintln!("    {msg}");
+        observations.push(msg);
+    } else {
+        observations.push(format!(
+            "post-TTL ({elapsed}s/{STALE_METRICS_TTL_SECS}s): {cluster} still observable \
+             after TTL expired — stale metrics not evicted"
+        ));
+        drop(apply_metrics_client_secret(&ctx, certs_dir));
+        wait_for_observable(cluster, cluster, TLS_TRANSITION_TIMEOUT);
+        return ProofResult {
+            success: false,
+            description: "Stale-cache TTL: cached metrics served before expiry, rejected after".to_owned(),
+            observations,
+        };
+    }
+
+    // 6. Restore the client cert Secret and verify recovery.
+    if let Err(e) = apply_metrics_client_secret(&ctx, certs_dir) {
+        observations.push(format!("failed to restore client secret: {e}"));
+        return ProofResult {
+            success: false,
+            description: "Stale-cache TTL: cached metrics served before expiry, rejected after".to_owned(),
+            observations,
+        };
+    }
+    let recovered = wait_for_observable(cluster, cluster, TLS_TRANSITION_TIMEOUT);
+    if recovered {
+        let candidates = read_overlay_candidates(cluster);
+        let score = overlay_score_for_cluster(&candidates, cluster);
+        let msg = format!("recovery: {cluster} observable after client cert restored, score={score:.2}");
+        eprintln!("    {msg}");
+        observations.push(msg);
+    } else {
+        observations.push(format!("{cluster}: provider did not recover after stale-cache test"));
+        return ProofResult {
+            success: false,
+            description: "Stale-cache TTL: cached metrics served before expiry, rejected after".to_owned(),
+            observations,
+        };
+    }
+
+    ProofResult {
+        success: true,
+        description: "Stale-cache TTL: cached metrics served before expiry, rejected after".to_owned(),
+        observations,
+    }
+}
+
+/// TLS Stage 8: Verify existing routing still works after TLS manipulations.
+fn proof_tls_routing() -> ProofResult {
+    let mut observations = Vec::new();
+
+    // Verify both providers are observable
+    for cluster in CLUSTERS {
+        if !is_provider_observable(cluster, cluster) && !wait_for_observable(cluster, cluster, TLS_TRANSITION_TIMEOUT) {
+            observations.push(format!("{cluster}: provider NOT observable — routing check impossible"));
+            return ProofResult {
+                success: false,
+                description: "Existing routing: inference routing works after TLS manipulations".to_owned(),
+                observations,
+            };
+        }
+        let candidates = read_overlay_candidates(cluster);
+        let score = overlay_score_for_cluster(&candidates, cluster);
+        observations.push(format!("{cluster}: observable, score={score:.2}"));
+    }
+
+    // Send an inference request and verify attribution
+    let probe_ctx = kind_context("pool-a");
+    match send_inference_request(&probe_ctx, SIM_MODEL) {
+        Ok(resp) => {
+            observations.push(format!(
+                "routing attribution: gateway={} provider={}",
+                resp.provider_gateway, resp.demo_attribution
+            ));
+        },
+        Err(e) => {
+            observations.push(format!("inference request failed: {e}"));
+            return ProofResult {
+                success: false,
+                description: "Existing routing: inference routing works after TLS manipulations".to_owned(),
+                observations,
+            };
+        },
+    }
+
+    ProofResult {
+        success: true,
+        description: "Existing routing: inference routing works after TLS manipulations".to_owned(),
+        observations,
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/xtask/src/env/operator.rs
+++ b/xtask/src/env/operator.rs
@@ -685,8 +685,6 @@ pub(crate) fn cleanup_install_rbac_test_resources(context: &str) -> Result<(), B
     eprintln!("  [OK] stale install/RBAC test resources removed");
     Ok(())
 }
-
-
 /// Build the Grid operator container image.
 ///
 /// Builds the operator image from the repository root using the multi-stage
@@ -4353,8 +4351,6 @@ pub(crate) fn assert_no_crdt_candidates_for_site(
     );
     Ok(())
 }
-
-
 /// Validate `GridSite` transition events with deterministic filtering,
 /// sorting, and content assertions.
 ///


### PR DESCRIPTION
Closes #23

## Summary

- Adds Secret-backed private-CA TLS and mutual-TLS support to provider metrics scraping.
- Enforces HTTPS when metrics TLS is configured and fails closed on invalid or stale secure telemetry.
- Adds bounded PEM and response handling with safe failure classification.
- Supports Secret rotation through bounded reconciliation without cluster-wide Secret enumeration.
- Adds CRD, Helm, documentation, llm-d runtime proof, stale-cache, routing, and rotation evidence.

## Validation

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace` — 1,929 passed
- `make doc`
- `scripts/verify-helm-chart.sh` — 162 passed
- `git diff --check`
- llm-d pool metrics mTLS demo passed
- workload inference demo passed 20/20
- GLB and combined-site demos passed
- evidence scans found no certificate, key, token, or Secret material
