### PR TITLE
Add configurable Grid scoring and metric refresh controls

### DIFF
--- a/charts/grid-operator/crds/gridnetwork.yaml
+++ b/charts/grid-operator/crds/gridnetwork.yaml
@@ -224,6 +224,36 @@ spec:
                     - scoreFirst
                   nullable: true
                   type: string
+                scoringPolicy:
+                  description: |-
+                    Scoring policy configuration.
+
+                    Selects how the operator scores providers for the routing overlay.
+
+                    **Default (absent):** the `noMetrics` strategy is used.
+                  nullable: true
+                  properties:
+                    strategy:
+                      description: |-
+                        Provider-level scoring strategy. Required when `scoringPolicy`
+                        is present. Omit the entire policy to use `noMetrics`.
+                      enum:
+                        - noMetrics
+                        - queueDepth
+                        - kvCachePressure
+                      type: string
+                  required:
+                    - strategy
+                  type: object
+                metricsRefreshInterval:
+                  description: |-
+                    Maximum time between provider metric refreshes and score/ranking recalculation.
+
+                    Use a duration such as `10s`. When absent or invalid, the operator uses its
+                    safe default cadence. TLS metric networks cap the interval at 60 seconds.
+                  nullable: true
+                  pattern: ^[0-9]+(ms|s)$
+                  type: string
                 seeds:
                   default: []
                   description: Initial SWIM seed peer addresses.

--- a/charts/grid-site/templates/gridnetwork.yaml
+++ b/charts/grid-site/templates/gridnetwork.yaml
@@ -18,6 +18,17 @@ spec:
   {{- with .Values.gridNetwork.routingPolicy }}
   routingPolicy: {{ . | quote }}
   {{- end }}
+  {{- with .Values.gridNetwork.scoringPolicy }}
+  {{- if .strategy }}
+  scoringPolicy:
+    strategy: {{ .strategy | quote }}
+  {{- end }}
+  {{- end }}
+  {{- with .Values.gridNetwork.metricsRefreshInterval }}
+  {{- if . }}
+  metricsRefreshInterval: {{ . | quote }}
+  {{- end }}
+  {{- end }}
   {{- with .Values.gridNetwork.swim }}
   swim:
     {{- toYaml . | nindent 4 }}

--- a/charts/grid-site/values.schema.json
+++ b/charts/grid-site/values.schema.json
@@ -38,6 +38,21 @@
           "type": "string",
           "enum": ["geographyFirst", "scoreFirst"]
         },
+        "scoringPolicy": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["strategy"],
+          "properties": {
+            "strategy": {
+              "type": "string",
+              "enum": ["noMetrics", "queueDepth", "kvCachePressure"]
+            }
+          }
+        },
+        "metricsRefreshInterval": {
+          "type": "string",
+          "pattern": "^[0-9]+(ms|s)$"
+        },
         "gatewayRefs": {
           "type": "array",
           "items": {

--- a/config/samples/gridnetwork.yaml
+++ b/config/samples/gridnetwork.yaml
@@ -8,6 +8,11 @@ spec:
   region: us-west-2
   zone: us-west-2a
 
+  # Provider scoring (defaults to noMetrics when absent).
+  # scoringPolicy:
+  #   strategy: noMetrics  # "noMetrics" | "queueDepth" | "kvCachePressure"
+  # metricsRefreshInterval: "30s"  # optional; defaults to 300s, or 60s with TLS metrics
+
   # SWIM protocol settings (defaults)
   swim:
     probeInterval: "5s"

--- a/deploy/crds/gridnetwork.yaml
+++ b/deploy/crds/gridnetwork.yaml
@@ -224,6 +224,40 @@ spec:
                     - scoreFirst
                   nullable: true
                   type: string
+                scoringPolicy:
+                  description: |-
+                    Scoring policy configuration.
+
+                    Selects how the operator scores providers for the routing overlay.
+
+                    **Default (absent):** the `noMetrics` strategy is used.
+
+                    See [`ScoringStrategy`] for the available provider-level strategies.
+                  nullable: true
+                  properties:
+                    strategy:
+                      description: |-
+                        Provider-level scoring strategy.
+
+                        Required when `scoringPolicy` is present. Omit the entire policy to use
+                        the `noMetrics` default.
+                      enum:
+                        - noMetrics
+                        - queueDepth
+                        - kvCachePressure
+                      type: string
+                  required:
+                    - strategy
+                  type: object
+                metricsRefreshInterval:
+                  description: |-
+                    Maximum time between provider metric refreshes and score/ranking recalculation.
+
+                    Use a duration such as `10s`. When absent or invalid, the operator uses its
+                    safe default cadence. TLS metric networks cap the interval at 60 seconds.
+                  nullable: true
+                  pattern: ^[0-9]+(ms|s)$
+                  type: string
                 seeds:
                   default: []
                   description: Initial SWIM seed peer addresses.

--- a/docs/architecture/routing.md
+++ b/docs/architecture/routing.md
@@ -54,6 +54,118 @@ The `ConfigMap` contains:
 
 Both keys describe the same routing state.
 
+## How re-ranking updates
+
+Grid does not re-rank a provider inside the request path. Re-ranking happens
+when the Grid operator reconciles a `GridNetwork` and publishes a new routing
+overlay. Praxis then uses the most recent overlay that it has accepted.
+
+The complete update path is:
+
+```text
+provider metrics / Kubernetes state / remote Grid state changes
+                              |
+                              v
+                    Grid operator reconcile
+                              |
+              scrape and normalize provider metrics
+                              |
+                  score and order candidates
+                              |
+          write a new versioned overlay ConfigMap
+                              |
+                 ConfigMap watch / projection
+                              |
+                    overlay-sync, if enabled
+                              |
+                    Praxis atomic hot reload
+                              |
+              next request uses the new ordering
+```
+
+### What causes a reconcile
+
+The operator has two kinds of triggers:
+
+| Trigger | What happens | Typical timing |
+|---|---|---:|
+| `InferenceProvider` change | Provider health, endpoint, model, metrics, or configuration changes can enqueue the owning `GridNetwork`. | Immediate watch event |
+| `GridSite` change | Site labels, geography, membership, or site status changes can enqueue the owning `GridNetwork`. | Immediate watch event |
+| `GridNetwork` change | A change to the network or gateway references enqueues that network. | Immediate watch event |
+| Remote SWIM/CRDT state observed | Remote provider and site state is consumed during reconciliation. | On the next reconcile/event-driven enqueue |
+| Periodic requeue | The operator periodically re-scrapes metrics and re-renders overlays. | **300 seconds by default** |
+| TLS metrics configuration | A network with any TLS-protected metrics provider uses a shorter bounded requeue so certificate rotation is noticed without a Secret watch. | **60 seconds** |
+
+The periodic interval is important for live metrics: a changing EPP queue does
+not itself change a Kubernetes resource, so it normally waits for the next
+`GridNetwork` reconcile. A provider or site watch can cause an earlier
+reconcile for other state changes.
+
+Set `spec.metricsRefreshInterval` when a deployment needs a different periodic
+cadence:
+
+```yaml
+spec:
+  metricsRefreshInterval: "10s"
+```
+
+The value accepts positive milliseconds or seconds; the CRD rejects other
+formats before they reach the operator. An absent value uses the safe default
+of 300 seconds for plaintext metrics. A network with TLS
+metric credentials defaults to 60 seconds and never permits a custom interval
+longer than that bound, so certificate rotation detection is not delayed.
+Shorter intervals increase Kubernetes API, metrics-scrape, and overlay-update
+load; use them for demos or deliberately latency-sensitive deployments.
+
+### What happens during re-ranking
+
+During reconciliation, Grid:
+
+1. Lists the eligible `InferenceProvider` resources and `GridSite` resources.
+2. Scrapes each configured metrics endpoint, such as an llm-d EPP endpoint.
+3. Normalizes queue, KV-cache, latency, and other signals; applies freshness
+   and health handling.
+4. Builds the candidate set, including eligible remote providers received
+   through Grid state.
+5. Computes the weighted score and applies admission and `routingPolicy`
+   ordering. The first candidate receives rank `0`, the next receives rank
+   `1`, and so on.
+6. Renders a content-addressed overlay for each gateway reference. Each
+   gateway can therefore receive a different ranking because its `localSite`
+   and routing perspective can differ.
+7. Applies the overlay ConfigMap and records rendered/distributed revision
+   status.
+
+If rendering or applying a new overlay fails, Grid retains the previously
+distributed revision rather than publishing a partial routing state.
+
+### How the new overlay reaches Praxis
+
+After Grid applies the ConfigMap, delivery is separate from re-ranking:
+
+- With `overlay-sync` enabled, the sidecar watches the named ConfigMap,
+  validates the envelope and digest, atomically replaces the serving file, and
+  exposes readiness/liveness state.
+- Without `overlay-sync`, Praxis uses the direct ConfigMap mount and its normal
+  file-watch/projection behavior.
+- Praxis validates the new overlay and atomically swaps its in-memory snapshot.
+  Invalid updates leave the last-known-good snapshot serving; no request reads
+  Kubernetes or Grid directly.
+
+Overlay-sync can remove kubelet projection delay, but it does **not** make
+metrics collection or operator reconciliation more frequent. The end-to-end
+route-change time is the sum of metric availability, the next reconcile,
+ConfigMap application, overlay delivery, and Praxis hot reload.
+
+### Demo-specific forced refresh
+
+The LLM-D pool metrics demo deliberately annotates the `GridNetwork` after a
+pressure or recovery transition. That annotation creates an immediate watch
+event and bypasses the normal 300-second periodic requeue, allowing the demo
+to show the queue change, re-ranking, overlay revision, and routed request in
+one controlled flow. This is orchestration behavior for the demo; it is not a
+different Grid scoring algorithm.
+
 ## Routing overlay format
 
 The envelope is the authoritative observable contract consumed by Praxis AI:

--- a/docs/architecture/scoring.md
+++ b/docs/architecture/scoring.md
@@ -56,6 +56,38 @@ queue contribution = 3.0 * (1.0 - normalized queue depth)
 The breakdown makes an operator decision explainable without requiring the
 demo, gateway, or observability stack to reimplement the scoring formula.
 
+## Selecting the provider-level strategy
+
+`GridNetwork.spec.scoringPolicy.strategy` selects the one provider-level signal
+that Grid should use for dynamic metric scoring. It is intentionally not an
+opaque blend of every available signal:
+
+| Strategy | What a higher score means |
+|---|---|
+| `noMetrics` | Do not prefer a provider using dynamic metrics. Health, admission, freshness, locality, and request-time policy still apply. |
+| `queueDepth` | The provider has less normalized queue pressure. This is the llm-d load-aware mode used by the pool-metrics demo. |
+| `kvCachePressure` | The provider has more available KV-cache capacity, meaning lower utilization pressure. |
+
+When `scoringPolicy` is absent, Grid uses `noMetrics`. The six weights in the
+table above describe the scoring engine's legacy combined-weight capability;
+they are not silently enabled by omitting the policy. Explicitly select a
+strategy when provider metrics should move cross-provider ranking.
+
+For example:
+
+```yaml
+spec:
+  routingPolicy: scoreFirst
+  scoringPolicy:
+    strategy: queueDepth
+  metricsRefreshInterval: "5s"
+```
+
+`routingPolicy` and `scoringPolicy` answer different questions. The scoring
+strategy calculates the dynamic metric score. `geographyFirst` or `scoreFirst`
+then determines whether locality or that score is the primary ordering rule.
+Admission and freshness remain higher-priority safety gates in both modes.
+
 ## Metrics Configuration
 
 `InferenceProvider.spec.metricsConfig` enables Prometheus text-format scraping.

--- a/operator/src/controller/grid_network.rs
+++ b/operator/src/controller/grid_network.rs
@@ -275,8 +275,17 @@ pub async fn reconcile(network: Arc<GridNetwork>, ctx: Arc<OperatorCtx>) -> Resu
     let remote_crdt_providers =
         routing_overlay::apply_stale_gc_filter(&remote_crdt_providers, membership.as_ref(), &stale_policy);
 
-    let (consumer_config_statuses, overlay_statuses) =
-        reconcile_routing_overlay_inner(&network, client, &providers, &remote_crdt_providers, &raw_metrics).await?;
+    let scoring_weights = crate::crd::grid_network::resolve_scoring_weights(network.spec.scoring_policy.as_ref());
+
+    let (consumer_config_statuses, overlay_statuses) = reconcile_routing_overlay_inner(
+        &network,
+        client,
+        &providers,
+        &remote_crdt_providers,
+        &raw_metrics,
+        &scoring_weights,
+    )
+    .await?;
 
     let grid_id = resolve_grid_id(&network);
     let phase = if swim_runtime_running {
@@ -320,7 +329,7 @@ pub async fn reconcile(network: Arc<GridNetwork>, ctx: Arc<OperatorCtx>) -> Resu
         reconcile_discovered_sites(name, swim.site_name(), snapshot, client, plaintext).await?;
     }
 
-    Ok(Action::requeue(requeue_interval_for_network(&providers)))
+    Ok(Action::requeue(requeue_interval_for_network(&network, &providers)))
 }
 
 /// Apply `spec.tls.swimKeyRef` before any reconcile-triggered SWIM send.
@@ -674,12 +683,17 @@ async fn apply_site_secret(
     clippy::cognitive_complexity,
     reason = "sequential overlay render loop with per-gateway eligibility filter, consumer config, and status; splitting obscures the pipeline"
 )]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "scoring_weights is threaded through overlay rendering without hiding the selected strategy"
+)]
 async fn reconcile_routing_overlay_inner(
     network: &GridNetwork,
     client: &Client,
     providers: &[InferenceProvider],
     remote_crdt_providers: &[crdt::ProviderState],
     raw_metrics: &HashMap<String, scoring::BackendMetrics>,
+    scoring_weights: &scoring::ScoringWeights,
 ) -> Result<(Vec<ConsumerConfigStatus>, Vec<OverlayRevisionStatus>), OperatorError> {
     let network_name = grid_network_name(network)?;
 
@@ -731,6 +745,7 @@ async fn reconcile_routing_overlay_inner(
             local_site,
             metrics_arg,
             timestamp.as_deref(),
+            scoring_weights,
         ) {
             Ok(overlay) => overlay,
             Err(error) => {
@@ -1933,19 +1948,47 @@ async fn reconcile_discovered_sites(
 /// collection and overlay publication in this reconcile loop detect
 /// certificate rotation without a cluster-wide Secret watch.
 ///
-/// For networks with only plaintext metrics (or no metrics), returns the
-/// default [`REQUEUE_INTERVAL`] (300 s).
+/// An explicit `spec.metricsRefreshInterval` is used when parseable. TLS
+/// networks are capped at [`TLS_REQUEUE_INTERVAL`] so certificate rotation is
+/// not delayed by an unsafe long custom interval. Invalid or absent values
+/// fall back to the appropriate safe default.
 ///
 /// [`InferenceProvider`]: crate::crd::inference_provider::InferenceProvider
-fn requeue_interval_for_network(providers: &[InferenceProvider]) -> Duration {
+fn requeue_interval_for_network(network: &GridNetwork, providers: &[InferenceProvider]) -> Duration {
     let any_has_tls = providers
         .iter()
         .any(|p| p.spec.metrics_config.as_ref().is_some_and(|mc| mc.tls.is_some()));
-    if any_has_tls {
+    let default = if any_has_tls {
         TLS_REQUEUE_INTERVAL
     } else {
         REQUEUE_INTERVAL
+    };
+    let configured = network
+        .spec
+        .metrics_refresh_interval
+        .as_deref()
+        .and_then(parse_metrics_refresh_interval);
+
+    match (configured, any_has_tls) {
+        (Some(interval), true) => interval.min(TLS_REQUEUE_INTERVAL),
+        (Some(interval), false) => interval,
+        (None, _) => default,
     }
+}
+
+/// Parse the deliberately small duration format accepted by
+/// `metricsRefreshInterval`: positive seconds or milliseconds.
+fn parse_metrics_refresh_interval(value: &str) -> Option<Duration> {
+    let value = value.trim();
+    let (number, multiplier) = if let Some(number) = value.strip_suffix("ms") {
+        (number, 1_u64)
+    } else if let Some(number) = value.strip_suffix('s') {
+        (number, 1_000_u64)
+    } else {
+        return None;
+    };
+    let millis = number.trim().parse::<u64>().ok()?.checked_mul(multiplier)?;
+    (millis > 0).then(|| Duration::from_millis(millis))
 }
 
 // ---------------------------------------------------------------------------
@@ -4045,7 +4088,7 @@ mod tests {
             make_inference_provider("p2", "net"),
         ];
         assert_eq!(
-            requeue_interval_for_network(&providers),
+            requeue_interval_for_network(&base_network(), &providers),
             REQUEUE_INTERVAL,
             "networks with no TLS providers should use 300s"
         );
@@ -4055,7 +4098,7 @@ mod tests {
     fn network_requeue_tls_provider_uses_tls_interval() {
         let providers = vec![make_provider_with_tls("p1", "net")];
         assert_eq!(
-            requeue_interval_for_network(&providers),
+            requeue_interval_for_network(&base_network(), &providers),
             TLS_REQUEUE_INTERVAL,
             "network with a TLS provider should use 60s"
         );
@@ -4068,7 +4111,7 @@ mod tests {
             make_provider_with_tls("secure", "net"),
         ];
         assert_eq!(
-            requeue_interval_for_network(&providers),
+            requeue_interval_for_network(&base_network(), &providers),
             TLS_REQUEUE_INTERVAL,
             "mixed plaintext/TLS providers should use 60s"
         );
@@ -4078,9 +4121,67 @@ mod tests {
     fn network_requeue_longer_health_interval_does_not_delay_tls() {
         let providers = vec![make_provider_with_tls_and_health_interval("p1", "net", "600s")];
         assert_eq!(
-            requeue_interval_for_network(&providers),
+            requeue_interval_for_network(&base_network(), &providers),
             TLS_REQUEUE_INTERVAL,
             "a longer healthCheck.interval must not delay TLS rotation detection"
         );
+    }
+
+    #[test]
+    fn network_requeue_uses_configured_seconds_interval() {
+        let providers = vec![make_inference_provider("p1", "net")];
+        let mut network = base_network();
+        network.spec.metrics_refresh_interval = Some("10s".to_owned());
+        assert_eq!(
+            requeue_interval_for_network(&network, &providers),
+            Duration::from_secs(10)
+        );
+    }
+
+    #[test]
+    fn network_requeue_uses_configured_milliseconds_interval() {
+        let providers = vec![make_inference_provider("p1", "net")];
+        let mut network = base_network();
+        network.spec.metrics_refresh_interval = Some("500ms".to_owned());
+        assert_eq!(
+            requeue_interval_for_network(&network, &providers),
+            Duration::from_millis(500)
+        );
+    }
+
+    #[test]
+    fn network_requeue_invalid_config_falls_back_to_safe_default() {
+        let providers = vec![make_inference_provider("p1", "net")];
+        let mut network = base_network();
+        network.spec.metrics_refresh_interval = Some("5m".to_owned());
+        assert_eq!(requeue_interval_for_network(&network, &providers), REQUEUE_INTERVAL);
+    }
+
+    #[test]
+    fn network_requeue_tls_caps_long_configured_interval() {
+        let providers = vec![make_provider_with_tls("p1", "net")];
+        let mut network = base_network();
+        network.spec.metrics_refresh_interval = Some("10m".to_owned());
+        assert_eq!(requeue_interval_for_network(&network, &providers), TLS_REQUEUE_INTERVAL);
+    }
+
+    #[test]
+    fn network_requeue_tls_allows_short_configured_interval() {
+        let providers = vec![make_provider_with_tls("p1", "net")];
+        let mut network = base_network();
+        network.spec.metrics_refresh_interval = Some("10s".to_owned());
+        assert_eq!(
+            requeue_interval_for_network(&network, &providers),
+            Duration::from_secs(10)
+        );
+    }
+
+    #[test]
+    fn metrics_refresh_duration_parser_rejects_unsupported_values() {
+        assert_eq!(parse_metrics_refresh_interval(""), None);
+        assert_eq!(parse_metrics_refresh_interval("10"), None);
+        assert_eq!(parse_metrics_refresh_interval("0s"), None);
+        assert_eq!(parse_metrics_refresh_interval("-1s"), None);
+        assert_eq!(parse_metrics_refresh_interval("1m"), None);
     }
 }

--- a/operator/src/crd/grid_network.rs
+++ b/operator/src/crd/grid_network.rs
@@ -38,6 +38,119 @@ pub enum RoutingPolicy {
 }
 
 // ---------------------------------------------------------------------------
+// Scoring policy
+// ---------------------------------------------------------------------------
+
+/// Provider-level strategy used to order inference pools.
+///
+/// Grid follows llm-d's scorer model: the operator selects one independently
+/// meaningful signal instead of blending unrelated objectives into an opaque
+/// total. Request-specific decisions, such as prefix-cache affinity, remain in
+/// the llm-d EPP after Grid has selected a provider pool.
+///
+/// When no [`ScoringPolicyConfig`] is set on the [`GridNetworkSpec`], dynamic
+/// metric scoring is disabled. This supports external APIs and ordinary
+/// providers that do not expose comparable EPP telemetry.
+#[derive(Clone, Copy, Debug, Default, Deserialize, JsonSchema, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum ScoringStrategy {
+    /// Do not prefer providers using dynamic metrics.
+    ///
+    /// All score contributions are zero. Health, admission, freshness,
+    /// geography, selection tiers, session affinity, and request-time picker
+    /// policy still apply. This is the generic default.
+    #[default]
+    NoMetrics,
+
+    /// Prefer the provider pool with the shortest normalized queue.
+    ///
+    /// This load-aware strategy corresponds to llm-d's `queue-scorer`. Lower
+    /// queue pressure produces a higher score.
+    QueueDepth,
+
+    /// Prefer the provider pool with the most available KV-cache capacity.
+    ///
+    /// This corresponds to llm-d's `kv-cache-utilization-scorer`: lower
+    /// utilization produces a higher score. It is a capacity-pressure signal,
+    /// not evidence that the current request's prefix is cached.
+    KvCachePressure,
+}
+
+impl ScoringStrategy {
+    /// Adapts the selected strategy to the existing scoring engine.
+    #[must_use]
+    pub fn weights(self) -> scoring::ScoringWeights {
+        match self {
+            Self::NoMetrics => scoring::ScoringWeights {
+                locality: 0.0,
+                queue_depth: 0.0,
+                kv_cache: 0.0,
+                prefix_cache: 0.0,
+                latency: 0.0,
+                cost: 0.0,
+            },
+            Self::QueueDepth => scoring::ScoringWeights {
+                locality: 0.0,
+                queue_depth: 1.0,
+                kv_cache: 0.0,
+                prefix_cache: 0.0,
+                latency: 0.0,
+                cost: 0.0,
+            },
+            Self::KvCachePressure => scoring::ScoringWeights {
+                locality: 0.0,
+                queue_depth: 0.0,
+                kv_cache: 1.0,
+                prefix_cache: 0.0,
+                latency: 0.0,
+                cost: 0.0,
+            },
+        }
+    }
+}
+
+/// Scoring policy configuration for the routing overlay.
+///
+/// Selects exactly one provider-level signal. When this field is absent from
+/// [`GridNetworkSpec`], `noMetrics` is used.
+///
+/// # Examples
+///
+/// ```yaml
+/// # Generic default (equivalent to omitting scoringPolicy):
+/// scoringPolicy:
+///   strategy: noMetrics
+///
+/// # Opt into llm-d load-aware scoring:
+/// scoringPolicy:
+///   strategy: queueDepth
+///
+/// # Or prefer available KV-cache capacity:
+/// scoringPolicy:
+///   strategy: kvCachePressure
+/// ```
+#[derive(Clone, Debug, Default, Deserialize, JsonSchema, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[schemars(deny_unknown_fields)]
+pub struct ScoringPolicyConfig {
+    /// Provider-level scoring strategy.
+    ///
+    /// Required when `scoringPolicy` is present. Omit the entire policy to use
+    /// the `noMetrics` default.
+    pub strategy: ScoringStrategy,
+}
+
+/// Resolve the effective [`scoring::ScoringWeights`] from a scoring policy.
+///
+/// The public API selects one scorer. The weight adapter is internal and
+/// keeps the existing scoring engine and score-breakdown contract intact.
+pub fn resolve_scoring_weights(policy: Option<&ScoringPolicyConfig>) -> scoring::ScoringWeights {
+    policy
+        .map_or_else(ScoringStrategy::default, |policy| policy.strategy)
+        .weights()
+}
+
+// ---------------------------------------------------------------------------
 // Spec
 // ---------------------------------------------------------------------------
 
@@ -103,6 +216,27 @@ pub struct GridNetworkSpec {
     /// freshness is a tiebreaker below geography and score.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub routing_policy: Option<RoutingPolicy>,
+
+    /// Scoring policy configuration.
+    ///
+    /// Selects how the operator scores providers for the routing overlay.
+    ///
+    /// **Default (absent):** the `noMetrics` strategy is used.
+    ///
+    /// See [`ScoringStrategy`] for the available provider-level strategies.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scoring_policy: Option<ScoringPolicyConfig>,
+
+    /// Maximum time between metric refreshes and score/ranking recalculation.
+    ///
+    /// This controls the `GridNetwork` reconcile cadence for provider metrics;
+    /// it does not change request-path routing or the overlay watch latency.
+    /// Use a duration such as `"10s"`. When absent or invalid, Grid uses its
+    /// safe default cadence (300 seconds, or 60 seconds when TLS metric
+    /// credentials require bounded certificate-rotation detection).
+    #[schemars(regex(pattern = "^[0-9]+(ms|s)$"))]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metrics_refresh_interval: Option<String>,
 
     /// Maximum age in seconds before a stale (`fresh=false`) remote routing
     /// candidate is removed from the overlay.
@@ -1234,5 +1368,384 @@ mod tests {
             json.get("reason").and_then(serde_json::Value::as_str),
             Some("EmptyCandidates"),
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // ScoringPolicy tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn scoring_strategy_default_is_no_metrics() {
+        assert_eq!(
+            ScoringStrategy::default(),
+            ScoringStrategy::NoMetrics,
+            "default strategy must be noMetrics"
+        );
+    }
+
+    #[test]
+    fn scoring_policy_absent_defaults_to_none() {
+        let json = serde_json::json!({ "gridId": "", "seeds": [] });
+        let spec: GridNetworkSpec = serde_json::from_value(json).unwrap_or_else(|_| std::process::abort());
+        assert!(
+            spec.scoring_policy.is_none(),
+            "absent scoringPolicy must default to None"
+        );
+    }
+
+    #[test]
+    fn scoring_policy_queue_depth_round_trips() {
+        let json = serde_json::json!({
+            "gridId": "",
+            "seeds": [],
+            "scoringPolicy": { "strategy": "queueDepth" }
+        });
+        let spec: GridNetworkSpec = serde_json::from_value(json).unwrap_or_else(|_| std::process::abort());
+        let policy = spec.scoring_policy.unwrap_or_else(|| std::process::abort());
+        assert_eq!(
+            policy.strategy,
+            ScoringStrategy::QueueDepth,
+            "queueDepth strategy must round-trip"
+        );
+    }
+
+    #[test]
+    fn scoring_policy_no_metrics_round_trips() {
+        let json = serde_json::json!({
+            "gridId": "",
+            "seeds": [],
+            "scoringPolicy": { "strategy": "noMetrics" }
+        });
+        let spec: GridNetworkSpec = serde_json::from_value(json).unwrap_or_else(|_| std::process::abort());
+        let policy = spec.scoring_policy.unwrap_or_else(|| std::process::abort());
+        assert_eq!(
+            policy.strategy,
+            ScoringStrategy::NoMetrics,
+            "noMetrics strategy must round-trip"
+        );
+    }
+
+    #[test]
+    fn scoring_policy_kv_cache_pressure_round_trips() {
+        let json = serde_json::json!({
+            "gridId": "",
+            "seeds": [],
+            "scoringPolicy": { "strategy": "kvCachePressure" }
+        });
+        let spec: GridNetworkSpec = serde_json::from_value(json).unwrap_or_else(|_| std::process::abort());
+        let policy = spec.scoring_policy.unwrap_or_else(|| std::process::abort());
+        assert_eq!(
+            policy.strategy,
+            ScoringStrategy::KvCachePressure,
+            "kvCachePressure strategy must round-trip"
+        );
+    }
+
+    #[test]
+    fn scoring_policy_rejects_removed_profile_shape() {
+        let json = serde_json::json!({
+            "gridId": "",
+            "seeds": [],
+            "scoringPolicy": { "profile": "balanced" }
+        });
+        let result = serde_json::from_value::<GridNetworkSpec>(json);
+        assert!(result.is_err(), "the removed profile/weights API must be rejected");
+    }
+
+    #[test]
+    fn scoring_policy_absent_not_serialized() {
+        let json = serde_json::json!({ "gridId": "", "seeds": [] });
+        let spec: GridNetworkSpec = serde_json::from_value(json).unwrap_or_else(|_| std::process::abort());
+        let serialized = serde_json::to_value(&spec).unwrap_or_else(|_| std::process::abort());
+        assert!(
+            serialized.get("scoringPolicy").is_none(),
+            "absent scoringPolicy must not appear in serialized output"
+        );
+    }
+
+    #[test]
+    fn scoring_policy_appears_in_crd_schema() {
+        let crd = crd_json();
+        let schema = crd
+            .pointer("/spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/scoringPolicy")
+            .unwrap_or_else(|| std::process::abort());
+        assert!(schema.is_object(), "scoringPolicy must appear in the CRD schema");
+    }
+
+    #[test]
+    fn scoring_strategy_enum_in_crd_schema() {
+        let crd = crd_json();
+        let strategy_schema = crd
+            .pointer(
+                "/spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/scoringPolicy/properties/strategy",
+            )
+            .unwrap_or_else(|| std::process::abort());
+        let enum_values = strategy_schema
+            .get("enum")
+            .and_then(serde_json::Value::as_array)
+            .unwrap_or_else(|| std::process::abort());
+        let values: Vec<&str> = enum_values.iter().filter_map(serde_json::Value::as_str).collect();
+        assert!(
+            values.contains(&"noMetrics"),
+            "CRD enum must include noMetrics: {values:?}"
+        );
+        assert!(
+            values.contains(&"queueDepth"),
+            "CRD enum must include queueDepth: {values:?}"
+        );
+        assert!(
+            values.contains(&"kvCachePressure"),
+            "CRD enum must include kvCachePressure: {values:?}"
+        );
+        assert_eq!(values.len(), 3, "only the three supported strategies belong in the CRD");
+    }
+
+    #[test]
+    fn metrics_refresh_interval_schema_requires_duration_suffix() {
+        let crd = crd_json();
+        let schema = crd
+            .pointer("/spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/metricsRefreshInterval")
+            .unwrap_or_else(|| std::process::abort());
+        assert_eq!(schema.get("type").and_then(serde_json::Value::as_str), Some("string"));
+        assert_eq!(
+            schema.get("pattern").and_then(serde_json::Value::as_str),
+            Some("^[0-9]+(ms|s)$")
+        );
+    }
+
+    #[test]
+    fn scoring_strategy_is_required_when_policy_is_present() {
+        let crd = crd_json();
+        let required = crd
+            .pointer("/spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/scoringPolicy/required")
+            .and_then(serde_json::Value::as_array)
+            .unwrap_or_else(|| std::process::abort());
+        assert_eq!(required, &[serde_json::Value::String("strategy".to_owned())]);
+    }
+
+    // -----------------------------------------------------------------------
+    // resolve_scoring_weights tests
+    // -----------------------------------------------------------------------
+
+    fn assert_weight(actual: f64, expected: f64, label: &str) {
+        assert!(
+            (actual - expected).abs() < f64::EPSILON,
+            "{label}: expected {expected}, got {actual}"
+        );
+    }
+
+    #[test]
+    fn resolve_weights_none_disables_all_signals() {
+        let w = resolve_scoring_weights(None);
+        assert_weight(w.queue_depth, 0.0, "queue_depth");
+        assert_weight(w.locality, 0.0, "locality");
+        assert_weight(w.kv_cache, 0.0, "kv_cache");
+        assert_weight(w.prefix_cache, 0.0, "prefix_cache");
+        assert_weight(w.latency, 0.0, "latency");
+        assert_weight(w.cost, 0.0, "cost");
+    }
+
+    #[test]
+    fn resolve_weights_explicit_no_metrics_disables_all_signals() {
+        let policy = ScoringPolicyConfig {
+            strategy: ScoringStrategy::NoMetrics,
+        };
+        let w = resolve_scoring_weights(Some(&policy));
+        assert_weight(w.queue_depth, 0.0, "queue_depth");
+        assert_weight(w.locality, 0.0, "locality");
+        assert_weight(w.kv_cache, 0.0, "kv_cache");
+        assert_weight(w.prefix_cache, 0.0, "prefix_cache");
+        assert_weight(w.latency, 0.0, "latency");
+        assert_weight(w.cost, 0.0, "cost");
+    }
+
+    #[test]
+    fn resolve_weights_explicit_queue_depth_all_others_zero() {
+        let policy = ScoringPolicyConfig {
+            strategy: ScoringStrategy::QueueDepth,
+        };
+        let w = resolve_scoring_weights(Some(&policy));
+        assert_weight(w.queue_depth, 1.0, "queue_depth");
+        assert_weight(w.locality, 0.0, "locality");
+        assert_weight(w.kv_cache, 0.0, "kv_cache");
+        assert_weight(w.prefix_cache, 0.0, "prefix_cache");
+        assert_weight(w.latency, 0.0, "latency");
+        assert_weight(w.cost, 0.0, "cost");
+    }
+
+    #[test]
+    fn resolve_weights_kv_cache_pressure_all_others_zero() {
+        let policy = ScoringPolicyConfig {
+            strategy: ScoringStrategy::KvCachePressure,
+        };
+        let w = resolve_scoring_weights(Some(&policy));
+        assert_weight(w.kv_cache, 1.0, "kv_cache");
+        assert_weight(w.queue_depth, 0.0, "queue_depth");
+        assert_weight(w.locality, 0.0, "locality");
+        assert_weight(w.prefix_cache, 0.0, "prefix_cache");
+        assert_weight(w.latency, 0.0, "latency");
+        assert_weight(w.cost, 0.0, "cost");
+    }
+
+    #[test]
+    fn scoring_policy_rejects_unknown_strategy() {
+        let json = serde_json::json!({
+            "gridId": "",
+            "seeds": [],
+            "scoringPolicy": { "strategy": "prefixAware" }
+        });
+        let result = serde_json::from_value::<GridNetworkSpec>(json);
+        assert!(result.is_err(), "unknown strategy must be rejected");
+    }
+
+    #[test]
+    fn scoring_policy_rejects_removed_weights_field() {
+        let json = serde_json::json!({
+            "gridId": "",
+            "seeds": [],
+            "scoringPolicy": {
+                "strategy": "queueDepth",
+                "weights": { "locality": 1.0 }
+            }
+        });
+        let result = serde_json::from_value::<GridNetworkSpec>(json);
+        assert!(result.is_err(), "weights field must be rejected by deny_unknown_fields");
+    }
+
+    // -----------------------------------------------------------------------
+    // Hand-calculated scoring assertions
+    // -----------------------------------------------------------------------
+
+    fn test_backend(name: &str) -> scoring::BackendConfig {
+        scoring::BackendConfig::new(
+            name.to_owned(),
+            0.0,
+            0.0,
+            format!("http://{name}:8000"),
+            scoring::BackendKind::Local,
+            scoring::ProviderKind::OpenAi,
+            Some("us-east-1".to_owned()),
+        )
+    }
+
+    fn assert_all_zero_except(b: &scoring::ScoreBreakdown, active: &str) {
+        if active != "queue_depth" {
+            assert_weight(b.queue_depth, 0.0, "queue_depth must be zero");
+        }
+        if active != "kv_cache" {
+            assert_weight(b.kv_cache, 0.0, "kv_cache must be zero");
+        }
+        assert_weight(b.locality, 0.0, "locality must be zero");
+        assert_weight(b.prefix_cache, 0.0, "prefix_cache must be zero");
+        assert_weight(b.latency, 0.0, "latency must be zero");
+        assert_weight(b.cost, 0.0, "cost must be zero");
+    }
+
+    #[test]
+    fn queue_depth_strategy_hand_calculated_score() {
+        let weights = ScoringStrategy::QueueDepth.weights();
+        let mut state = scoring::GridState::new();
+        state
+            .add_backend(test_backend("pool-a"))
+            .unwrap_or_else(|_| std::process::abort());
+        state.set_metrics(
+            "pool-a".to_owned(),
+            scoring::BackendMetrics::new(0.0, true, 0.50, 100.0, 0.0, 0.25),
+        );
+
+        let scored = scoring::score_backends(&state, &weights, Some("us-east-1"));
+        let s = scored.first().unwrap_or_else(|| std::process::abort());
+
+        assert_weight(s.breakdown.queue_depth, 0.75, "queue: 1.0*(1.0-0.25)");
+        assert_weight(s.breakdown.total, 0.75, "total score");
+        assert_all_zero_except(&s.breakdown, "queue_depth");
+    }
+
+    #[test]
+    fn kv_cache_pressure_strategy_hand_calculated_score() {
+        let weights = ScoringStrategy::KvCachePressure.weights();
+        let mut state = scoring::GridState::new();
+        state
+            .add_backend(test_backend("pool-a"))
+            .unwrap_or_else(|_| std::process::abort());
+        state.set_metrics(
+            "pool-a".to_owned(),
+            scoring::BackendMetrics::new(0.0, true, 0.60, 100.0, 0.0, 0.10),
+        );
+
+        let scored = scoring::score_backends(&state, &weights, Some("us-east-1"));
+        let s = scored.first().unwrap_or_else(|| std::process::abort());
+
+        assert_weight(s.breakdown.kv_cache, 0.40, "kv: 1.0*(1.0-0.60)");
+        assert_weight(s.breakdown.total, 0.40, "total score");
+        assert_all_zero_except(&s.breakdown, "kv_cache");
+    }
+
+    // -----------------------------------------------------------------------
+    // Opposing-signal ordering: prove strategies are not combined
+    // -----------------------------------------------------------------------
+
+    fn opposing_signal_state() -> scoring::GridState {
+        let mut state = scoring::GridState::new();
+        state
+            .add_backend(test_backend("pool-a"))
+            .unwrap_or_else(|_| std::process::abort());
+        state
+            .add_backend(test_backend("pool-b"))
+            .unwrap_or_else(|_| std::process::abort());
+        state.set_metrics(
+            "pool-a".to_owned(),
+            scoring::BackendMetrics::new(0.0, true, 0.80, 100.0, 0.0, 0.10),
+        );
+        state.set_metrics(
+            "pool-b".to_owned(),
+            scoring::BackendMetrics::new(0.0, true, 0.20, 100.0, 0.0, 0.90),
+        );
+        state
+    }
+
+    #[test]
+    fn no_metrics_strategy_ignores_runtime_metric_differences() {
+        let state = opposing_signal_state();
+        let weights = ScoringStrategy::NoMetrics.weights();
+        let scored = scoring::score_backends(&state, &weights, Some("us-east-1"));
+
+        assert_eq!(scored.len(), 2);
+        for backend in scored {
+            assert_weight(backend.breakdown.total, 0.0, "total");
+            assert_all_zero_except(&backend.breakdown, "none");
+        }
+    }
+
+    #[test]
+    fn queue_depth_strategy_prefers_shorter_queue_despite_worse_kv() {
+        let state = opposing_signal_state();
+        let weights = ScoringStrategy::QueueDepth.weights();
+        let scored = scoring::score_backends(&state, &weights, Some("us-east-1"));
+
+        let first = scored.first().unwrap_or_else(|| std::process::abort());
+        let second = scored.get(1).unwrap_or_else(|| std::process::abort());
+        assert_eq!(first.name, "pool-a", "pool-a has shorter queue and must rank first");
+        assert_eq!(second.name, "pool-b");
+        assert_weight(first.breakdown.total, 0.90, "pool-a: 1-0.10");
+        assert_weight(second.breakdown.total, 0.10, "pool-b: 1-0.90");
+        assert_weight(first.breakdown.kv_cache, 0.0, "kv must not contribute");
+        assert_weight(second.breakdown.kv_cache, 0.0, "kv must not contribute");
+    }
+
+    #[test]
+    fn kv_cache_pressure_strategy_prefers_lower_kv_despite_worse_queue() {
+        let state = opposing_signal_state();
+        let weights = ScoringStrategy::KvCachePressure.weights();
+        let scored = scoring::score_backends(&state, &weights, Some("us-east-1"));
+
+        let first = scored.first().unwrap_or_else(|| std::process::abort());
+        let second = scored.get(1).unwrap_or_else(|| std::process::abort());
+        assert_eq!(first.name, "pool-b", "pool-b has lower KV and must rank first");
+        assert_eq!(second.name, "pool-a");
+        assert_weight(first.breakdown.total, 0.80, "pool-b: 1-0.20");
+        assert_weight(second.breakdown.total, 0.20, "pool-a: 1-0.80");
+        assert_weight(first.breakdown.queue_depth, 0.0, "queue must not contribute");
+        assert_weight(second.breakdown.queue_depth, 0.0, "queue must not contribute");
     }
 }

--- a/operator/src/resources/routing_overlay.rs
+++ b/operator/src/resources/routing_overlay.rs
@@ -522,12 +522,12 @@ pub(crate) fn apply_stale_gc_filter(
 /// Compute the score breakdown equivalent to what [`scoring::score_backends`]
 /// would assign to a provider whose `backend_kind` cannot be parsed.
 ///
-/// Applies [`scoring::ScoringWeights::default`] with neutral runtime signals
-/// (0.5, the scoring crate's default for missing metrics) and no cost (treated
-/// as free → cost signal = 1.0).  This places unmapped providers on the same
-/// numeric scale as scored providers so they can be sorted in a single pass.
-fn unmapped_provider_breakdown(backend_kind: &str) -> scoring::ScoreBreakdown {
-    let w = scoring::ScoringWeights::default();
+/// Applies the given weights with neutral runtime signals (0.5, the scoring
+/// crate's default for missing metrics) and no cost (treated as free → cost
+/// signal = 1.0).  This places unmapped providers on the same numeric scale
+/// as scored providers so they can be sorted in a single pass.
+fn unmapped_provider_breakdown(backend_kind: &str, weights: &scoring::ScoringWeights) -> scoring::ScoreBreakdown {
+    let w = weights;
     let locality = w.locality * backend_locality_score(backend_kind);
     let cost = w.cost * 1.0;
     let queue_depth = w.queue_depth * UNMAPPED_NEUTRAL_SIGNAL;
@@ -550,10 +550,9 @@ fn unmapped_provider_breakdown(backend_kind: &str) -> scoring::ScoreBreakdown {
 ///
 /// For each local [`InferenceProvider`] in `network_name` that can be mapped
 /// to a [`scoring::BackendConfig`], the score is produced by
-/// [`scoring::score_backends`] using [`scoring::ScoringWeights::default`]
-/// and the network's `local_region`.  Providers whose `backend_kind` cannot
-/// be parsed fall back to [`unmapped_provider_breakdown`], which is on the same
-/// numeric scale.
+/// [`scoring::score_backends`] using the given weights and the network's
+/// `local_region`.  Providers whose `backend_kind` cannot be parsed fall back
+/// to [`unmapped_provider_breakdown`], which is on the same numeric scale.
 ///
 /// Remote CRDT providers are also scored and included in the result map.
 /// Their scores are derived from [`scoring::score_backends`] via
@@ -567,15 +566,20 @@ fn unmapped_provider_breakdown(backend_kind: &str) -> scoring::ScoreBreakdown {
 /// by [`is_candidate_fresh`] (local) or [`crdt_phase_to_fresh`] (remote).
 ///
 /// Returns a map from routing cluster name to score.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "scoring_weights is threaded through overlay rendering without hiding the selected strategy"
+)]
 fn provider_ordering_scores(
     network_name: &str,
     providers: &[InferenceProvider],
     remote_crdt_providers: &[crdt::ProviderState],
     local_region: Option<&str>,
     metrics: Option<&HashMap<&str, scoring::BackendMetrics>>,
+    weights: &scoring::ScoringWeights,
 ) -> HashMap<String, scoring::ScoreBreakdown> {
     let state = build_grid_state_with_metrics(network_name, providers, remote_crdt_providers, metrics);
-    let scored = scoring::score_backends(&state, &scoring::ScoringWeights::default(), local_region);
+    let scored = scoring::score_backends(&state, weights, local_region);
     let from_engine: HashMap<String, scoring::ScoreBreakdown> =
         scored.into_iter().map(|sb| (sb.name, sb.breakdown)).collect();
 
@@ -586,7 +590,7 @@ fn provider_ordering_scores(
             let breakdown = from_engine
                 .get(cluster.as_str())
                 .cloned()
-                .unwrap_or_else(|| unmapped_provider_breakdown(&p.spec.backend_kind));
+                .unwrap_or_else(|| unmapped_provider_breakdown(&p.spec.backend_kind, weights));
             Some((cluster, breakdown))
         })
         .collect();
@@ -596,7 +600,7 @@ fn provider_ordering_scores(
             from_engine
                 .get(provider.routing_cluster.as_str())
                 .cloned()
-                .unwrap_or_else(|| unmapped_provider_breakdown(&provider.backend_kind))
+                .unwrap_or_else(|| unmapped_provider_breakdown(&provider.backend_kind, weights))
         });
     }
 
@@ -1099,6 +1103,7 @@ pub fn render_routing_overlay(
     local_site: &str,
     metrics: Option<&HashMap<&str, scoring::BackendMetrics>>,
     generated_at: Option<&str>,
+    weights: &scoring::ScoringWeights,
 ) -> Result<RoutingOverlay, String> {
     let network_name = network
         .metadata
@@ -1112,6 +1117,7 @@ pub fn render_routing_overlay(
         remote_crdt_providers,
         network.spec.region.as_deref(),
         metrics,
+        weights,
     );
 
     let admission_map = build_admission_map(network_name, providers, remote_crdt_providers, metrics);
@@ -1921,6 +1927,14 @@ mod tests {
 
     // -----------------------------------------------------------------------
     // Scoring-engine-backed ordering (OP-05c-a)
+    //
+    // These tests pass `ScoringWeights::default()` — the scoring crate's
+    // legacy combined defaults (locality=3, queue=3, kv=2, …). They verify
+    // overlay rendering mechanics (sort stability, admission, locality tiers)
+    // against the full six-signal surface. Production deploys use
+    // `resolve_scoring_weights(policy)`, which returns strategy-selected
+    // one-hot weights; those paths are covered by the dedicated noMetrics,
+    // queueDepth, and kvCachePressure sections below and in the CRD tests.
     // -----------------------------------------------------------------------
 
     #[test]
@@ -1929,8 +1943,17 @@ mod tests {
         let network = test_network("net");
         let local_prov = test_provider_with_backend_kind("local-prov", "net", "local");
         let api_prov = test_provider_with_backend_kind("api-prov", "net", "api_provider");
-        let overlay = render_routing_overlay(&network, &[], &[api_prov, local_prov], &[], "test-site", None, None)
-            .unwrap_or_else(|_| std::process::abort());
+        let overlay = render_routing_overlay(
+            &network,
+            &[],
+            &[api_prov, local_prov],
+            &[],
+            "test-site",
+            None,
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
         assert_eq!(
             overlay.candidates.first().map(|c| c.cluster.as_str()),
             Some("local-prov"),
@@ -1946,8 +1969,17 @@ mod tests {
         let network = test_network("net");
         let free_prov = test_provider_with_cost("free-prov", "net", 0.0);
         let costly_prov = test_provider_with_cost("costly-prov", "net", 50.0); // 50/million = 0.05/1k
-        let overlay = render_routing_overlay(&network, &[], &[costly_prov, free_prov], &[], "test-site", None, None)
-            .unwrap_or_else(|_| std::process::abort());
+        let overlay = render_routing_overlay(
+            &network,
+            &[],
+            &[costly_prov, free_prov],
+            &[],
+            "test-site",
+            None,
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
         assert_eq!(
             overlay.candidates.first().map(|c| c.cluster.as_str()),
             Some("free-prov"),
@@ -1961,8 +1993,17 @@ mod tests {
         let network = test_network("net");
         let p_z = test_provider_with_backend_kind("z-local", "net", "local");
         let p_a = test_provider_with_backend_kind("a-local", "net", "local");
-        let overlay = render_routing_overlay(&network, &[], &[p_z, p_a], &[], "test-site", None, None)
-            .unwrap_or_else(|_| std::process::abort());
+        let overlay = render_routing_overlay(
+            &network,
+            &[],
+            &[p_z, p_a],
+            &[],
+            "test-site",
+            None,
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
         assert_eq!(
             overlay.candidates.first().map(|c| c.cluster.as_str()),
             Some("a-local"),
@@ -1980,8 +2021,17 @@ mod tests {
         let network = test_network("net");
         let cloud = test_provider_with_backend_kind("cloud-prov", "net", "cloud_managed");
         let unknown = test_provider_with_backend_kind("unknown-prov", "net", "nonexistent_kind");
-        let overlay = render_routing_overlay(&network, &[], &[cloud, unknown], &[], "test-site", None, None)
-            .unwrap_or_else(|_| std::process::abort());
+        let overlay = render_routing_overlay(
+            &network,
+            &[],
+            &[cloud, unknown],
+            &[],
+            "test-site",
+            None,
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
         assert_eq!(
             overlay.candidates.first().map(|c| c.cluster.as_str()),
             Some("unknown-prov"),
@@ -1996,8 +2046,17 @@ mod tests {
         let network = test_network("net");
         let self_hosted = test_provider_with_backend_kind("vllm-prov", "net", "local");
         let api = test_provider_with_backend_kind("api-prov", "net", "api_provider");
-        let overlay = render_routing_overlay(&network, &[], &[api, self_hosted], &[], "test-site", None, None)
-            .unwrap_or_else(|_| std::process::abort());
+        let overlay = render_routing_overlay(
+            &network,
+            &[],
+            &[api, self_hosted],
+            &[],
+            "test-site",
+            None,
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
         assert_eq!(overlay.candidates.len(), 2, "both providers must appear");
         assert_eq!(
             overlay.candidates.first().map(|c| c.cluster.as_str()),
@@ -2020,10 +2079,20 @@ mod tests {
             "test-site",
             None,
             None,
+            &scoring::ScoringWeights::default(),
         )
         .unwrap_or_else(|_| std::process::abort());
-        let rev = render_routing_overlay(&network, &[], &[api, local], &[], "test-site", None, None)
-            .unwrap_or_else(|_| std::process::abort());
+        let rev = render_routing_overlay(
+            &network,
+            &[],
+            &[api, local],
+            &[],
+            "test-site",
+            None,
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
         let fwd_clusters: Vec<&str> = fwd.candidates.iter().map(|c| c.cluster.as_str()).collect();
         let rev_clusters: Vec<&str> = rev.candidates.iter().map(|c| c.cluster.as_str()).collect();
         assert_eq!(
@@ -2040,8 +2109,17 @@ mod tests {
         let network = test_network_with_region("net", "eu-west-1");
         let local = test_provider_with_backend_kind("local-prov", "net", "local");
         let remote = test_provider_with_backend_kind("remote-prov", "net", "remote");
-        let overlay = render_routing_overlay(&network, &[], &[remote, local], &[], "test-site", None, None)
-            .unwrap_or_else(|_| std::process::abort());
+        let overlay = render_routing_overlay(
+            &network,
+            &[],
+            &[remote, local],
+            &[],
+            "test-site",
+            None,
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
         assert_eq!(
             overlay.candidates.first().map(|c| c.cluster.as_str()),
             Some("local-prov"),
@@ -2104,8 +2182,17 @@ mod tests {
         let network = test_network("mesh-net");
         let local_prov = test_provider_with_backend_kind("provider-self-hosted", "mesh-net", "local");
         let remote_prov = test_provider_with_backend_kind("provider-remote", "mesh-net", "remote");
-        let overlay = render_routing_overlay(&network, &[], &[remote_prov, local_prov], &[], "site-a", None, None)
-            .unwrap_or_else(|_| std::process::abort());
+        let overlay = render_routing_overlay(
+            &network,
+            &[],
+            &[remote_prov, local_prov],
+            &[],
+            "site-a",
+            None,
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
 
         assert_eq!(overlay.candidates.len(), 2, "both local and remote must appear");
         // Local must rank first (higher locality/score).
@@ -2138,8 +2225,17 @@ mod tests {
         let local_down =
             test_provider_with_backend_kind_and_phase("provider-local", "fallback-net", "local", "Unavailable");
         let api_fallback = test_provider_with_backend_kind("provider-api", "fallback-net", "api_provider");
-        let overlay = render_routing_overlay(&network, &[], &[local_down, api_fallback], &[], "site-a", None, None)
-            .unwrap_or_else(|_| std::process::abort());
+        let overlay = render_routing_overlay(
+            &network,
+            &[],
+            &[local_down, api_fallback],
+            &[],
+            "site-a",
+            None,
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
 
         assert_eq!(
             overlay.candidates.len(),
@@ -2171,8 +2267,17 @@ mod tests {
         let local_degraded =
             test_provider_with_backend_kind_and_phase("provider-local", "fallback-net", "local", "Degraded");
         let api_ok = test_provider_with_backend_kind("provider-api", "fallback-net", "api_provider");
-        let overlay = render_routing_overlay(&network, &[], &[api_ok, local_degraded], &[], "site-a", None, None)
-            .unwrap_or_else(|_| std::process::abort());
+        let overlay = render_routing_overlay(
+            &network,
+            &[],
+            &[api_ok, local_degraded],
+            &[],
+            "site-a",
+            None,
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
 
         assert_eq!(
             overlay.candidates.len(),
@@ -2216,6 +2321,7 @@ mod tests {
             "site-a",
             None,
             None,
+            &scoring::ScoringWeights::default(),
         )
         .unwrap_or_else(|_| std::process::abort());
 
@@ -2253,6 +2359,7 @@ mod tests {
             "site-a",
             None,
             None,
+            &scoring::ScoringWeights::default(),
         )
         .unwrap_or_else(|_| std::process::abort());
         assert_eq!(
@@ -2276,6 +2383,7 @@ mod tests {
             "site-a",
             None,
             None,
+            &scoring::ScoringWeights::default(),
         )
         .unwrap_or_else(|_| std::process::abort());
         assert_eq!(overlay2.candidates.len(), 2, "recovered local must reappear (cycle 2)");
@@ -2300,8 +2408,17 @@ mod tests {
         let network = test_network("empty-net");
         let p1 = test_provider_with_phase("prov-a", "empty-net", &["model-a"], "Unavailable");
         let p2 = test_provider_with_phase("prov-b", "empty-net", &["model-b"], "Unavailable");
-        let overlay = render_routing_overlay(&network, &[], &[p1, p2], &[], "site-a", None, None)
-            .unwrap_or_else(|_| std::process::abort());
+        let overlay = render_routing_overlay(
+            &network,
+            &[],
+            &[p1, p2],
+            &[],
+            "site-a",
+            None,
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
 
         assert!(
             overlay.candidates.is_empty(),
@@ -2320,8 +2437,17 @@ mod tests {
         let network = test_network("json-net");
         let local_prov = test_provider_with_backend_kind("prov-a", "json-net", "local");
         let api_prov = test_provider_with_backend_kind("prov-b", "json-net", "api_provider");
-        let overlay = render_routing_overlay(&network, &[], &[local_prov, api_prov], &[], "site-a", None, None)
-            .unwrap_or_else(|_| std::process::abort());
+        let overlay = render_routing_overlay(
+            &network,
+            &[],
+            &[local_prov, api_prov],
+            &[],
+            "site-a",
+            None,
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
         let cm = build_cm(&overlay, "json-net", "gw");
         let json = overlay_json_from_cm(&cm);
         let candidates = json
@@ -2434,8 +2560,17 @@ mod tests {
         let network = test_network("net");
         let local_prov = test_provider_with_backend_kind("local-prov", "net", "local");
         let api_prov = test_provider_with_backend_kind("api-prov", "net", "api_provider");
-        let overlay = render_routing_overlay(&network, &[], &[api_prov, local_prov], &[], "test-site", None, None)
-            .unwrap_or_else(|_| std::process::abort());
+        let overlay = render_routing_overlay(
+            &network,
+            &[],
+            &[api_prov, local_prov],
+            &[],
+            "test-site",
+            None,
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
         assert_eq!(
             overlay.candidates.first().map(|c| c.cluster.as_str()),
             Some("local-prov"),
@@ -2459,6 +2594,7 @@ mod tests {
             "test-site",
             None,
             None,
+            &scoring::ScoringWeights::default(),
         )
         .unwrap_or_else(|_| std::process::abort());
         let clusters: Vec<&str> = overlay.candidates.iter().map(|c| c.cluster.as_str()).collect();
@@ -2475,8 +2611,17 @@ mod tests {
         let network = test_network("net");
         let p_z = test_provider_with_backend_kind("z-api", "net", "api_provider");
         let p_a = test_provider_with_backend_kind("a-api", "net", "api_provider");
-        let overlay = render_routing_overlay(&network, &[], &[p_z, p_a], &[], "test-site", None, None)
-            .unwrap_or_else(|_| std::process::abort());
+        let overlay = render_routing_overlay(
+            &network,
+            &[],
+            &[p_z, p_a],
+            &[],
+            "test-site",
+            None,
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
         assert_eq!(
             overlay.candidates.first().map(|c| c.cluster.as_str()),
             Some("a-api"),
@@ -2497,10 +2642,20 @@ mod tests {
             "test-site",
             None,
             None,
+            &scoring::ScoringWeights::default(),
         )
         .unwrap_or_else(|_| std::process::abort());
-        let rev = render_routing_overlay(&network, &[], &[api, local], &[], "test-site", None, None)
-            .unwrap_or_else(|_| std::process::abort());
+        let rev = render_routing_overlay(
+            &network,
+            &[],
+            &[api, local],
+            &[],
+            "test-site",
+            None,
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
         let fwd_clusters: Vec<&str> = fwd.candidates.iter().map(|c| c.cluster.as_str()).collect();
         let rev_clusters: Vec<&str> = rev.candidates.iter().map(|c| c.cluster.as_str()).collect();
         assert_eq!(
@@ -2516,8 +2671,17 @@ mod tests {
         let network = test_network("net");
         let cloud = test_provider_with_backend_kind("cloud-prov", "net", "cloud_managed");
         let unknown = test_provider_with_backend_kind("unknown-prov", "net", "nonexistent_kind");
-        let overlay = render_routing_overlay(&network, &[], &[cloud, unknown], &[], "test-site", None, None)
-            .unwrap_or_else(|_| std::process::abort());
+        let overlay = render_routing_overlay(
+            &network,
+            &[],
+            &[cloud, unknown],
+            &[],
+            "test-site",
+            None,
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
         assert_eq!(
             overlay.candidates.first().map(|c| c.cluster.as_str()),
             Some("unknown-prov"),
@@ -2532,8 +2696,17 @@ mod tests {
     #[test]
     fn empty_network_renders_empty_candidates() {
         let network = test_network("my-net");
-        let overlay = render_routing_overlay(&network, &[], &[], &[], "test-site", None, None)
-            .unwrap_or_else(|_| std::process::abort());
+        let overlay = render_routing_overlay(
+            &network,
+            &[],
+            &[],
+            &[],
+            "test-site",
+            None,
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
         assert!(overlay.candidates.is_empty(), "no providers should yield no candidates");
     }
 
@@ -2541,8 +2714,17 @@ mod tests {
     fn provider_in_different_network_is_excluded() {
         let network = test_network("net-a");
         let provider = test_provider("prov", "net-b", &["model-1"]);
-        let overlay = render_routing_overlay(&network, &[], &[provider], &[], "test-site", None, None)
-            .unwrap_or_else(|_| std::process::abort());
+        let overlay = render_routing_overlay(
+            &network,
+            &[],
+            &[provider],
+            &[],
+            "test-site",
+            None,
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
         assert!(
             overlay.candidates.is_empty(),
             "provider in net-b must be excluded from net-a overlay"
@@ -2553,8 +2735,17 @@ mod tests {
     fn provider_with_two_models_renders_two_candidates() {
         let network = test_network("net-a");
         let provider = test_provider("prov", "net-a", &["model-1", "model-2"]);
-        let overlay = render_routing_overlay(&network, &[], &[provider], &[], "test-site", None, None)
-            .unwrap_or_else(|_| std::process::abort());
+        let overlay = render_routing_overlay(
+            &network,
+            &[],
+            &[provider],
+            &[],
+            "test-site",
+            None,
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
         assert_eq!(overlay.candidates.len(), 2, "two models must produce two candidates");
     }
 
@@ -2563,8 +2754,17 @@ mod tests {
         let network = test_network("net");
         let p1 = test_provider("prov-a", "net", &["llama-3"]);
         let p2 = test_provider("prov-b", "net", &["llama-3"]);
-        let overlay = render_routing_overlay(&network, &[], &[p1, p2], &[], "test-site", None, None)
-            .unwrap_or_else(|_| std::process::abort());
+        let overlay = render_routing_overlay(
+            &network,
+            &[],
+            &[p1, p2],
+            &[],
+            "test-site",
+            None,
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
         assert_eq!(
             overlay.candidates.len(),
             2,
@@ -2580,8 +2780,17 @@ mod tests {
         let network = test_network("net");
         let p1 = test_provider("site-b", "net", &["z-model", "a-model"]);
         let p2 = test_provider("site-a", "net", &["c-model"]);
-        let overlay = render_routing_overlay(&network, &[], &[p1, p2], &[], "test-site", None, None)
-            .unwrap_or_else(|_| std::process::abort());
+        let overlay = render_routing_overlay(
+            &network,
+            &[],
+            &[p1, p2],
+            &[],
+            "test-site",
+            None,
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
         let names: Vec<&str> = overlay.candidates.iter().map(|c| c.name.as_str()).collect();
         assert_eq!(
             names,
@@ -2595,10 +2804,28 @@ mod tests {
         let network = test_network("net");
         let p1 = test_provider("z-site", "net", &["z-model"]);
         let p2 = test_provider("a-site", "net", &["a-model"]);
-        let fwd = render_routing_overlay(&network, &[], &[p1.clone(), p2.clone()], &[], "test-site", None, None)
-            .unwrap_or_else(|_| std::process::abort());
-        let rev = render_routing_overlay(&network, &[], &[p2, p1], &[], "test-site", None, None)
-            .unwrap_or_else(|_| std::process::abort());
+        let fwd = render_routing_overlay(
+            &network,
+            &[],
+            &[p1.clone(), p2.clone()],
+            &[],
+            "test-site",
+            None,
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
+        let rev = render_routing_overlay(
+            &network,
+            &[],
+            &[p2, p1],
+            &[],
+            "test-site",
+            None,
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
         let fwd_names: Vec<&str> = fwd.candidates.iter().map(|c| c.name.as_str()).collect();
         let rev_names: Vec<&str> = rev.candidates.iter().map(|c| c.name.as_str()).collect();
         assert_eq!(
@@ -2611,7 +2838,16 @@ mod tests {
     fn blank_model_name_returns_error() {
         let network = test_network("net");
         let provider = test_provider("prov", "net", &[""]);
-        let result = render_routing_overlay(&network, &[], &[provider], &[], "test-site", None, None);
+        let result = render_routing_overlay(
+            &network,
+            &[],
+            &[provider],
+            &[],
+            "test-site",
+            None,
+            None,
+            &scoring::ScoringWeights::default(),
+        );
         assert!(result.is_err(), "blank model name must return an error");
     }
 
@@ -2625,8 +2861,17 @@ mod tests {
         let site_a = test_site("site-a", "net");
         let site_b = test_site("site-b", "net");
         let provider = test_provider("prov", "net", &["model"]);
-        let overlay = render_routing_overlay(&network, &[site_a, site_b], &[provider], &[], "test-site", None, None)
-            .unwrap_or_else(|_| std::process::abort());
+        let overlay = render_routing_overlay(
+            &network,
+            &[site_a, site_b],
+            &[provider],
+            &[],
+            "test-site",
+            None,
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
         assert_eq!(
             overlay.candidates.len(),
             2,
@@ -2651,6 +2896,7 @@ mod tests {
             "test-site",
             None,
             None,
+            &scoring::ScoringWeights::default(),
         )
         .unwrap_or_else(|_| std::process::abort());
         assert_eq!(
@@ -2669,8 +2915,17 @@ mod tests {
         let network = test_network("net-a");
         let site_other = test_site("site-other", "net-b");
         let provider = test_provider("prov", "net-a", &["model"]);
-        let overlay = render_routing_overlay(&network, &[site_other], &[provider], &[], "test-site", None, None)
-            .unwrap_or_else(|_| std::process::abort());
+        let overlay = render_routing_overlay(
+            &network,
+            &[site_other],
+            &[provider],
+            &[],
+            "test-site",
+            None,
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
         assert_eq!(
             overlay.candidates.len(),
             1,
@@ -2691,8 +2946,17 @@ mod tests {
         let network = test_network("net");
         let site_cpu = test_site_with_labels("cpu-site", "net", &[("hw", "cpu")]);
         let provider = test_provider_with_selector("prov", "net", &["model"], &[("hw", "gpu")]);
-        let overlay = render_routing_overlay(&network, &[site_cpu], &[provider], &[], "test-site", None, None)
-            .unwrap_or_else(|_| std::process::abort());
+        let overlay = render_routing_overlay(
+            &network,
+            &[site_cpu],
+            &[provider],
+            &[],
+            "test-site",
+            None,
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
         assert!(
             overlay.candidates.is_empty(),
             "selector matched nothing in a known site inventory — must emit no candidates"
@@ -2707,8 +2971,17 @@ mod tests {
         let site = test_site("site-a", "net");
         let p1 = test_provider("prov-a", "net", &["shared-model"]);
         let p2 = test_provider("prov-b", "net", &["shared-model"]);
-        let overlay = render_routing_overlay(&network, &[site], &[p1, p2], &[], "test-site", None, None)
-            .unwrap_or_else(|_| std::process::abort());
+        let overlay = render_routing_overlay(
+            &network,
+            &[site],
+            &[p1, p2],
+            &[],
+            "test-site",
+            None,
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
         assert_eq!(
             overlay.candidates.len(),
             2,
@@ -2724,8 +2997,17 @@ mod tests {
         let network = test_network("net");
         let site = test_site("site-a", "net");
         let provider = test_provider("my-provider", "net", &["model"]);
-        let overlay = render_routing_overlay(&network, &[site], &[provider], &[], "test-site", None, None)
-            .unwrap_or_else(|_| std::process::abort());
+        let overlay = render_routing_overlay(
+            &network,
+            &[site],
+            &[provider],
+            &[],
+            "test-site",
+            None,
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
         assert_eq!(
             overlay.candidates[0].cluster, "my-provider",
             "cluster must always equal the provider metadata name"
@@ -2778,8 +3060,17 @@ mod tests {
     fn unavailable_provider_is_excluded() {
         let network = test_network("net");
         let provider = test_provider_with_phase("prov", "net", &["model-1"], "Unavailable");
-        let overlay = render_routing_overlay(&network, &[], &[provider], &[], "test-site", None, None)
-            .unwrap_or_else(|_| std::process::abort());
+        let overlay = render_routing_overlay(
+            &network,
+            &[],
+            &[provider],
+            &[],
+            "test-site",
+            None,
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
         assert!(overlay.candidates.is_empty(), "Unavailable provider must be excluded");
     }
 
@@ -2787,8 +3078,17 @@ mod tests {
     fn available_provider_is_included_with_fresh_true() {
         let network = test_network("net");
         let provider = test_provider_with_phase("prov", "net", &["model-1"], "Available");
-        let overlay = render_routing_overlay(&network, &[], &[provider], &[], "test-site", None, None)
-            .unwrap_or_else(|_| std::process::abort());
+        let overlay = render_routing_overlay(
+            &network,
+            &[],
+            &[provider],
+            &[],
+            "test-site",
+            None,
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
         assert_eq!(overlay.candidates.len(), 1, "Available provider must be included");
         assert!(
             overlay.candidates.first().is_some_and(|c| c.fresh),
@@ -2800,8 +3100,17 @@ mod tests {
     fn pending_provider_is_included_with_fresh_true() {
         let network = test_network("net");
         let provider = test_provider_with_phase("prov", "net", &["model-1"], "Pending");
-        let overlay = render_routing_overlay(&network, &[], &[provider], &[], "test-site", None, None)
-            .unwrap_or_else(|_| std::process::abort());
+        let overlay = render_routing_overlay(
+            &network,
+            &[],
+            &[provider],
+            &[],
+            "test-site",
+            None,
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
         assert_eq!(
             overlay.candidates.len(),
             1,
@@ -2817,8 +3126,17 @@ mod tests {
     fn provider_with_absent_status_is_included_with_fresh_true() {
         let network = test_network("net");
         let provider = test_provider("prov", "net", &["model-1"]);
-        let overlay = render_routing_overlay(&network, &[], &[provider], &[], "test-site", None, None)
-            .unwrap_or_else(|_| std::process::abort());
+        let overlay = render_routing_overlay(
+            &network,
+            &[],
+            &[provider],
+            &[],
+            "test-site",
+            None,
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
         assert_eq!(
             overlay.candidates.len(),
             1,
@@ -2834,8 +3152,17 @@ mod tests {
     fn degraded_provider_is_included_with_fresh_false() {
         let network = test_network("net");
         let provider = test_provider_with_phase("prov", "net", &["model-1"], "Degraded");
-        let overlay = render_routing_overlay(&network, &[], &[provider], &[], "test-site", None, None)
-            .unwrap_or_else(|_| std::process::abort());
+        let overlay = render_routing_overlay(
+            &network,
+            &[],
+            &[provider],
+            &[],
+            "test-site",
+            None,
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
         assert_eq!(
             overlay.candidates.len(),
             1,
@@ -2852,8 +3179,17 @@ mod tests {
         // All models from a Degraded provider inherit fresh=false.
         let network = test_network("net");
         let provider = test_provider_with_phase("prov", "net", &["model-a", "model-b"], "Degraded");
-        let overlay = render_routing_overlay(&network, &[], &[provider], &[], "test-site", None, None)
-            .unwrap_or_else(|_| std::process::abort());
+        let overlay = render_routing_overlay(
+            &network,
+            &[],
+            &[provider],
+            &[],
+            "test-site",
+            None,
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
         assert_eq!(overlay.candidates.len(), 2, "both models must be present");
         assert!(
             overlay.candidates.iter().all(|c| !c.fresh),
@@ -2868,8 +3204,17 @@ mod tests {
         let network = test_network("net");
         let available = test_provider_with_phase("avail-prov", "net", &["model-a"], "Available");
         let degraded = test_provider_with_phase("degr-prov", "net", &["model-a"], "Degraded");
-        let overlay = render_routing_overlay(&network, &[], &[available, degraded], &[], "test-site", None, None)
-            .unwrap_or_else(|_| std::process::abort());
+        let overlay = render_routing_overlay(
+            &network,
+            &[],
+            &[available, degraded],
+            &[],
+            "test-site",
+            None,
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
         assert_eq!(overlay.candidates.len(), 2, "both providers must contribute candidates");
         let avail_candidate = overlay
             .candidates
@@ -2891,8 +3236,17 @@ mod tests {
         // in the ConfigMap and be readable by the overlay consumer.
         let network = test_network("net");
         let provider = test_provider_with_phase("prov", "net", &["model-1"], "Degraded");
-        let overlay = render_routing_overlay(&network, &[], &[provider], &[], "test-site", None, None)
-            .unwrap_or_else(|_| std::process::abort());
+        let overlay = render_routing_overlay(
+            &network,
+            &[],
+            &[provider],
+            &[],
+            "test-site",
+            None,
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
         let cm = build_cm(&overlay, "net", "gw");
         let json = overlay_json_from_cm(&cm);
         let fresh = json
@@ -2913,8 +3267,17 @@ mod tests {
         let site_a = test_site("site-a", "net");
         let site_b = test_site("site-b", "net");
         let provider = test_provider_with_phase("prov", "net", &["model-a"], "Degraded");
-        let overlay = render_routing_overlay(&network, &[site_a, site_b], &[provider], &[], "test-site", None, None)
-            .unwrap_or_else(|_| std::process::abort());
+        let overlay = render_routing_overlay(
+            &network,
+            &[site_a, site_b],
+            &[provider],
+            &[],
+            "test-site",
+            None,
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
         assert_eq!(overlay.candidates.len(), 2, "one candidate per matched site");
         assert!(
             overlay.candidates.iter().all(|c| !c.fresh),
@@ -2936,8 +3299,17 @@ mod tests {
         // Stale provider is given Degraded status so is_candidate_fresh returns false.
         let healthy = test_provider("healthy-prov", "net", &["shared-model"]);
         let stale = test_provider_with_phase("stale-prov", "net", &["shared-model"], "Degraded");
-        let overlay = render_routing_overlay(&network, &[], &[stale, healthy], &[], "test-site", None, None)
-            .unwrap_or_else(|_| std::process::abort());
+        let overlay = render_routing_overlay(
+            &network,
+            &[],
+            &[stale, healthy],
+            &[],
+            "test-site",
+            None,
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
 
         assert_eq!(overlay.candidates.len(), 2, "both candidates must be present");
         let first = overlay.candidates.first().unwrap_or_else(|| std::process::abort());
@@ -2961,8 +3333,17 @@ mod tests {
         // observability and as a last-resort fallback when no healthy alternative exists.
         let network = test_network("net");
         let stale = test_provider_with_phase("stale-prov", "net", &["model-x"], "Degraded");
-        let overlay = render_routing_overlay(&network, &[], &[stale], &[], "test-site", None, None)
-            .unwrap_or_else(|_| std::process::abort());
+        let overlay = render_routing_overlay(
+            &network,
+            &[],
+            &[stale],
+            &[],
+            "test-site",
+            None,
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
         assert_eq!(overlay.candidates.len(), 1, "stale candidate must not be dropped");
         assert!(
             overlay.candidates.first().is_some_and(|c| !c.fresh),
@@ -2991,6 +3372,7 @@ mod tests {
             "test-site",
             None,
             None,
+            &scoring::ScoringWeights::default(),
         )
         .unwrap_or_else(|_| std::process::abort());
         assert_eq!(overlay.candidates.len(), 2, "both local and remote candidates present");
@@ -3017,12 +3399,21 @@ mod tests {
             "test-site",
             None,
             None,
+            &scoring::ScoringWeights::default(),
         )
         .unwrap_or_else(|_| std::process::abort());
         // Submit healthy first, then stale.
-        let overlay_healthy_first =
-            render_routing_overlay(&network, &[], &[healthy, stale], &[], "test-site", None, None)
-                .unwrap_or_else(|_| std::process::abort());
+        let overlay_healthy_first = render_routing_overlay(
+            &network,
+            &[],
+            &[healthy, stale],
+            &[],
+            "test-site",
+            None,
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
 
         let first_stale_first = overlay_stale_first
             .candidates
@@ -3049,8 +3440,17 @@ mod tests {
     #[test]
     fn configmap_name_matches_pattern() {
         let network = test_network("my-net");
-        let overlay = render_routing_overlay(&network, &[], &[], &[], "test-site", None, None)
-            .unwrap_or_else(|_| std::process::abort());
+        let overlay = render_routing_overlay(
+            &network,
+            &[],
+            &[],
+            &[],
+            "test-site",
+            None,
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
         let cm = build_cm(&overlay, "my-net", "gw");
         assert_eq!(
             cm.metadata.name.as_deref(),
@@ -3062,8 +3462,17 @@ mod tests {
     #[test]
     fn configmap_has_correct_labels() {
         let network = test_network("net");
-        let overlay = render_routing_overlay(&network, &[], &[], &[], "test-site", None, None)
-            .unwrap_or_else(|_| std::process::abort());
+        let overlay = render_routing_overlay(
+            &network,
+            &[],
+            &[],
+            &[],
+            "test-site",
+            None,
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
         let cm = build_cm(&overlay, "net", "gw");
         let labels = cm.metadata.labels.as_ref().unwrap_or_else(|| std::process::abort());
         assert_eq!(
@@ -3083,8 +3492,17 @@ mod tests {
     #[test]
     fn configmap_data_key_is_grid_config_json() {
         let network = test_network("net");
-        let overlay = render_routing_overlay(&network, &[], &[], &[], "test-site", None, None)
-            .unwrap_or_else(|_| std::process::abort());
+        let overlay = render_routing_overlay(
+            &network,
+            &[],
+            &[],
+            &[],
+            "test-site",
+            None,
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
         let cm = build_cm(&overlay, "net", "gw");
         assert!(
             cm.data.as_ref().is_some_and(|d| d.contains_key("routing-config.json")),
@@ -3098,8 +3516,17 @@ mod tests {
         // Serialization of RoutingOverlay cannot currently fail (all fields
         // are plain Strings / booleans), so we just verify the Ok path.
         let network = test_network("net");
-        let overlay = render_routing_overlay(&network, &[], &[], &[], "test-site", None, None)
-            .unwrap_or_else(|_| std::process::abort());
+        let overlay = render_routing_overlay(
+            &network,
+            &[],
+            &[],
+            &[],
+            "test-site",
+            None,
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
         let result = build_overlay_configmap(&overlay, None, "net", "gw", "ns");
         assert!(result.is_ok(), "well-formed overlay must serialize without error");
     }
@@ -3152,8 +3579,17 @@ mod tests {
     #[test]
     fn json_overlay_has_correct_top_level_fields() {
         let network = test_network("my-net");
-        let overlay = render_routing_overlay(&network, &[], &[], &[], "site-a", None, None)
-            .unwrap_or_else(|_| std::process::abort());
+        let overlay = render_routing_overlay(
+            &network,
+            &[],
+            &[],
+            &[],
+            "site-a",
+            None,
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
         let value = overlay_json_from_cm(&build_cm(&overlay, "my-net", "gw"));
         assert_eq!(value.get("network").and_then(serde_json::Value::as_str), Some("my-net"));
         assert_eq!(
@@ -3166,8 +3602,17 @@ mod tests {
     #[test]
     fn local_site_parameter_flows_to_overlay() {
         let network = test_network("my-net");
-        let overlay = render_routing_overlay(&network, &[], &[], &[], "site-a", None, None)
-            .unwrap_or_else(|_| std::process::abort());
+        let overlay = render_routing_overlay(
+            &network,
+            &[],
+            &[],
+            &[],
+            "site-a",
+            None,
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
         assert_eq!(
             overlay.local_site, "site-a",
             "local_site parameter must appear verbatim in the overlay"
@@ -3179,10 +3624,28 @@ mod tests {
     fn different_local_site_per_call_produces_different_overlays() {
         // Simulates two gateways in the same network declaring different local sites.
         let network = test_network("my-net");
-        let overlay_a = render_routing_overlay(&network, &[], &[], &[], "site-a", None, None)
-            .unwrap_or_else(|_| std::process::abort());
-        let overlay_b = render_routing_overlay(&network, &[], &[], &[], "site-b", None, None)
-            .unwrap_or_else(|_| std::process::abort());
+        let overlay_a = render_routing_overlay(
+            &network,
+            &[],
+            &[],
+            &[],
+            "site-a",
+            None,
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
+        let overlay_b = render_routing_overlay(
+            &network,
+            &[],
+            &[],
+            &[],
+            "site-b",
+            None,
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
         assert_eq!(overlay_a.local_site, "site-a", "gateway A must identify site-a");
         assert_eq!(overlay_b.local_site, "site-b", "gateway B must identify site-b");
         assert_eq!(
@@ -3195,8 +3658,17 @@ mod tests {
     fn json_candidate_has_correct_fields() {
         let network = test_network("my-net");
         let provider = test_provider("prov-a", "my-net", &["granite-3.3-8b"]);
-        let overlay = render_routing_overlay(&network, &[], &[provider], &[], "test-site", None, None)
-            .unwrap_or_else(|_| std::process::abort());
+        let overlay = render_routing_overlay(
+            &network,
+            &[],
+            &[provider],
+            &[],
+            "test-site",
+            None,
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
         let value = overlay_json_from_cm(&build_cm(&overlay, "my-net", "gw"));
         let c = value
             .get("candidates")
@@ -3230,7 +3702,16 @@ mod tests {
             "spec": { "seeds": [] }
         }))
         .unwrap_or_else(|_| std::process::abort());
-        let result = render_routing_overlay(&network, &[], &[], &[], "local", None, None);
+        let result = render_routing_overlay(
+            &network,
+            &[],
+            &[],
+            &[],
+            "local",
+            None,
+            None,
+            &scoring::ScoringWeights::default(),
+        );
         assert!(result.is_err(), "network without metadata.name must return an error");
     }
 
@@ -3251,7 +3732,16 @@ mod tests {
             }
         }))
         .unwrap_or_else(|_| std::process::abort());
-        let result = render_routing_overlay(&network, &[], &[provider], &[], "local", None, None);
+        let result = render_routing_overlay(
+            &network,
+            &[],
+            &[provider],
+            &[],
+            "local",
+            None,
+            None,
+            &scoring::ScoringWeights::default(),
+        );
         assert!(
             result.is_err(),
             "InferenceProvider without metadata.name must return an error"
@@ -3281,7 +3771,14 @@ mod tests {
         );
 
         let providers_for_ordering = [provider_busy, provider_idle];
-        let ordering = provider_ordering_scores("net", &providers_for_ordering, &[], None, Some(&metrics));
+        let ordering = provider_ordering_scores(
+            "net",
+            &providers_for_ordering,
+            &[],
+            None,
+            Some(&metrics),
+            &scoring::ScoringWeights::default(),
+        );
 
         let busy_score = ordering["provider-busy"].total;
         let idle_score = ordering["provider-idle"].total;
@@ -3299,9 +3796,17 @@ mod tests {
         let local = test_provider_with_backend_kind("prov-local", "net", "local");
         let api = test_provider_with_backend_kind("prov-api", "net", "api_provider");
         let ps_static = [local.clone(), api.clone()];
-        let ordering_static = provider_ordering_scores("net", &ps_static, &[], None, None);
+        let ordering_static =
+            provider_ordering_scores("net", &ps_static, &[], None, None, &scoring::ScoringWeights::default());
         let ps_empty = [local, api];
-        let ordering_no_metrics = provider_ordering_scores("net", &ps_empty, &[], None, Some(&HashMap::new()));
+        let ordering_no_metrics = provider_ordering_scores(
+            "net",
+            &ps_empty,
+            &[],
+            None,
+            Some(&HashMap::new()),
+            &scoring::ScoringWeights::default(),
+        );
         assert_eq!(
             ordering_static["prov-local"].total, ordering_no_metrics["prov-local"].total,
             "empty metrics map must yield same score as None"
@@ -3309,6 +3814,240 @@ mod tests {
         assert_eq!(
             ordering_static["prov-api"].total, ordering_no_metrics["prov-api"].total,
             "empty metrics map must yield same score as None"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // noMetrics strategy — overlay rendering with production default weights
+    //
+    // Weight resolution itself is tested in crd::grid_network::tests.
+    // These tests verify overlay-level behavior: that zero weights produce
+    // zero breakdowns, that admission and geography still apply, and that
+    // scoreFirst does not manufacture a preference.
+    // -----------------------------------------------------------------------
+
+    fn no_metrics_weights() -> scoring::ScoringWeights {
+        crate::crd::grid_network::resolve_scoring_weights(None)
+    }
+
+    fn assert_weight(actual: f64, expected: f64, label: &str) {
+        assert!(
+            (actual - expected).abs() < f64::EPSILON,
+            "{label}: expected {expected}, got {actual}"
+        );
+    }
+
+    #[test]
+    fn no_metrics_all_score_contributions_are_zero() {
+        let a = test_provider_with_backend_kind("prov-a", "net", "local");
+        let b = test_provider_with_backend_kind("prov-b", "net", "local");
+        let network = test_network("net");
+
+        let mut metrics = HashMap::new();
+        metrics.insert(
+            "prov-a",
+            scoring::BackendMetrics::new(0.0, true, 0.80, 100.0, 0.0, 0.10),
+        );
+        metrics.insert(
+            "prov-b",
+            scoring::BackendMetrics::new(0.0, true, 0.20, 100.0, 0.0, 0.90),
+        );
+
+        let overlay = render_routing_overlay(
+            &network,
+            &[],
+            &[a, b],
+            &[],
+            "gw",
+            Some(&metrics),
+            None,
+            &no_metrics_weights(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
+
+        for c in &overlay.candidates {
+            let bd = c.score_breakdown.as_ref().unwrap_or_else(|| std::process::abort());
+            assert_weight(bd.queue_depth, 0.0, &format!("{}: queue_depth", c.cluster));
+            assert_weight(bd.kv_cache, 0.0, &format!("{}: kv_cache", c.cluster));
+            assert_weight(bd.locality, 0.0, &format!("{}: locality", c.cluster));
+            assert_weight(bd.prefix_cache, 0.0, &format!("{}: prefix_cache", c.cluster));
+            assert_weight(bd.latency, 0.0, &format!("{}: latency", c.cluster));
+            assert_weight(bd.cost, 0.0, &format!("{}: cost", c.cluster));
+            assert_weight(bd.total, 0.0, &format!("{}: total", c.cluster));
+        }
+    }
+
+    #[test]
+    fn no_metrics_opposing_metrics_produce_equal_dynamic_scores() {
+        let a = test_provider_with_backend_kind("prov-a", "net", "local");
+        let b = test_provider_with_backend_kind("prov-b", "net", "local");
+        let network = test_network_score_first("net");
+
+        let mut metrics = HashMap::new();
+        metrics.insert(
+            "prov-a",
+            scoring::BackendMetrics::new(0.0, true, 0.80, 100.0, 0.0, 0.10),
+        );
+        metrics.insert(
+            "prov-b",
+            scoring::BackendMetrics::new(0.0, true, 0.20, 100.0, 0.0, 0.90),
+        );
+
+        let overlay = render_routing_overlay(
+            &network,
+            &[],
+            &[a, b],
+            &[],
+            "gw",
+            Some(&metrics),
+            None,
+            &no_metrics_weights(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
+
+        let scores: Vec<f64> = overlay.candidates.iter().map(|c| c.score.unwrap_or(f64::NAN)).collect();
+        assert_eq!(scores.len(), 2);
+        assert_weight(
+            scores[0],
+            scores[1],
+            "both providers must have equal dynamic scores under noMetrics",
+        );
+    }
+
+    #[test]
+    fn no_metrics_geography_first_still_prefers_local() {
+        let local = test_provider_with_backend_kind("prov-local", "net", "local");
+        let remote = test_provider_with_backend_kind("prov-remote", "net", "remote");
+        let network = test_network("net");
+
+        let mut metrics = HashMap::new();
+        metrics.insert(
+            "prov-local",
+            scoring::BackendMetrics::new(0.0, true, 0.80, 0.0, 0.0, 0.80),
+        );
+        metrics.insert(
+            "prov-remote",
+            scoring::BackendMetrics::new(0.0, true, 0.01, 0.0, 0.0, 0.01),
+        );
+
+        let overlay = render_routing_overlay(
+            &network,
+            &[],
+            &[remote, local],
+            &[],
+            "prov-local",
+            Some(&metrics),
+            None,
+            &no_metrics_weights(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
+
+        assert_eq!(
+            overlay.candidates.first().map(|c| c.cluster.as_str()),
+            Some("prov-local"),
+            "geographyFirst with noMetrics: local must rank first despite worse metrics"
+        );
+    }
+
+    #[test]
+    fn no_metrics_admission_still_restricts_saturated_provider() {
+        let healthy = test_provider_with_backend_kind("prov-healthy", "net", "api_provider");
+        let saturated = test_provider_with_backend_kind("prov-saturated", "net", "local");
+        let network = test_network("net");
+
+        let mut metrics = HashMap::new();
+        metrics.insert(
+            "prov-saturated",
+            scoring::BackendMetrics::new(0.0, true, 0.95, 0.0, 0.0, 0.95),
+        );
+        metrics.insert(
+            "prov-healthy",
+            scoring::BackendMetrics::new(0.0, true, 0.1, 0.0, 0.0, 0.1),
+        );
+
+        let overlay = render_routing_overlay(
+            &network,
+            &[],
+            &[saturated, healthy],
+            &[],
+            "gw",
+            Some(&metrics),
+            None,
+            &no_metrics_weights(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
+
+        assert_eq!(
+            overlay.candidates.first().map(|c| c.cluster.as_str()),
+            Some("prov-healthy"),
+            "noMetrics: admission must still order NewAndExisting above ExistingOnly"
+        );
+        assert_eq!(
+            overlay.candidates[0].admission_state,
+            Some(AdmissionState::NewAndExisting),
+            "first candidate must be NewAndExisting under noMetrics"
+        );
+    }
+
+    #[test]
+    fn no_metrics_unavailable_provider_still_excluded() {
+        let available = test_provider_with_backend_kind("prov-up", "net", "local");
+        let unavailable = test_provider_with_backend_kind_and_phase("prov-down", "net", "local", "Unavailable");
+
+        let network = test_network("net");
+        let overlay = render_routing_overlay(
+            &network,
+            &[],
+            &[available, unavailable],
+            &[],
+            "gw",
+            None,
+            None,
+            &no_metrics_weights(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
+
+        let names: Vec<&str> = overlay.candidates.iter().map(|c| c.cluster.as_str()).collect();
+        assert!(names.contains(&"prov-up"), "available provider must appear in overlay");
+        assert!(
+            !names.contains(&"prov-down"),
+            "unavailable provider must be excluded even under noMetrics"
+        );
+    }
+
+    #[test]
+    fn no_metrics_score_first_does_not_manufacture_preference() {
+        let a = test_provider_with_backend_kind("prov-a", "net", "local");
+        let b = test_provider_with_backend_kind("prov-b", "net", "local");
+        let network = test_network_score_first("net");
+
+        let mut metrics = HashMap::new();
+        metrics.insert(
+            "prov-a",
+            scoring::BackendMetrics::new(0.0, true, 0.90, 100.0, 0.0, 0.99),
+        );
+        metrics.insert(
+            "prov-b",
+            scoring::BackendMetrics::new(0.0, true, 0.01, 100.0, 0.0, 0.01),
+        );
+
+        let overlay = render_routing_overlay(
+            &network,
+            &[],
+            &[a, b],
+            &[],
+            "gw",
+            Some(&metrics),
+            None,
+            &no_metrics_weights(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
+
+        let scores: Vec<f64> = overlay.candidates.iter().map(|c| c.score.unwrap_or(f64::NAN)).collect();
+        assert_weight(
+            scores[0],
+            scores[1],
+            "scoreFirst with noMetrics: extreme metric differences must not create score preference",
         );
     }
 
@@ -3336,8 +4075,17 @@ mod tests {
             scoring::BackendMetrics::new(0.0, true, 0.0, 0.0, 0.0, 0.1),
         );
 
-        let overlay = render_routing_overlay(&network, &[], &[busy, idle], &[], "local-gw", Some(&metrics), None)
-            .unwrap_or_else(|_| std::process::abort());
+        let overlay = render_routing_overlay(
+            &network,
+            &[],
+            &[busy, idle],
+            &[],
+            "local-gw",
+            Some(&metrics),
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
 
         // idle (queue_depth=0.1) must rank before busy (queue_depth=0.9).
         let first = overlay.candidates.first().map(|c| c.cluster.as_str());
@@ -3357,12 +4105,29 @@ mod tests {
         let api = test_provider_with_backend_kind("prov-api", "net", "api_provider");
         let network = test_network("net");
 
-        let overlay_none = render_routing_overlay(&network, &[], &[api.clone(), local.clone()], &[], "gw", None, None)
-            .unwrap_or_else(|_| std::process::abort());
+        let overlay_none = render_routing_overlay(
+            &network,
+            &[],
+            &[api.clone(), local.clone()],
+            &[],
+            "gw",
+            None,
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
 
-        let overlay_empty =
-            render_routing_overlay(&network, &[], &[api, local], &[], "gw", Some(&HashMap::new()), None)
-                .unwrap_or_else(|_| std::process::abort());
+        let overlay_empty = render_routing_overlay(
+            &network,
+            &[],
+            &[api, local],
+            &[],
+            "gw",
+            Some(&HashMap::new()),
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
 
         assert_eq!(
             overlay_none.candidates[0].cluster, overlay_empty.candidates[0].cluster,
@@ -3391,8 +4156,17 @@ mod tests {
         );
         // "unmapped-prov" intentionally absent from the metrics map.
 
-        let overlay = render_routing_overlay(&network, &[], &[known, unmapped], &[], "gw", Some(&metrics), None)
-            .unwrap_or_else(|_| std::process::abort());
+        let overlay = render_routing_overlay(
+            &network,
+            &[],
+            &[known, unmapped],
+            &[],
+            "gw",
+            Some(&metrics),
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
 
         assert_eq!(
             overlay.candidates.len(),
@@ -3462,8 +4236,17 @@ mod tests {
             scoring::BackendMetrics::new(0.0, true, 0.1, 0.0, 0.0, 0.1),
         );
 
-        let overlay = render_routing_overlay(&network, &[], &[local, remote], &[], "gw", Some(&metrics), None)
-            .unwrap_or_else(|_| std::process::abort());
+        let overlay = render_routing_overlay(
+            &network,
+            &[],
+            &[local, remote],
+            &[],
+            "gw",
+            Some(&metrics),
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
 
         assert_eq!(
             overlay.candidates.first().map(|c| c.cluster.as_str()),
@@ -3488,8 +4271,17 @@ mod tests {
             scoring::BackendMetrics::new(0.0, true, 0.3, 100.0, 0.5, 0.3),
         );
 
-        let overlay = render_routing_overlay(&network, &[], &[local, remote], &[], "gw", Some(&metrics), None)
-            .unwrap_or_else(|_| std::process::abort());
+        let overlay = render_routing_overlay(
+            &network,
+            &[],
+            &[local, remote],
+            &[],
+            "gw",
+            Some(&metrics),
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
 
         assert_eq!(
             overlay.candidates.first().map(|c| c.cluster.as_str()),
@@ -3504,8 +4296,17 @@ mod tests {
         let api = test_provider_with_backend_kind("prov-api", "net", "api_provider");
         let network = test_network_score_first("net");
 
-        let overlay = render_routing_overlay(&network, &[], &[local, api], &[], "gw", None, None)
-            .unwrap_or_else(|_| std::process::abort());
+        let overlay = render_routing_overlay(
+            &network,
+            &[],
+            &[local, api],
+            &[],
+            "gw",
+            None,
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
 
         let first = &overlay.candidates[0];
         assert!(first.fresh, "first candidate must be fresh");
@@ -3532,8 +4333,17 @@ mod tests {
             scoring::BackendMetrics::new(0.0, true, 0.1, 0.0, 0.0, 0.1),
         );
 
-        let overlay = render_routing_overlay(&network, &[], &[saturated, healthy], &[], "gw", Some(&metrics), None)
-            .unwrap_or_else(|_| std::process::abort());
+        let overlay = render_routing_overlay(
+            &network,
+            &[],
+            &[saturated, healthy],
+            &[],
+            "gw",
+            Some(&metrics),
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
 
         assert_eq!(
             overlay.candidates.first().map(|c| c.cluster.as_str()),
@@ -3563,8 +4373,17 @@ mod tests {
             scoring::BackendMetrics::new(0.0, true, 0.3, 500.0, 0.4, 0.2),
         );
 
-        let overlay = render_routing_overlay(&network, &[], &[local], &[], "gw", Some(&metrics), None)
-            .unwrap_or_else(|_| std::process::abort());
+        let overlay = render_routing_overlay(
+            &network,
+            &[],
+            &[local],
+            &[],
+            "gw",
+            Some(&metrics),
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
 
         let c = &overlay.candidates[0];
         assert!(c.score.is_some(), "candidate must have a score");
@@ -3598,10 +4417,28 @@ mod tests {
         .unwrap_or_else(|_| std::process::abort());
 
         let providers = [local, remote, api];
-        let overlay_default = render_routing_overlay(&no_policy, &[], &providers, &[], "gw", None, None)
-            .unwrap_or_else(|_| std::process::abort());
-        let overlay_geo = render_routing_overlay(&geo_policy, &[], &providers, &[], "gw", None, None)
-            .unwrap_or_else(|_| std::process::abort());
+        let overlay_default = render_routing_overlay(
+            &no_policy,
+            &[],
+            &providers,
+            &[],
+            "gw",
+            None,
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
+        let overlay_geo = render_routing_overlay(
+            &geo_policy,
+            &[],
+            &providers,
+            &[],
+            "gw",
+            None,
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
 
         let order_default: Vec<&str> = overlay_default.candidates.iter().map(|c| c.cluster.as_str()).collect();
         let order_geo: Vec<&str> = overlay_geo.candidates.iter().map(|c| c.cluster.as_str()).collect();
@@ -3627,8 +4464,17 @@ mod tests {
             scoring::BackendMetrics::new(0.0, true, 0.1, 0.0, 0.0, 0.1),
         );
 
-        let overlay = render_routing_overlay(&network, &[], &[local, remote], &[], "local-site", Some(&metrics), None)
-            .unwrap_or_else(|_| std::process::abort());
+        let overlay = render_routing_overlay(
+            &network,
+            &[],
+            &[local, remote],
+            &[],
+            "local-site",
+            Some(&metrics),
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
 
         assert_eq!(
             overlay.candidates.first().map(|c| c.cluster.as_str()),
@@ -3699,8 +4545,17 @@ mod tests {
     fn routing_cluster_ref_appears_in_candidate_cluster() {
         let network = test_network("net");
         let provider = test_provider_with_routing_cluster_ref("prov-a", "net", Some("gateway-site-x"));
-        let overlay = render_routing_overlay(&network, &[], &[provider], &[], "test-site", None, None)
-            .unwrap_or_else(|_| std::process::abort());
+        let overlay = render_routing_overlay(
+            &network,
+            &[],
+            &[provider],
+            &[],
+            "test-site",
+            None,
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
         assert_eq!(overlay.candidates.len(), 1, "one candidate");
         assert_eq!(
             overlay.candidates.first().map(|c| c.cluster.as_str()),
@@ -3714,8 +4569,17 @@ mod tests {
         // In Phase 1 (no GridSites), site = routingClusterRef.
         let network = test_network("net");
         let provider = test_provider_with_routing_cluster_ref("prov-a", "net", Some("site-x"));
-        let overlay = render_routing_overlay(&network, &[], &[provider], &[], "test-site", None, None)
-            .unwrap_or_else(|_| std::process::abort());
+        let overlay = render_routing_overlay(
+            &network,
+            &[],
+            &[provider],
+            &[],
+            "test-site",
+            None,
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
         assert_eq!(
             overlay.candidates.first().map(|c| c.site.as_str()),
             Some("site-x"),
@@ -3740,8 +4604,17 @@ mod tests {
             }
         }))
         .unwrap_or_else(|_| std::process::abort());
-        let overlay = render_routing_overlay(&network, &[], &[provider], &[], "test-site", None, None)
-            .unwrap_or_else(|_| std::process::abort());
+        let overlay = render_routing_overlay(
+            &network,
+            &[],
+            &[provider],
+            &[],
+            "test-site",
+            None,
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
         assert_eq!(overlay.candidates.len(), 2, "two model candidates");
         assert!(
             overlay.candidates.iter().all(|c| c.cluster == "gateway-site-x"),
@@ -3757,8 +4630,17 @@ mod tests {
         let p2 = test_provider_with_routing_cluster_ref("prov-b", "net", Some("site-x"));
         // Both produce (kind=inference_model, name=model-x, site=site-x, cluster=site-x)
         // They share the same cluster and site, so after dedup there should be ONE entry.
-        let overlay = render_routing_overlay(&network, &[], &[p1, p2], &[], "test-site", None, None)
-            .unwrap_or_else(|_| std::process::abort());
+        let overlay = render_routing_overlay(
+            &network,
+            &[],
+            &[p1, p2],
+            &[],
+            "test-site",
+            None,
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
         assert_eq!(
             overlay.candidates.len(),
             1,
@@ -3784,8 +4666,17 @@ mod tests {
             "status": { "phase": "Unavailable", "matchingSites": [], "observedGeneration": 0 }
         }))
         .unwrap_or_else(|_| std::process::abort());
-        let overlay = render_routing_overlay(&network, &[], &[provider], &[], "test-site", None, None)
-            .unwrap_or_else(|_| std::process::abort());
+        let overlay = render_routing_overlay(
+            &network,
+            &[],
+            &[provider],
+            &[],
+            "test-site",
+            None,
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
         assert!(
             overlay.candidates.is_empty(),
             "Unavailable must be excluded even with routingClusterRef"
@@ -3810,8 +4701,17 @@ mod tests {
             "status": { "phase": "Degraded", "matchingSites": [], "observedGeneration": 0 }
         }))
         .unwrap_or_else(|_| std::process::abort());
-        let overlay = render_routing_overlay(&network, &[], &[provider], &[], "test-site", None, None)
-            .unwrap_or_else(|_| std::process::abort());
+        let overlay = render_routing_overlay(
+            &network,
+            &[],
+            &[provider],
+            &[],
+            "test-site",
+            None,
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
         assert_eq!(overlay.candidates.len(), 1, "Degraded must be included");
         assert!(
             overlay.candidates.first().is_some_and(|c| !c.fresh),
@@ -3850,6 +4750,7 @@ mod tests {
             "test-site",
             None,
             None,
+            &scoring::ScoringWeights::default(),
         )
         .unwrap_or_else(|_| std::process::abort());
         assert_eq!(overlay.candidates.len(), 2, "two candidates");
@@ -4167,8 +5068,17 @@ mod tests {
             crdt::ProviderPhase::Available,
             &["model-remote"],
         );
-        let overlay = render_routing_overlay(&network, &[], &[], &[remote], "local-site", None, None)
-            .unwrap_or_else(|_| std::process::abort());
+        let overlay = render_routing_overlay(
+            &network,
+            &[],
+            &[],
+            &[remote],
+            "local-site",
+            None,
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
         assert_eq!(
             overlay.candidates.len(),
             1,
@@ -4193,8 +5103,17 @@ mod tests {
             crdt::ProviderPhase::Unavailable,
             &["model-remote"],
         );
-        let overlay = render_routing_overlay(&network, &[], &[], &[unavailable], "local-site", None, None)
-            .unwrap_or_else(|_| std::process::abort());
+        let overlay = render_routing_overlay(
+            &network,
+            &[],
+            &[],
+            &[unavailable],
+            "local-site",
+            None,
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
         assert!(
             overlay.candidates.is_empty(),
             "Unavailable CRDT provider must be excluded from overlay"
@@ -4301,8 +5220,17 @@ mod tests {
     fn bearer_token_candidate_carries_credential_ref() {
         let network = test_network("net");
         let provider = test_provider_with_bearer_auth("api-prov", "net");
-        let overlay = render_routing_overlay(&network, &[], &[provider], &[], "site-a", None, None)
-            .unwrap_or_else(|_| std::process::abort());
+        let overlay = render_routing_overlay(
+            &network,
+            &[],
+            &[provider],
+            &[],
+            "site-a",
+            None,
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
         let cred = overlay
             .candidates
             .first()
@@ -4318,8 +5246,17 @@ mod tests {
     fn credential_ref_in_configmap_json_contains_secret_ref_not_token_value() {
         let network = test_network("net");
         let provider = test_provider_with_bearer_auth("api-prov", "net");
-        let overlay = render_routing_overlay(&network, &[], &[provider], &[], "site-a", None, None)
-            .unwrap_or_else(|_| std::process::abort());
+        let overlay = render_routing_overlay(
+            &network,
+            &[],
+            &[provider],
+            &[],
+            "site-a",
+            None,
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
         let cm = build_cm(&overlay, "net", "gw");
         let json = overlay_json_from_cm(&cm);
         let candidate = json
@@ -4348,8 +5285,17 @@ mod tests {
     fn no_auth_candidate_has_no_credential_field_in_json() {
         let network = test_network("net");
         let provider = test_provider("no-auth", "net", &["model-a"]);
-        let overlay = render_routing_overlay(&network, &[], &[provider], &[], "site-a", None, None)
-            .unwrap_or_else(|_| std::process::abort());
+        let overlay = render_routing_overlay(
+            &network,
+            &[],
+            &[provider],
+            &[],
+            "site-a",
+            None,
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
         let cm = build_cm(&overlay, "net", "gw");
         let json = overlay_json_from_cm(&cm);
         let candidate = json
@@ -4367,8 +5313,17 @@ mod tests {
     fn manual_auth_candidate_has_no_credential_field_in_json() {
         let network = test_network("net");
         let provider = test_provider_with_manual_auth("manual-prov", "net");
-        let overlay = render_routing_overlay(&network, &[], &[provider], &[], "site-a", None, None)
-            .unwrap_or_else(|_| std::process::abort());
+        let overlay = render_routing_overlay(
+            &network,
+            &[],
+            &[provider],
+            &[],
+            "site-a",
+            None,
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
         let cm = build_cm(&overlay, "net", "gw");
         let json = overlay_json_from_cm(&cm);
         let candidate = json
@@ -4714,8 +5669,17 @@ mod tests {
     fn render_overlay_local_providers_unchanged_with_empty_remote() {
         let network = test_network("net");
         let local_prov = test_provider_with_backend_kind("prov-local", "net", "local");
-        let overlay = render_routing_overlay(&network, &[], &[local_prov], &[], "local-site", None, None)
-            .unwrap_or_else(|_| std::process::abort());
+        let overlay = render_routing_overlay(
+            &network,
+            &[],
+            &[local_prov],
+            &[],
+            "local-site",
+            None,
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
         assert_eq!(
             overlay.candidates.len(),
             1,
@@ -4930,6 +5894,7 @@ mod tests {
             "site-prod",
             None,
             None,
+            &scoring::ScoringWeights::default(),
         )
         .unwrap_or_else(|_| std::process::abort());
         assert_eq!(
@@ -4950,6 +5915,7 @@ mod tests {
             "site-staging",
             None,
             None,
+            &scoring::ScoringWeights::default(),
         )
         .unwrap_or_else(|_| std::process::abort());
         assert_eq!(
@@ -4978,6 +5944,7 @@ mod tests {
             "site-prod",
             None,
             None,
+            &scoring::ScoringWeights::default(),
         )
         .unwrap_or_else(|_| std::process::abort());
         assert_eq!(
@@ -4999,6 +5966,7 @@ mod tests {
             "site-staging",
             None,
             None,
+            &scoring::ScoringWeights::default(),
         )
         .unwrap_or_else(|_| std::process::abort());
         assert_eq!(
@@ -5031,6 +5999,7 @@ mod tests {
             "site-prod",
             None,
             None,
+            &scoring::ScoringWeights::default(),
         )
         .unwrap_or_else(|_| std::process::abort());
         assert_eq!(
@@ -5048,6 +6017,7 @@ mod tests {
             "site-staging",
             None,
             None,
+            &scoring::ScoringWeights::default(),
         )
         .unwrap_or_else(|_| std::process::abort());
         assert_eq!(
@@ -5065,6 +6035,7 @@ mod tests {
             "site-other",
             None,
             None,
+            &scoring::ScoringWeights::default(),
         )
         .unwrap_or_else(|_| std::process::abort());
         assert_eq!(
@@ -5092,6 +6063,7 @@ mod tests {
             "unknown-site",
             None,
             None,
+            &scoring::ScoringWeights::default(),
         )
         .unwrap_or_else(|_| std::process::abort());
 
@@ -5138,6 +6110,7 @@ mod tests {
             "site-prod",
             None,
             None,
+            &scoring::ScoringWeights::default(),
         )
         .unwrap_or_else(|_| std::process::abort());
         // With 2 sites and 3 providers, we expect 6 candidates (3 providers × 2 sites each)
@@ -5166,6 +6139,7 @@ mod tests {
             "site-staging",
             None,
             None,
+            &scoring::ScoringWeights::default(),
         )
         .unwrap_or_else(|_| std::process::abort());
         // Staging site only, 2 allowed providers (unrestricted + platform-only) = 2 candidates
@@ -5205,6 +6179,7 @@ mod tests {
             "site-prod",
             None,
             None,
+            &scoring::ScoringWeights::default(),
         )
         .unwrap_or_else(|_| std::process::abort());
         assert_eq!(overlay.candidates.len(), 1, "local unrestricted provider must appear");
@@ -5233,6 +6208,7 @@ mod tests {
             "site-prod",
             None,
             None,
+            &scoring::ScoringWeights::default(),
         )
         .unwrap_or_else(|_| std::process::abort());
         assert_eq!(
@@ -5250,6 +6226,7 @@ mod tests {
             "site-staging",
             None,
             None,
+            &scoring::ScoringWeights::default(),
         )
         .unwrap_or_else(|_| std::process::abort());
         assert_eq!(
@@ -5279,6 +6256,7 @@ mod tests {
             "site-wrong",
             None,
             None,
+            &scoring::ScoringWeights::default(),
         )
         .unwrap_or_else(|_| std::process::abort());
         assert_eq!(
@@ -5306,6 +6284,7 @@ mod tests {
             "unknown-site",
             None,
             None,
+            &scoring::ScoringWeights::default(),
         )
         .unwrap_or_else(|_| std::process::abort());
 
@@ -5337,6 +6316,7 @@ mod tests {
             "site-prod",
             None,
             None,
+            &scoring::ScoringWeights::default(),
         )
         .unwrap_or_else(|_| std::process::abort());
         assert_eq!(
@@ -5369,6 +6349,7 @@ mod tests {
             "site-prod",
             None,
             None,
+            &scoring::ScoringWeights::default(),
         )
         .unwrap_or_else(|_| std::process::abort());
         assert_eq!(
@@ -5386,6 +6367,7 @@ mod tests {
             "site-staging",
             None,
             None,
+            &scoring::ScoringWeights::default(),
         )
         .unwrap_or_else(|_| std::process::abort());
         assert_eq!(
@@ -5414,6 +6396,7 @@ mod tests {
             "site-wrong",
             None,
             None,
+            &scoring::ScoringWeights::default(),
         )
         .unwrap_or_else(|_| std::process::abort());
         assert_eq!(
@@ -5441,6 +6424,7 @@ mod tests {
             "unknown-site",
             None,
             None,
+            &scoring::ScoringWeights::default(),
         )
         .unwrap_or_else(|_| std::process::abort());
 
@@ -5535,6 +6519,7 @@ mod tests {
             "site-a",
             Some(&metrics),
             None,
+            &scoring::ScoringWeights::default(),
         )
         .unwrap_or_else(|_| std::process::abort());
 
@@ -5579,6 +6564,7 @@ mod tests {
             "site-a",
             Some(&metrics),
             None,
+            &scoring::ScoringWeights::default(),
         )
         .unwrap_or_else(|_| std::process::abort());
 
@@ -5626,6 +6612,7 @@ mod tests {
             "site-a",
             Some(&metrics),
             None,
+            &scoring::ScoringWeights::default(),
         )
         .unwrap_or_else(|_| std::process::abort());
 
@@ -5642,8 +6629,17 @@ mod tests {
         let prov_local = test_provider_with_backend_kind("prov-local", "net", "local");
         let prov_api = test_provider_with_backend_kind("prov-api", "net", "api_provider");
 
-        let overlay = render_routing_overlay(&network, &[], &[prov_local, prov_api], &[], "local-gw", None, None)
-            .unwrap_or_else(|_| std::process::abort());
+        let overlay = render_routing_overlay(
+            &network,
+            &[],
+            &[prov_local, prov_api],
+            &[],
+            "local-gw",
+            None,
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
 
         assert_eq!(overlay.candidates.len(), 2, "both candidates must be present");
         assert_eq!(
@@ -5681,6 +6677,7 @@ mod tests {
             "site-a",
             None,
             None,
+            &scoring::ScoringWeights::default(),
         )
         .unwrap_or_else(|_| std::process::abort());
 
@@ -5712,6 +6709,7 @@ mod tests {
             "site-a",
             None,
             Some("2026-07-24T12:00:00Z"),
+            &scoring::ScoringWeights::default(),
         )
         .unwrap_or_else(|_| std::process::abort());
 
@@ -5770,8 +6768,17 @@ mod tests {
         let prov = test_provider("prov-a", "net", &["llm"]);
         let ts = "2026-07-24T12:00:00Z";
 
-        let overlay = render_routing_overlay(&network, &[], &[prov], &[], "net", None, Some(ts))
-            .unwrap_or_else(|_| std::process::abort());
+        let overlay = render_routing_overlay(
+            &network,
+            &[],
+            &[prov],
+            &[],
+            "net",
+            None,
+            Some(ts),
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
 
         assert_eq!(
             overlay.generated_at.as_deref(),
@@ -5793,8 +6800,17 @@ mod tests {
         let site_b = test_site_with_geography_and_label("site-b", "net", Some("us-east"), Some("az-2"));
         let prov = test_provider_on_site("prov-b", "net", "site-b", "local", &["llm"]);
 
-        let overlay = render_routing_overlay(&network, &[site_a, site_b], &[prov], &[], "site-a", None, None)
-            .unwrap_or_else(|_| std::process::abort());
+        let overlay = render_routing_overlay(
+            &network,
+            &[site_a, site_b],
+            &[prov],
+            &[],
+            "site-a",
+            None,
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
 
         assert_eq!(overlay.candidates.len(), 1, "one candidate");
         assert_eq!(
@@ -5819,8 +6835,17 @@ mod tests {
         let mut metrics: HashMap<&str, scoring::BackendMetrics> = HashMap::new();
         metrics.insert("prov-a", scoring::BackendMetrics::new(0.0, true, 0.5, 100.0, 0.5, 0.90));
 
-        let overlay = render_routing_overlay(&network, &[site_a], &[prov], &[], "site-a", Some(&metrics), None)
-            .unwrap_or_else(|_| std::process::abort());
+        let overlay = render_routing_overlay(
+            &network,
+            &[site_a],
+            &[prov],
+            &[],
+            "site-a",
+            Some(&metrics),
+            None,
+            &scoring::ScoringWeights::default(),
+        )
+        .unwrap_or_else(|_| std::process::abort());
 
         assert_eq!(overlay.candidates.len(), 1, "one candidate");
         assert_eq!(

--- a/tests/e2e/topologies/grid-llmd-pool-metrics/forge.yaml
+++ b/tests/e2e/topologies/grid-llmd-pool-metrics/forge.yaml
@@ -244,6 +244,9 @@ spec:
               region: pool-a
               zone: pool-a-1
               routingPolicy: scoreFirst
+              scoringPolicy:
+                strategy: queueDepth
+              metricsRefreshInterval: "5s"
               swim:
                 probeInterval: "5s"
                 suspicionTimeout: "15s"
@@ -321,6 +324,9 @@ spec:
               region: pool-b
               zone: pool-b-1
               routingPolicy: scoreFirst
+              scoringPolicy:
+                strategy: queueDepth
+              metricsRefreshInterval: "5s"
               swim:
                 probeInterval: "5s"
                 suspicionTimeout: "15s"

--- a/xtask/src/env/llmd_pool_metrics_demo.rs
+++ b/xtask/src/env/llmd_pool_metrics_demo.rs
@@ -76,11 +76,11 @@ const DATA_PLANE_INTERVAL: Duration = Duration::from_secs(1);
 /// Configured queue capacity (matches MOCK_MAX_NUM_SEQS on VCR pods).
 const QUEUE_CAPACITY: f64 = 4.0;
 
-/// Scoring weight for queue_depth signal (must match ScoringWeights default).
-const QUEUE_DEPTH_WEIGHT: f64 = 3.0;
+/// Scoring weight for queue_depth signal (one-hot strategy: weight = 1.0).
+const QUEUE_DEPTH_WEIGHT: f64 = 1.0;
 
-/// Scoring weight for kv_cache signal (must match ScoringWeights default).
-const KV_CACHE_WEIGHT: f64 = 2.0;
+/// Scoring weight for kv_cache signal (one-hot strategy: weight = 1.0).
+const KV_CACHE_WEIGHT: f64 = 1.0;
 
 /// Minimum score gap required before capturing the pressure scorecard.
 ///


### PR DESCRIPTION
## Summary

Add explicit provider scoring strategies and configurable metric refresh cadence to
GridNetwork reconciliation.

## What changed

### Configurable scoring

- Add `GridNetwork.spec.scoringPolicy.strategy`.
- Support `noMetrics`, `queueDepth`, and `kvCachePressure`.
- Wire the selected strategy from the CRD through the operator into routing
  overlay rendering.
- Preserve admission, freshness, locality, and request-time Praxis behavior.
- Make the default explicit: an omitted policy resolves to `noMetrics`; Grid
  does not silently enable the legacy combined six-signal weights.
- Add CRD round-trip, enum, unknown-field, weight-resolution, hand-calculated
  score, and opposing-signal ordering tests.

### Configurable metric refresh

- Add `GridNetwork.spec.metricsRefreshInterval`, accepting positive `ms` or
  `s` durations.
- Use the configured interval for periodic provider metric scraping and
  re-ranking.
- Preserve safe defaults:
  - 300 seconds for ordinary/plaintext metrics.
  - 60 seconds when TLS metric credentials are configured.
- Cap a TLS network's custom interval at 60 seconds so certificate rotation
  detection is not delayed.
- Reject invalid duration formats through CRD schema validation.
- Add parser, fallback, TLS-cap, and short-interval tests.

### llm-d pool-metrics demo

- Configure both pool GridNetworks with:
  - `routingPolicy: scoreFirst`
  - `scoringPolicy.strategy: queueDepth`
  - `metricsRefreshInterval: "5s"`
- Align demo score narration with the one-hot queue-depth strategy.

### Documentation and manifests

- Update generated and Helm CRD surfaces.
- Update Helm values schema and GridNetwork template.
- Update samples and routing/scoring architecture documentation.
- Document the full path from EPP metrics to operator reconciliation, overlay
  publication, overlay-sync, and Praxis hot reload.
- Explain how score, rank, locality, admission, and refresh cadence interact.

## Validation

- `cargo test --workspace` — pass.
- `cargo test -p operator` — 973 library tests plus 4 binary tests pass.
- `cargo test -p scoring` — 36 tests plus 3 doctests pass.
- `cargo test -p xtask` — 460 tests pass.
- `cargo check -p operator` — pass.
- `cargo check -p xtask` — pass.
- `cargo clippy -p operator --all-targets -- -D warnings` — pass.
- `cargo fmt --all -- --check` — pass.
- `helm lint charts/grid-site --set gridNetwork.name=test --set gridSite.name=test` — pass.
- Helm rendering verified for `queueDepth` and `metricsRefreshInterval: "5s"`.
- Generated CRD schema verified against the checked-in duration pattern.
- `git diff --check` — pass.

No runtime Kind E2E was run in this change; the existing llm-d demo remains
configured for the later cold runtime validation.