### PR TITLE
fix(operator): stop GridNetwork reconciler infinite hot-loop (grid#42)

### DIFF
--- a/operator/src/controller/grid_network.rs
+++ b/operator/src/controller/grid_network.rs
@@ -29,7 +29,7 @@ use crate::{
             ConsumerConfig, ConsumerConfigPhase, ConsumerConfigStatus, GatewayRef, GridNetwork, GridNetworkPhase,
             GridNetworkStatus, OverlayPhase, OverlayRevisionStatus, TransportMode,
         },
-        grid_site::{GridSite, GridSitePhase},
+        grid_site::{GridSite, GridSitePhase, GridSiteStatus},
         inference_provider::InferenceProvider,
     },
     error::OperatorError,
@@ -829,6 +829,12 @@ async fn reconcile_routing_overlay_inner(
                 continue;
             },
         };
+        let rendered_at = stable_rendered_at(
+            find_prior_overlay(network, gw_ref),
+            &render.revision_hex,
+            &resource_version,
+            &render.rendered_at,
+        );
         overlay_statuses.push(OverlayRevisionStatus {
             gateway_name: gw_ref.name.clone(),
             namespace: gw_ref.namespace.clone(),
@@ -838,7 +844,7 @@ async fn reconcile_routing_overlay_inner(
             distributed_revision: render.revision_hex.clone(),
             content_digest: render.revision_hex,
             config_map_resource_version: resource_version,
-            rendered_at: render.rendered_at,
+            rendered_at,
             candidate_count: render.candidate_count,
             phase: OverlayPhase::Distributed,
             reason: String::new(),
@@ -883,6 +889,35 @@ fn find_prior_overlay<'a>(network: &'a GridNetwork, gw_ref: &GatewayRef) -> Opti
             .find(|e| e.gateway_name == gw_ref.name && e.namespace == gw_ref.namespace)
             .filter(|e| !e.distributed_revision.is_empty())
     })
+}
+
+/// Decide the `rendered_at` timestamp to record for a freshly-successful
+/// overlay distribution.
+///
+/// `fresh_rendered_at` is derived from a new timestamp taken on every
+/// reconcile tick (see `rfc3339_now` in `reconcile_overlays_and_consumer_configs`),
+/// so using it unconditionally would make every `OverlayRevisionStatus`
+/// compare as changed even when the overlay's actual content (distributed
+/// revision, `ConfigMap` `resourceVersion`) is byte-for-byte identical to
+/// what is already recorded — silently defeating
+/// [`grid_network_status_needs_update`]'s equality check and reproducing the
+/// same class of reconcile hot-loop as grid#42, just against the
+/// `GridNetwork` object's own status subresource instead of `GridSite` or
+/// the overlay `ConfigMap`. Reuse the prior timestamp whenever nothing
+/// observable changed; only advance it when the distributed revision or
+/// `ConfigMap` `resourceVersion` actually moved.
+fn stable_rendered_at(
+    prior: Option<&OverlayRevisionStatus>,
+    revision_hex: &str,
+    resource_version: &str,
+    fresh_rendered_at: &str,
+) -> String {
+    match prior {
+        Some(p) if p.distributed_revision == revision_hex && p.config_map_resource_version == resource_version => {
+            p.rendered_at.clone()
+        },
+        _ => fresh_rendered_at.to_owned(),
+    }
 }
 
 /// Resolve rendered-side evidence from render result, prior status, or defaults.
@@ -1072,9 +1107,37 @@ fn render_overlay_for_gateway(
     })
 }
 
-/// Server-side apply a pre-rendered overlay `ConfigMap` for a single gateway.
+/// True when `existing`'s revision annotation already matches `revision_hex`,
+/// meaning a re-apply of the overlay `ConfigMap` would be a no-op write.
 ///
-/// Returns the Kubernetes `resourceVersion` of the applied `ConfigMap`.
+/// Pure/synchronous so it is fully unit-testable without a live Kubernetes
+/// API. Server-side apply still writes managedFields metadata (bumping
+/// resourceVersion and firing a watch event) even when applied content is
+/// byte-for-byte unchanged; combined with the apply being re-triggered by the
+/// very watch event it emits, applying unconditionally becomes an infinite
+/// reconcile hot-loop (see grid#42).
+fn configmap_up_to_date(existing: &ConfigMap, revision_hex: &str) -> bool {
+    existing
+        .metadata
+        .annotations
+        .as_ref()
+        .and_then(|a| a.get(overlay_envelope::ANNOTATION_REVISION))
+        .is_some_and(|rev| rev == revision_hex)
+}
+
+/// Server-side apply a pre-rendered overlay `ConfigMap` for a single gateway,
+/// skipping the apply when [`configmap_up_to_date`] says it would be a no-op.
+///
+/// Returns the Kubernetes `resourceVersion` of the (applied or pre-existing)
+/// `ConfigMap`.
+#[expect(
+    clippy::too_many_lines,
+    reason = "fetch-guard, apply, and logging is a single cohesive sequence"
+)]
+#[expect(
+    clippy::large_stack_frames,
+    reason = "async future over Kubernetes API types with serde_json values"
+)]
 async fn distribute_overlay_configmap(
     overlay: &routing_overlay::RoutingOverlay,
     render: &OverlayRenderResult,
@@ -1092,6 +1155,18 @@ async fn distribute_overlay_configmap(
     .map_err(OperatorError::Json)?;
 
     let api: Api<ConfigMap> = Api::namespaced(client.clone(), &gw_ref.namespace);
+
+    if let Ok(existing) = api.get(&render.config_map_name).await
+        && configmap_up_to_date(&existing, &render.revision_hex)
+    {
+        tracing::debug!(
+            cm_name = %render.config_map_name,
+            revision = %render.revision_hex,
+            "routing overlay ConfigMap already at this revision; skipping no-op apply"
+        );
+        return Ok(existing.metadata.resource_version.unwrap_or_default());
+    }
+
     let applied = api
         .patch(
             &render.config_map_name,
@@ -1740,6 +1815,166 @@ fn network_uses_plaintext_egress(network: &GridNetwork) -> bool {
     has_plaintext_endpoint || (network.spec.tls.ca_secret_ref.is_none() && network.spec.tls.site_secret_ref.is_none())
 }
 
+/// `GridSite.status.reason` recorded for every cert-PEM validation failure.
+///
+/// Single source of truth for both [`decide_cert_pem_write`]'s write (via
+/// [`reconcile_site_cert_pem`]) and [`already_recorded_invalid`]'s read, so
+/// the two can never drift apart the way a hand-duplicated literal could.
+const REASON_TRUST_MATERIAL_INVALID: &str = "TrustMaterialInvalid";
+
+/// Diagnostic message for [`CertPemStatus::ContainsPrivateKey`].
+const CERT_PEM_MSG_CONTAINS_PRIVATE_KEY: &str =
+    "received trust material from remote site contained private-key markers; discarded";
+
+/// Diagnostic message for [`CertPemStatus::NotACertificate`].
+const CERT_PEM_MSG_NOT_A_CERTIFICATE: &str = "received cert PEM from remote site is not a valid certificate; check \
+                                               GRID_TLS_SITE_SECRET_REF configuration on the remote operator";
+
+/// Diagnostic message for [`CertPemStatus::TooLarge`].
+const CERT_PEM_MSG_TOO_LARGE: &str = "received cert PEM from remote site exceeds the configured size bound";
+
+/// What (if anything) [`reconcile_site_cert_pem`] should write to `GridSite`
+/// status for a received site cert PEM.
+///
+/// Produced by the pure [`decide_cert_pem_write`] so the branching logic is
+/// unit-testable without a live Kubernetes API — see grid#42, where writing
+/// unconditionally on every branch turned a stable, unchanged site into an
+/// infinite reconcile hot-loop.
+#[derive(Debug, Eq, PartialEq)]
+enum CertPemWrite {
+    /// `existing_status` already reflects this outcome; nothing to do.
+    NoOp,
+    /// Store the structurally-valid cert PEM.
+    StoreValid,
+    /// Reject with `TrustMaterialInvalid`, recording this diagnostic message.
+    RejectInvalid {
+        /// Diagnostic message to record in `status.message`.
+        message: &'static str,
+        /// Selects `error!` (private-key leak) vs `warn!` (malformed or
+        /// oversized) logging in the caller.
+        security_violation: bool,
+    },
+}
+
+/// Pure decision: given the current `GridSite` status and a freshly-checked
+/// [`CertPemStatus`], decide what (if anything) to write.
+///
+/// Never itself touches the Kubernetes API — see [`CertPemWrite`].
+fn decide_cert_pem_write(
+    existing_status: &Option<GridSiteStatus>,
+    cert_pem: &str,
+    check: &CertPemStatus,
+) -> CertPemWrite {
+    match check {
+        CertPemStatus::ValidStructure => {
+            if existing_status.as_ref().and_then(|s| s.public_cert_pem.as_deref()) == Some(cert_pem) {
+                CertPemWrite::NoOp
+            } else {
+                CertPemWrite::StoreValid
+            }
+        },
+        CertPemStatus::ContainsPrivateKey => {
+            decide_reject_invalid(existing_status, CERT_PEM_MSG_CONTAINS_PRIVATE_KEY, true)
+        },
+        CertPemStatus::NotACertificate => decide_reject_invalid(existing_status, CERT_PEM_MSG_NOT_A_CERTIFICATE, false),
+        CertPemStatus::TooLarge => decide_reject_invalid(existing_status, CERT_PEM_MSG_TOO_LARGE, false),
+    }
+}
+
+/// Shared decision logic for the three invalid-cert-PEM outcomes: skip when
+/// `existing_status` already records this exact `message`, otherwise reject.
+fn decide_reject_invalid(
+    existing_status: &Option<GridSiteStatus>,
+    message: &'static str,
+    security_violation: bool,
+) -> CertPemWrite {
+    if already_recorded_invalid(existing_status, message) {
+        CertPemWrite::NoOp
+    } else {
+        CertPemWrite::RejectInvalid {
+            message,
+            security_violation,
+        }
+    }
+}
+
+/// True when `existing` already records the given invalid-cert `message` with
+/// no stored `publicCertPem`, meaning a re-patch with the same content would
+/// be a redundant write.
+fn already_recorded_invalid(existing: &Option<GridSiteStatus>, message: &str) -> bool {
+    existing.as_ref().is_some_and(|s| {
+        s.public_cert_pem.is_none() && s.reason == REASON_TRUST_MATERIAL_INVALID && s.message == message
+    })
+}
+
+/// Validate a received site cert PEM and store (or reject) it in `GridSite`
+/// status, per [`decide_cert_pem_write`]. Purely an imperative shell around
+/// that pure decision: no branching logic lives here, only I/O and logging.
+#[expect(
+    clippy::cognitive_complexity,
+    reason = "three sequential match arms, each a distinct security invariant (store/reject/security-log); splitting further would fragment cohesive I/O steps rather than reduce complexity"
+)]
+#[expect(
+    clippy::too_many_lines,
+    reason = "three JSON-patch-plus-log branches read clearer inline than split further"
+)]
+#[expect(
+    clippy::large_stack_frames,
+    reason = "async future over Kubernetes API types with serde_json values"
+)]
+async fn reconcile_site_cert_pem(
+    api: &Api<GridSite>,
+    site_name: &str,
+    existing_status: &Option<GridSiteStatus>,
+    cert_pem: &str,
+) -> Result<(), OperatorError> {
+    match decide_cert_pem_write(existing_status, cert_pem, &trust_bundle::check_cert_pem(cert_pem)) {
+        CertPemWrite::NoOp => {
+            tracing::debug!(name = %site_name, "cert PEM status already up to date; skipping no-op status patch");
+        },
+        CertPemWrite::StoreValid => {
+            // Use strategic merge patch (not SSA) so only publicCertPem is
+            // updated; SSA with a partial payload would clear other status
+            // fields managed by "grid-operator" (e.g., reason, message).
+            let cert_merge = serde_json::json!({ "status": { "publicCertPem": cert_pem } });
+            api.patch_status(site_name, &PatchParams::default(), &Patch::Merge(&cert_merge))
+                .await?;
+            tracing::info!(
+                name = %site_name,
+                "received and stored public site certificate PEM (structure valid; not chain-verified)"
+            );
+        },
+        CertPemWrite::RejectInvalid {
+            message,
+            security_violation,
+        } => {
+            // Write a status marker so operators can see the invalid material.
+            // Do not store the raw PEM; record only the invalid status.
+            let invalid_status_doc = serde_json::json!({
+                "apiVersion": "grid.praxis-proxy.io/v1alpha1",
+                "kind": "GridSite",
+                "status": {
+                    "publicCertPem": null,
+                    "reason": REASON_TRUST_MATERIAL_INVALID,
+                    "message": message
+                }
+            });
+            api.patch_status(site_name, &PatchParams::default(), &Patch::Merge(&invalid_status_doc))
+                .await?;
+            if security_violation {
+                tracing::error!(
+                    name = %site_name,
+                    "SECURITY: received cert PEM contains private key markers from remote SWIM peer; \
+                     discarding — private keys must never appear in SWIM broadcasts"
+                );
+            } else {
+                tracing::warn!(name = %site_name, %message, "rejected invalid cert PEM from remote site");
+            }
+        },
+    }
+    Ok(())
+}
+
 /// Create or update `GridSite` resources for remote Alive SWIM members.
 ///
 /// Uses server-side apply, so the call is idempotent: applying an already-existing
@@ -1760,10 +1995,6 @@ fn network_uses_plaintext_egress(network: &GridNetwork) -> bool {
 #[expect(
     clippy::large_stack_frames,
     reason = "async future over Kubernetes API types with serde_json values"
-)]
-#[expect(
-    clippy::cognitive_complexity,
-    reason = "cert PEM validation branches add arms but each branch is a distinct security invariant; splitting obscures the trust contract"
 )]
 async fn reconcile_discovered_sites(
     network_name: &str,
@@ -1819,18 +2050,23 @@ async fn reconcile_discovered_sites(
         )
         .await?;
 
+        // Fetch current status once and reuse it below for every write in this
+        // iteration. Every status patch bumps the GridSite's resourceVersion,
+        // which fires a watch event that re-triggers a GridNetwork reconcile
+        // (related object updated) — re-entering this same loop. Writing
+        // unconditionally therefore turns a stable, unchanged site into an
+        // infinite reconcile hot-loop; checking against current state first
+        // makes each write idempotent in practice, not just in intent (see
+        // grid#42).
+        let existing_status = api.get(&site.name).await.ok().and_then(|s| s.status);
+
         // Only write Discovered when the current phase is Pending.
         // If the GridSite controller has already advanced the phase (e.g. to
         // Connecting), we must not regress it.
-        let should_write_discovered = {
-            match api.get(&site.name).await {
-                Ok(existing) => {
-                    let current_phase = existing.status.as_ref().map(|s| &s.phase);
-                    matches!(current_phase, None | Some(GridSitePhase::Pending))
-                },
-                Err(_) => true, // Site was just created; safe to write Discovered.
-            }
-        };
+        let should_write_discovered = matches!(
+            existing_status.as_ref().map(|s| &s.phase),
+            None | Some(GridSitePhase::Pending)
+        );
 
         if should_write_discovered {
             let status_doc = serde_json::json!({
@@ -1853,80 +2089,13 @@ async fn reconcile_discovered_sites(
 
         // Write received public cert PEM to status after structure validation.
         // Private key material must never be written to status; invalid PEM is
-        // also rejected and recorded as TrustMaterialInvalid.
+        // also rejected and recorded as TrustMaterialInvalid. Skips any patch
+        // that would be a no-op given `existing_status` — otherwise every
+        // reconcile re-issues an unconditional write, which (per the comment
+        // above `existing_status`) becomes an infinite reconcile hot-loop even
+        // when the remote site's cert hasn't changed (grid#42).
         if let Some(cert_pem) = &site.site_cert_pem {
-            match trust_bundle::check_cert_pem(cert_pem) {
-                CertPemStatus::ValidStructure => {
-                    // Use strategic merge patch (not SSA) so only publicCertPem is
-                    // updated; SSA with a partial payload would clear other status
-                    // fields managed by "grid-operator" (e.g., reason, message).
-                    let cert_merge = serde_json::json!({ "status": { "publicCertPem": cert_pem } });
-                    api.patch_status(&site.name, &PatchParams::default(), &Patch::Merge(&cert_merge))
-                        .await?;
-                    tracing::info!(
-                        name = %site.name,
-                        "received and stored public site certificate PEM (structure valid; not chain-verified)"
-                    );
-                },
-                CertPemStatus::ContainsPrivateKey => {
-                    // Security violation: the remote peer sent private key material.
-                    // Do not store it; clear any prior publicCertPem and log at error
-                    // level so operators can investigate.
-                    let invalid_status_doc = serde_json::json!({
-                        "apiVersion": "grid.praxis-proxy.io/v1alpha1",
-                        "kind": "GridSite",
-                        "status": {
-                            "publicCertPem": null,
-                            "reason": "TrustMaterialInvalid",
-                            "message": "received trust material from remote site contained private-key markers; discarded"
-                        }
-                    });
-                    api.patch_status(&site.name, &PatchParams::default(), &Patch::Merge(&invalid_status_doc))
-                        .await?;
-                    tracing::error!(
-                        name = %site.name,
-                        "SECURITY: received cert PEM contains private key markers from remote SWIM peer; \
-                         discarding — private keys must never appear in SWIM broadcasts"
-                    );
-                },
-                CertPemStatus::NotACertificate => {
-                    // Write a status marker so operators can see the invalid material.
-                    // Do not store the raw PEM; record only the invalid status.
-                    let invalid_status_doc = serde_json::json!({
-                        "apiVersion": "grid.praxis-proxy.io/v1alpha1",
-                        "kind": "GridSite",
-                        "status": {
-                            "publicCertPem": null,
-                            "reason": "TrustMaterialInvalid",
-                            "message": "received cert PEM from remote site is not a valid certificate; \
-                                        check GRID_TLS_SITE_SECRET_REF configuration on the remote operator"
-                        }
-                    });
-                    api.patch_status(&site.name, &PatchParams::default(), &Patch::Merge(&invalid_status_doc))
-                        .await?;
-                    tracing::warn!(
-                        name = %site.name,
-                        "received cert PEM from remote site is not a valid certificate"
-                    );
-                },
-                CertPemStatus::TooLarge => {
-                    let invalid_status_doc = serde_json::json!({
-                        "apiVersion": "grid.praxis-proxy.io/v1alpha1",
-                        "kind": "GridSite",
-                        "status": {
-                            "publicCertPem": null,
-                            "reason": "TrustMaterialInvalid",
-                            "message": "received cert PEM from remote site exceeds the configured size bound"
-                        }
-                    });
-                    api.patch_status(&site.name, &PatchParams::default(), &Patch::Merge(&invalid_status_doc))
-                        .await?;
-                    tracing::warn!(
-                        name = %site.name,
-                        "received cert PEM from remote site exceeds the configured size bound"
-                    );
-                },
-            }
+            reconcile_site_cert_pem(&api, &site.name, &existing_status, cert_pem).await?;
         }
 
         tracing::info!(
@@ -3143,6 +3312,232 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
+    // already_recorded_invalid — grid#42 reconcile-hot-loop regression guard
+    // -----------------------------------------------------------------------
+
+    fn invalid_cert_status(message: &str) -> GridSiteStatus {
+        GridSiteStatus {
+            public_cert_pem: None,
+            reason: REASON_TRUST_MATERIAL_INVALID.to_owned(),
+            message: message.to_owned(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn already_recorded_invalid_true_when_reason_message_and_absence_all_match() {
+        let existing = Some(invalid_cert_status("private key detected"));
+        assert!(
+            already_recorded_invalid(&existing, "private key detected"),
+            "identical reason/message/absent-cert must be recognized as already recorded"
+        );
+    }
+
+    #[test]
+    fn already_recorded_invalid_false_when_status_is_none() {
+        assert!(
+            !already_recorded_invalid(&None, "private key detected"),
+            "a GridSite with no status yet has nothing recorded"
+        );
+    }
+
+    #[test]
+    fn already_recorded_invalid_false_when_message_differs() {
+        let existing = Some(invalid_cert_status("private key detected"));
+        assert!(
+            !already_recorded_invalid(&existing, "cert exceeds size bound"),
+            "a different rejection reason must not be treated as already recorded"
+        );
+    }
+
+    #[test]
+    fn already_recorded_invalid_false_when_reason_is_not_trust_material_invalid() {
+        let existing = Some(GridSiteStatus {
+            public_cert_pem: None,
+            reason: "AwaitingDiscovery".to_owned(),
+            message: "private key detected".to_owned(),
+            ..Default::default()
+        });
+        assert!(
+            !already_recorded_invalid(&existing, "private key detected"),
+            "a status recorded for an unrelated reason must not suppress the write"
+        );
+    }
+
+    #[test]
+    fn already_recorded_invalid_false_when_public_cert_pem_still_present() {
+        let existing = Some(GridSiteStatus {
+            public_cert_pem: Some("stale cert".to_owned()),
+            reason: REASON_TRUST_MATERIAL_INVALID.to_owned(),
+            message: "private key detected".to_owned(),
+            ..Default::default()
+        });
+        assert!(
+            !already_recorded_invalid(&existing, "private key detected"),
+            "a leftover publicCertPem means the invalid status was never actually applied yet"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // decide_cert_pem_write — grid#42 acceptance criterion:
+    //
+    //   "reconciling an unchanged remote site must decide NoOp for every
+    //    possible cert-PEM outcome" — i.e. a stable GridSite never causes a
+    //    write, which is precisely the condition that stops the infinite
+    //    reconcile hot-loop (repeated no-op writes bumping resourceVersion
+    //    and re-triggering the reconciler). These tests assert that
+    //    business-level property directly, across all four outcomes, rather
+    //    than only exercising the internal `already_recorded_invalid` guard.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn decide_cert_pem_write_is_noop_for_every_outcome_when_site_is_already_stable() {
+        // ValidStructure: publicCertPem already stored verbatim.
+        let stored = Some(GridSiteStatus {
+            public_cert_pem: Some("cert-a".to_owned()),
+            ..Default::default()
+        });
+        assert_eq!(
+            decide_cert_pem_write(&stored, "cert-a", &CertPemStatus::ValidStructure),
+            CertPemWrite::NoOp,
+            "an unchanged valid cert must never be re-patched (grid#42)"
+        );
+
+        // Every invalid outcome: already recorded with its exact message.
+        for (check, message) in [
+            (CertPemStatus::ContainsPrivateKey, CERT_PEM_MSG_CONTAINS_PRIVATE_KEY),
+            (CertPemStatus::NotACertificate, CERT_PEM_MSG_NOT_A_CERTIFICATE),
+            (CertPemStatus::TooLarge, CERT_PEM_MSG_TOO_LARGE),
+        ] {
+            let recorded = Some(invalid_cert_status(message));
+            assert_eq!(
+                decide_cert_pem_write(&recorded, "irrelevant-pem", &check),
+                CertPemWrite::NoOp,
+                "an unchanged rejection ({check:?}) must never be re-patched (grid#42)"
+            );
+        }
+    }
+
+    #[test]
+    fn decide_cert_pem_write_stores_valid_cert_on_first_sight() {
+        assert_eq!(
+            decide_cert_pem_write(&None, "cert-a", &CertPemStatus::ValidStructure),
+            CertPemWrite::StoreValid,
+            "a GridSite with no prior status must store the first valid cert seen"
+        );
+    }
+
+    #[test]
+    fn decide_cert_pem_write_stores_valid_cert_when_it_rotates() {
+        let stale = Some(GridSiteStatus {
+            public_cert_pem: Some("cert-old".to_owned()),
+            ..Default::default()
+        });
+        assert_eq!(
+            decide_cert_pem_write(&stale, "cert-new", &CertPemStatus::ValidStructure),
+            CertPemWrite::StoreValid,
+            "a rotated cert (different from what's stored) must still be written"
+        );
+    }
+
+    #[test]
+    fn decide_cert_pem_write_rejects_private_key_as_security_violation() {
+        assert_eq!(
+            decide_cert_pem_write(&None, "leaked-key", &CertPemStatus::ContainsPrivateKey),
+            CertPemWrite::RejectInvalid {
+                message: CERT_PEM_MSG_CONTAINS_PRIVATE_KEY,
+                security_violation: true
+            },
+            "private-key leakage must be flagged as a security violation, not a routine rejection"
+        );
+    }
+
+    #[test]
+    fn decide_cert_pem_write_rejects_malformed_cert_as_non_security() {
+        assert_eq!(
+            decide_cert_pem_write(&None, "garbage", &CertPemStatus::NotACertificate),
+            CertPemWrite::RejectInvalid {
+                message: CERT_PEM_MSG_NOT_A_CERTIFICATE,
+                security_violation: false
+            },
+            "a malformed cert is an operator misconfiguration, not a security violation"
+        );
+    }
+
+    #[test]
+    fn decide_cert_pem_write_rejects_oversized_cert_as_non_security() {
+        assert_eq!(
+            decide_cert_pem_write(&None, "huge", &CertPemStatus::TooLarge),
+            CertPemWrite::RejectInvalid {
+                message: CERT_PEM_MSG_TOO_LARGE,
+                security_violation: false
+            },
+            "an oversized cert is a bound violation, not a security violation"
+        );
+    }
+
+    #[test]
+    fn decide_cert_pem_write_re_rejects_when_recorded_reason_no_longer_matches() {
+        // Status shows a *different* rejection (or none) — must not be
+        // mistaken for "already handled".
+        let recorded_other_reason = Some(invalid_cert_status(CERT_PEM_MSG_TOO_LARGE));
+        assert_eq!(
+            decide_cert_pem_write(&recorded_other_reason, "leaked-key", &CertPemStatus::ContainsPrivateKey),
+            CertPemWrite::RejectInvalid {
+                message: CERT_PEM_MSG_CONTAINS_PRIVATE_KEY,
+                security_violation: true
+            },
+            "a newly-observed private-key leak must be recorded even if a different rejection was previously stored"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // configmap_up_to_date — grid#42 acceptance criterion for the overlay
+    // ConfigMap: re-applying an unchanged revision must be recognized as a
+    // no-op so `distribute_overlay_configmap` can skip the write.
+    // -----------------------------------------------------------------------
+
+    fn configmap_with_revision(revision: Option<&str>) -> ConfigMap {
+        let annotations = revision.map(|rev| {
+            std::collections::BTreeMap::from([(overlay_envelope::ANNOTATION_REVISION.to_owned(), rev.to_owned())])
+        });
+        ConfigMap {
+            metadata: kube::api::ObjectMeta {
+                annotations,
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn configmap_up_to_date_true_when_revision_annotation_matches() {
+        let cm = configmap_with_revision(Some("abc123"));
+        assert!(
+            configmap_up_to_date(&cm, "abc123"),
+            "identical revision must be recognized as up to date (grid#42)"
+        );
+    }
+
+    #[test]
+    fn configmap_up_to_date_false_when_revision_annotation_differs() {
+        let cm = configmap_with_revision(Some("abc123"));
+        assert!(
+            !configmap_up_to_date(&cm, "def456"),
+            "a changed revision must not be treated as up to date"
+        );
+    }
+
+    #[test]
+    fn configmap_up_to_date_false_when_no_revision_annotation_present() {
+        let cm = configmap_with_revision(None);
+        assert!(
+            !configmap_up_to_date(&cm, "abc123"),
+            "a ConfigMap with no revision annotation at all must never be treated as up to date"
+        );
+    }
+
+    // -----------------------------------------------------------------------
     // parse_crd_seeds — pure seed normalization
     // -----------------------------------------------------------------------
 
@@ -3440,6 +3835,67 @@ mod tests {
         assert!(status.rendered_revision.is_empty());
         assert!(status.distributed_revision.is_empty());
         assert_eq!(status.reason, "EmptyCandidates");
+    }
+
+    // -----------------------------------------------------------------------
+    // stable_rendered_at (grid#42: GridNetwork status resourceVersion churn)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn stable_rendered_at_reuses_prior_when_nothing_changed() {
+        let gw = make_gw_ref("gw", "grid-system");
+        let prior = rendered_overlay_status(&gw);
+
+        let rendered_at = stable_rendered_at(
+            Some(&prior),
+            &prior.distributed_revision,
+            &prior.config_map_resource_version,
+            "2026-08-12T04:37:55.488097906Z",
+        );
+
+        assert_eq!(
+            rendered_at, prior.rendered_at,
+            "identical revision and resourceVersion must not advance rendered_at, or every \
+             reconcile tick bumps GridNetwork's own resourceVersion forever (grid#42)"
+        );
+    }
+
+    #[test]
+    fn stable_rendered_at_advances_when_revision_changes() {
+        let gw = make_gw_ref("gw", "grid-system");
+        let prior = rendered_overlay_status(&gw);
+        let fresh = "2026-08-12T04:37:55.488097906Z";
+
+        let rendered_at = stable_rendered_at(Some(&prior), &"b".repeat(64), &prior.config_map_resource_version, fresh);
+
+        assert_eq!(
+            rendered_at, fresh,
+            "a genuinely new distributed revision must advance rendered_at"
+        );
+    }
+
+    #[test]
+    fn stable_rendered_at_advances_when_configmap_resource_version_changes() {
+        let gw = make_gw_ref("gw", "grid-system");
+        let prior = rendered_overlay_status(&gw);
+        let fresh = "2026-08-12T04:37:55.488097906Z";
+
+        let rendered_at = stable_rendered_at(Some(&prior), &prior.distributed_revision, "43", fresh);
+
+        assert_eq!(
+            rendered_at, fresh,
+            "a genuinely new ConfigMap resourceVersion must advance rendered_at"
+        );
+    }
+
+    #[test]
+    fn stable_rendered_at_uses_fresh_value_with_no_prior() {
+        let fresh = "2026-08-12T04:37:55.488097906Z";
+        let rendered_at = stable_rendered_at(None, &"a".repeat(64), "42", fresh);
+        assert_eq!(
+            rendered_at, fresh,
+            "first-ever distribution has no prior to compare against"
+        );
     }
 
     #[expect(

--- a/xtask/src/env/glb.rs
+++ b/xtask/src/env/glb.rs
@@ -78,6 +78,17 @@ const DATA_PLANE_CONVERGENCE_WAIT: Duration = Duration::from_secs(45);
 /// Delay between request-path convergence probes.
 const DATA_PLANE_PROBE_INTERVAL: Duration = Duration::from_secs(1);
 
+/// Window over which [`check_overlay_metadata_settles`] confirms the overlay
+/// `ConfigMap`'s `resourceVersion` stops changing once converged.
+///
+/// grid#42's reconcile hot-loop produced continuous writes at roughly
+/// 250-300/sec on helios08, so any window long enough to observe a handful of
+/// reconcile ticks (the operator's default requeue is much faster than that
+/// under active SWIM traffic) is enough to distinguish "stopped writing" from
+/// "still churning" — 15s is comfortably longer than that while keeping the
+/// added proof step fast.
+const OVERLAY_SETTLE_WINDOW: Duration = Duration::from_secs(15);
+
 /// Runtime directory retaining the public CA used by client probes.
 const GTM_TLS_DIR: &str = ".forge/runtime/glb-tls/gtm";
 
@@ -1416,6 +1427,16 @@ fn run_steps(ctx: &PrereqContext, mode: DemoMode, ingress_mode: IngressMode, res
         )
     });
 
+    // Regression guard for grid#42: convergence above proves the ConfigMap
+    // *reached* the right state; this proves it *stays* there instead of
+    // being unconditionally re-applied on every reconcile tick.
+    proof_banner("checking overlay metadata stays converged (no reconcile hot-loop)");
+    record_step(
+        "overlay metadata stable (grid#42)",
+        results,
+        check_overlay_metadata_settles,
+    );
+
     // One site advertises two independent providers for the same model.
     proof_banner("checking multiple providers in one site overlay");
     record_step("same-site provider candidates", results, || {
@@ -1706,6 +1727,7 @@ const PROOF_LABELS: &[&str] = &[
     "swim advertise addr",
     "gridnetwork seeds",
     "overlay metadata",
+    "overlay metadata stable (grid#42)",
     "same-site provider candidates",
     "provider gateway addr",
     "remote gridsite egress",
@@ -1983,7 +2005,6 @@ fn run_probe_pod(
         logs: safe_truncate_str(logs.trim(), 512),
     })
 }
-
 
 /// Best-effort cleanup for a `NetworkPolicy` probe pod.
 struct ProbePodGuard {
@@ -2588,6 +2609,100 @@ fn check_overlay_metadata() -> Result<String, Box<dyn std::error::Error>> {
         "dual-key: {legacy_evidence}; envelope: schema=1.0.0, revision={}, annotations and Grid status verified",
         safe_truncate_str(revision, 16)
     ))
+}
+
+/// Regression guard for [grid#42](https://github.com/praxis-proxy/grid/issues/42): an infinite
+/// reconcile hot-loop with three independent unconditional-write sources —
+/// `distribute_overlay_configmap`'s overlay `ConfigMap` apply, the `GridSite`
+/// cert-PEM status patch, and (discovered during live helios08 validation of
+/// the first two fixes) the `GridNetwork`'s own `status.overlayStatus[].renderedAt`
+/// timestamp, which was refreshed from a new clock read on every reconcile
+/// tick regardless of whether the distributed content actually changed.
+/// Each write bumped its object's `resourceVersion` and fired a watch event
+/// that re-triggered the `GridNetwork` reconciler — so the overlay
+/// `ConfigMap`'s and/or the `GridNetwork`'s own `resourceVersion` climbed
+/// continuously (~250-300 writes/sec on the `ConfigMap`, ~13-14 writes/sec on
+/// `GridNetwork` itself, observed on helios08) and never settled —
+/// [`check_overlay_metadata`]'s own resourceVersion-equality assertion would
+/// eventually see a match by chance, but the underlying churn never stopped.
+///
+/// Must run *after* [`check_overlay_metadata`] has already passed once (see
+/// its call site): this only proves stability, not initial correctness.
+/// Captures the `ConfigMap`'s and the `GridNetwork`'s current
+/// `resourceVersion`s and confirms both are unchanged after
+/// [`OVERLAY_SETTLE_WINDOW`] — proving the operator actually stopped
+/// writing to either object, rather than merely happening to observe
+/// equal resourceVersions mid-churn.
+fn check_overlay_metadata_settles() -> Result<String, Box<dyn std::error::Error>> {
+    let context = kubectl_context(PRIMARY_EDGE);
+    let watched = [
+        WatchedResourceVersion::capture(&context, "configmap", OVERLAY_CONFIGMAP)?,
+        WatchedResourceVersion::capture(&context, "gridnetwork", GRID_NETWORK_NAME)?,
+    ];
+
+    let deadline = Instant::now() + OVERLAY_SETTLE_WINDOW;
+    while Instant::now() < deadline {
+        thread::park_timeout(DATA_PLANE_PROBE_INTERVAL);
+        for resource in &watched {
+            resource.assert_unchanged(&context)?;
+        }
+    }
+
+    Ok(format!(
+        "{} both stable for {OVERLAY_SETTLE_WINDOW:?}",
+        watched
+            .iter()
+            .map(WatchedResourceVersion::summary)
+            .collect::<Vec<_>>()
+            .join(" and ")
+    ))
+}
+
+/// A Kubernetes object's `resourceVersion`, captured once as a baseline so it
+/// can be re-checked against the live value to detect reconcile churn.
+///
+/// Used by [`check_overlay_metadata_settles`] to watch both the overlay
+/// `ConfigMap` and the `GridNetwork` object itself without duplicating the
+/// fetch-compare-format logic per resource (see grid#42: both objects were
+/// independent sources of the same unconditional-write hot-loop pattern).
+struct WatchedResourceVersion {
+    /// `kubectl` resource kind, e.g. `"configmap"`.
+    kind: &'static str,
+    /// Resource name within `PRIMARY_EDGE`'s namespace.
+    name: &'static str,
+    /// `resourceVersion` observed at capture time.
+    baseline: String,
+}
+
+impl WatchedResourceVersion {
+    /// Read `kind`/`name`'s current `resourceVersion` as the stability baseline.
+    fn capture(context: &str, kind: &'static str, name: &'static str) -> Result<Self, Box<dyn std::error::Error>> {
+        let baseline = kubectl_jsonpath(context, kind, name, "{.metadata.resourceVersion}")?;
+        Ok(Self { kind, name, baseline })
+    }
+
+    /// Re-reads the live `resourceVersion` and errors if it moved away from
+    /// `baseline` — the observable signature of an unconditional-write
+    /// reconcile hot-loop (grid#42).
+    fn assert_unchanged(&self, context: &str) -> Result<(), Box<dyn std::error::Error>> {
+        let current = kubectl_jsonpath(context, self.kind, self.name, "{.metadata.resourceVersion}")?;
+        let baseline = &self.baseline;
+        if current != *baseline {
+            return Err(format!(
+                "{} {} resourceVersion changed from {baseline} to {current} within the \
+                 {OVERLAY_SETTLE_WINDOW:?} settle window — indicates an unconditional-write reconcile \
+                 hot-loop (grid#42), not a converged, stable overlay",
+                self.kind, self.name
+            )
+            .into());
+        }
+        Ok(())
+    }
+
+    /// One-line "kind name resourceVersion=X" fragment for the success message.
+    fn summary(&self) -> String {
+        format!("{} {} resourceVersion={}", self.kind, self.name, self.baseline)
+    }
 }
 
 /// Validate overlay JSON contains candidates with required metadata.


### PR DESCRIPTION
## Summary

Fixes #42 — the `GridNetwork` reconciler had three independent unconditional-write sources, each of which bumped a Kubernetes object's `resourceVersion` on every reconcile tick regardless of whether anything had actually changed. Every such write fires a watch event that re-triggers the reconciler, so together they produced a self-sustaining hot-loop. Live on helios08 this measured ~250-300 writes/sec on the overlay `ConfigMap` and ~13-14 writes/sec on `GridNetwork`'s own status, and it prevented `grid-glb-demo`'s overlay convergence check from ever settling.

## The three sources (all fixed the same way: functional core / imperative shell)

1. **`GridSite` cert-PEM status** — `reconcile_discovered_sites` patched `status.publicCertPem` unconditionally on every pass. Extracted the branching into a pure `decide_cert_pem_write()` and a thin `reconcile_site_cert_pem()` shell around it, so a write only happens when the decision actually differs from what's stored.
2. **Overlay `ConfigMap`** — `distribute_overlay_configmap()` re-applied the `ConfigMap` via SSA every tick even when its revision annotation already matched. Added `configmap_up_to_date()` to skip the apply when it would be a no-op.
3. **`GridNetwork`'s own status** — `OverlayRevisionStatus.rendered_at` was recomputed from a fresh clock read every tick, which alone was enough to make `grid_network_status_needs_update`'s equality check always see a diff. Added `stable_rendered_at()` to reuse the prior timestamp when the distributed revision and `ConfigMap` `resourceVersion` are unchanged. (This third source only surfaced after live-validating fixes 1 and 2 on helios08 — `GridNetwork`'s own `resourceVersion` kept climbing even with the other two writes guarded.)

Also promotes the cert-PEM diagnostic message strings and the `"TrustMaterialInvalid"` status reason — previously duplicated as hand-copied literals between production code and tests — to shared `const`s so the two can't drift apart.

## Regression coverage

- Unit tests for all three pure decision functions (`decide_cert_pem_write`, `configmap_up_to_date`, `stable_rendered_at`), verified RED (temporarily reverted the fix, confirmed the new tests fail) → GREEN.
- New xtask check in `grid-glb-demo`: `check_overlay_metadata_settles()` confirms the overlay `ConfigMap`'s and `GridNetwork`'s `resourceVersion`s are both stable for 15s *after* initial convergence — proving the operator stopped writing, not just that it happened to observe a matching value mid-churn.

## Validation

- `cargo clippy -p operator -p xtask --all-targets -- -D warnings` — clean
- `cargo fmt -p operator -p xtask -- --check` — clean
- `cargo test -p operator` (192 passed) and `cargo test -p xtask env::glb::` (93 passed)
- Live-validated on helios08 via `cargo xtask env verify-operator-reconcile` — both the overlay `ConfigMap` and `GridNetwork` `resourceVersion`s settled and stayed settled.

## Known unrelated gap

`grid-glb-demo`'s full run (provider-gateway path) is separately blocked by a pre-existing gap unrelated to this fix — tracked in #44, cross-referenced there. This PR was validated via `verify-operator-reconcile` instead, which exercises the reconciler logic this PR changes without depending on the blocked provider-gateway path.
