### PR TITLE
fix(xtask): restore make lint to green on main

### DIFF
--- a/xtask/src/env/combined_site_demo.rs
+++ b/xtask/src/env/combined_site_demo.rs
@@ -4359,8 +4359,7 @@ fn apply_image_overrides(config: &mut serde_yaml::Value) {
     let operator_image = std::env::var("GRID_XTASK_OPERATOR_IMAGE")
         .unwrap_or_else(|_| "ghcr.io/praxis-proxy/grid-operator:v0.1.3".to_owned());
     let vcr_image = crate::env::image_overrides::vcr_image();
-    let image_pull_policy =
-        std::env::var("GRID_XTASK_IMAGE_PULL_POLICY").unwrap_or_else(|_| "IfNotPresent".to_owned());
+    let image_pull_policy = std::env::var("GRID_XTASK_IMAGE_PULL_POLICY").unwrap_or_else(|_| "IfNotPresent".to_owned());
 
     let (gateway_repo, gateway_tag) = parse_image_ref(&gateway_image);
     let (operator_repo, operator_tag) = parse_image_ref(&operator_image);

--- a/xtask/src/env/image_overrides.rs
+++ b/xtask/src/env/image_overrides.rs
@@ -128,10 +128,13 @@ pub(crate) fn image_pull_policy() -> String {
 }
 
 /// Get the image pull policy for the given ingress mode.
+///
+/// Both `IngressMode` variants currently use the same registry-backed
+/// default; the parameter is kept so a future mode-specific default can be
+/// added without changing this function's signature.
 pub(crate) fn demo_image_pull_policy(mode: IngressMode) -> String {
     let default = match mode {
-        IngressMode::Global => DEFAULT_WORKLOAD_IMAGE_PULL_POLICY,
-        IngressMode::Workload => DEFAULT_WORKLOAD_IMAGE_PULL_POLICY,
+        IngressMode::Global | IngressMode::Workload => DEFAULT_WORKLOAD_IMAGE_PULL_POLICY,
     };
     env::var(IMAGE_PULL_POLICY_ENV).unwrap_or_else(|_| default.to_owned())
 }
@@ -170,14 +173,8 @@ mod tests {
         assert_eq!(DEFAULT_GATEWAY_IMAGE, "localhost/praxis-ai:llmd-ext-proc");
         assert_eq!(DEFAULT_MOCK_EPP_IMAGE, "localhost/praxis-ai-mock-epp:latest");
         assert_eq!(DEFAULT_OPERATOR_IMAGE, "grid-operator:latest");
-        assert_eq!(
-            DEFAULT_GLB_GATEWAY_IMAGE,
-            "ghcr.io/praxis-proxy/grid-ai-rollup:v0.1.3"
-        );
-        assert_eq!(
-            DEFAULT_GLB_OPERATOR_IMAGE,
-            "ghcr.io/praxis-proxy/grid-operator:v0.1.3"
-        );
+        assert_eq!(DEFAULT_GLB_GATEWAY_IMAGE, "ghcr.io/praxis-proxy/grid-ai-rollup:v0.1.3");
+        assert_eq!(DEFAULT_GLB_OPERATOR_IMAGE, "ghcr.io/praxis-proxy/grid-operator:v0.1.3");
         assert_eq!(DEFAULT_IMAGE_PULL_POLICY, "Never");
         assert_eq!(
             DEFAULT_WORKLOAD_GATEWAY_IMAGE,


### PR DESCRIPTION
## Context

Noticed while investigating [`ai#716`](https://github.com/praxis-proxy/ai/issues/716) that `main`'s own `lint` CI check has been red since [`ad9f36c`](https://github.com/praxis-proxy/grid/commit/ad9f36c5e1c71d4282cea0a3ab8195263c08b2c8) (everything else — tests, coverage, msrv, etc. — is green).

## What's wrong

`make lint` fails on two independent issues in the same gate, both pre-existing:

1. **`cargo clippy -D warnings` (`clippy::match_same_arms`)** — `IngressMode::Global` and `IngressMode::Workload` both map to the same `DEFAULT_WORKLOAD_IMAGE_PULL_POLICY` value in `demo_image_pull_policy`. Merged into a single or-pattern arm (clippy's own suggested fix), with a doc comment on why the parameter stays despite both variants currently sharing a default. Existing test coverage (`public_demo_modes_use_registry_defaults`) already asserts both variants return the same value.
2. **`cargo +nightly-2026-03-28 fmt --all -- --check`** (same nightly this repo's CI pins) — two call sites had drifted from the formatter's output. CI's `lint` job short-circuits at the clippy step today, so this second failure is currently hidden: fixing only the clippy issue would just move the same red check to a different error. Ran the pinned formatter to resolve — purely whitespace/line-wrapping, no logic changes.

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo +nightly-2026-03-28 fmt --all -- --check` — clean
- [x] `cargo test -p xtask image_overrides` — 6/6 passing
- [x] `cargo machete` — clean