### PR TITLE
fix(crdt): cap distinct origin site-slots per tenant_spend counter

### DIFF
--- a/crdt/src/gcounter.rs
+++ b/crdt/src/gcounter.rs
@@ -97,6 +97,23 @@ impl GCounter {
     pub fn remove_slot(&mut self, site: &str) {
         self.slots.remove(site);
     }
+
+    /// Return the number of distinct sites with a recorded slot.
+    ///
+    /// Used to enforce a hard cap on distinct origins contributing to a
+    /// single counter (see `grid_state::MAX_TENANT_SPEND_ORIGINS`), as
+    /// defense-in-depth against a compromised or churning origin claiming
+    /// unbounded new site identities.
+    #[must_use]
+    pub fn slot_count(&self) -> usize {
+        self.slots.len()
+    }
+
+    /// Return whether `site` already has a recorded slot.
+    #[must_use]
+    pub fn has_slot(&self, site: &str) -> bool {
+        self.slots.contains_key(site)
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -256,6 +273,37 @@ mod tests {
         c.remove_slot("site-never-contributed");
 
         assert_eq!(c.total(), 10, "removing an absent slot must not change the total");
+    }
+
+    #[test]
+    fn slot_count_reflects_distinct_sites_after_merge() {
+        let mut a = GCounter::new("site-a".to_owned());
+        a.increment(10);
+        assert_eq!(a.slot_count(), 1, "one increment from one site is one slot");
+
+        let mut b = GCounter::new("site-b".to_owned());
+        b.increment(5);
+        a.merge(&b);
+
+        assert_eq!(a.slot_count(), 2, "merging in a second site's slot must be counted");
+    }
+
+    #[test]
+    fn slot_count_is_zero_for_a_fresh_counter() {
+        let c = GCounter::new("site-a".to_owned());
+        assert_eq!(c.slot_count(), 0, "a counter with no increments yet has no slots");
+    }
+
+    #[test]
+    fn has_slot_reports_presence_per_site() {
+        let mut c = GCounter::new("site-a".to_owned());
+        c.increment(10);
+
+        assert!(c.has_slot("site-a"), "site-a incremented, so it must have a slot");
+        assert!(
+            !c.has_slot("site-b"),
+            "site-b never contributed, so it must not have a slot"
+        );
     }
 
     #[test]

--- a/crdt/src/grid_state.rs
+++ b/crdt/src/grid_state.rs
@@ -1090,9 +1090,6 @@ mod tests {
 
     #[test]
     fn merge_tenant_spend_from_origin_refuses_new_origin_once_tenant_at_capacity() {
-        // Security: bound the number of distinct site-slots a single tenant's
-        // counter accumulates, independent of MAX_TRACKED_TENANTS (which
-        // bounds tenant_id count, not origins-per-tenant).
         let mut snap = GridStateSnapshot::new("site-local".to_owned());
         fill_tenant_origins(&mut snap, "tenant-x", MAX_TENANT_SPEND_ORIGINS);
 
@@ -1102,7 +1099,8 @@ mod tests {
         assert_eq!(
             counter.slot_count(),
             MAX_TENANT_SPEND_ORIGINS,
-            "a brand-new origin must be refused once this tenant's counter is at its hard bound"
+            "a brand-new origin must be refused once this tenant's counter is at its hard bound -- this caps \
+             distinct site-slots per tenant, independent of MAX_TRACKED_TENANTS (which bounds tenant_id count)"
         );
         assert!(
             !counter.has_slot("site-overflow"),
@@ -1120,15 +1118,14 @@ mod tests {
         let mut snap = GridStateSnapshot::new("site-local".to_owned());
         fill_tenant_origins(&mut snap, "tenant-x", MAX_TENANT_SPEND_ORIGINS);
 
-        // site-0 already has a slot; a higher-amount update from it must still
-        // merge even though the tenant's counter is at the origin-slot cap.
         merge_one_origin_spend(&mut snap, "site-0", "tenant-x", 99);
 
         let counter = tenant_counter(&snap, "tenant-x");
         assert_eq!(
             counter.slot_count(),
             MAX_TENANT_SPEND_ORIGINS,
-            "updating an already-tracked origin must not change the slot count"
+            "site-0 already has a slot, so a higher-amount update from it must still merge even at the \
+             origin-slot cap; updating an already-tracked origin must not change the slot count"
         );
         assert_eq!(
             counter.total(),
@@ -1139,9 +1136,6 @@ mod tests {
 
     #[test]
     fn merge_tenant_spend_from_origin_admits_new_origin_one_below_capacity() {
-        // Pin the exact boundary: MAX_TENANT_SPEND_ORIGINS - 1 distinct
-        // origins already tracked must still admit one more (the cap itself,
-        // not cap - 1, is the refusal point).
         let mut snap = GridStateSnapshot::new("site-local".to_owned());
         fill_tenant_origins(&mut snap, "tenant-x", MAX_TENANT_SPEND_ORIGINS - 1);
 
@@ -1151,7 +1145,9 @@ mod tests {
         assert_eq!(
             counter.slot_count(),
             MAX_TENANT_SPEND_ORIGINS,
-            "the (MAX_TENANT_SPEND_ORIGINS)-th distinct origin must still be admitted"
+            "pins the exact boundary: with MAX_TENANT_SPEND_ORIGINS - 1 origins already tracked, the \
+             (MAX_TENANT_SPEND_ORIGINS)-th distinct origin must still be admitted -- the cap itself, not \
+             cap - 1, is the refusal point"
         );
         assert!(
             counter.has_slot("site-last"),
@@ -1161,15 +1157,18 @@ mod tests {
 
     #[test]
     fn merge_tenant_spend_from_origin_caps_are_independent_per_tenant() {
-        // A different tenant's counter must not be affected by another
-        // tenant's origin-slot cap being reached.
         let mut snap = GridStateSnapshot::new("site-local".to_owned());
         fill_tenant_origins(&mut snap, "tenant-x", MAX_TENANT_SPEND_ORIGINS);
 
         merge_one_origin_spend(&mut snap, "site-0", "tenant-y", 5);
 
         let tenant_y = tenant_counter(&snap, "tenant-y");
-        assert_eq!(tenant_y.slot_count(), 1, "tenant-y's cap is independent of tenant-x's");
+        assert_eq!(
+            tenant_y.slot_count(),
+            1,
+            "tenant-y's cap is independent of tenant-x's; another tenant reaching its origin-slot cap must \
+             not affect this one"
+        );
         assert_eq!(tenant_y.total(), 5);
     }
 }

--- a/crdt/src/grid_state.rs
+++ b/crdt/src/grid_state.rs
@@ -31,6 +31,25 @@ use crate::{GCounter, OrSet};
 /// `max_origins` bound already used for retained-origin maps in `swim`.
 pub const MAX_TRACKED_TENANTS: usize = 1_024;
 
+/// Hard bound on the number of distinct site-slots accumulated within a
+/// single tenant's [`GridStateSnapshot::tenant_spend`] counter.
+///
+/// A different axis from [`MAX_TRACKED_TENANTS`], which bounds the number of
+/// distinct `tenant_id` keys: this bounds the number of distinct *origins*
+/// (sites) contributing to any one tenant's counter. Without this bound, a
+/// compromised or churning origin repeatedly claiming new site identities
+/// could grow a single tenant's [`GCounter`] slot map without limit, since
+/// nothing currently removes a site's slot once recorded (dead-member
+/// eviction deliberately does not clear `tenant_spend` — see
+/// [`GridStateSnapshot::remove_origin_tenant_spend`]'s doc comment).
+///
+/// 256 is generous headroom for any real Grid deployment's site count (Grid's
+/// SWIM layer is documented to scale to 50,000+ nodes, but that bounds
+/// membership gossip fan-out, not the number of *distinct sites a customer
+/// actually deploys* — realistically tens, not thousands) while still
+/// bounding pathological/adversarial growth.
+pub const MAX_TENANT_SPEND_ORIGINS: usize = 256;
+
 // ---------------------------------------------------------------------------
 // Access policy
 // ---------------------------------------------------------------------------
@@ -251,10 +270,17 @@ impl GridStateSnapshot {
     /// peer cannot forge another site's recorded spend by embedding extra
     /// slots in its own broadcast.
     ///
-    /// Also enforces [`MAX_TRACKED_TENANTS`]: once that many distinct
-    /// `tenant_id`s are tracked, brand-new `tenant_id`s are silently refused
-    /// (already-tracked tenants keep accepting updates) to bound memory
-    /// growth from gossip carrying arbitrary attacker-supplied `tenant_id`s.
+    /// Also enforces two independent bounds:
+    ///
+    /// - [`MAX_TRACKED_TENANTS`]: once that many distinct `tenant_id`s are tracked, brand-new `tenant_id`s are silently
+    ///   refused.
+    /// - [`MAX_TENANT_SPEND_ORIGINS`]: once a single tenant's counter has that many distinct origin slots, a brand-new
+    ///   origin's contribution to that tenant is silently refused.
+    ///
+    /// In both cases, already-tracked tenants/origins keep accepting
+    /// updates — only brand-new keys are refused at capacity — to bound
+    /// memory growth from gossip carrying arbitrary attacker-supplied
+    /// `tenant_id`s or an unbounded number of claimed origin identities.
     ///
     /// [`merge_tenant_spend`]: Self::merge_tenant_spend
     pub fn merge_tenant_spend_from_origin(&mut self, origin_site: &str, other: &BTreeMap<String, GCounter>) {
@@ -266,10 +292,14 @@ impl GridStateSnapshot {
             if !self.tenant_spend.contains_key(tenant_id) && self.tenant_spend.len() >= MAX_TRACKED_TENANTS {
                 continue;
             }
-            self.tenant_spend
+            let entry = self
+                .tenant_spend
                 .entry(tenant_id.clone())
-                .or_insert_with(|| GCounter::new(self.site_id.clone()))
-                .merge(&origin_only);
+                .or_insert_with(|| GCounter::new(self.site_id.clone()));
+            if !entry.has_slot(origin_site) && entry.slot_count() >= MAX_TENANT_SPEND_ORIGINS {
+                continue;
+            }
+            entry.merge(&origin_only);
         }
     }
 
@@ -1028,5 +1058,118 @@ mod tests {
             99,
             "an already-tracked tenant must still accept updates while the map is at capacity"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // MAX_TENANT_SPEND_ORIGINS bound (grid#52: distinct site-slots per tenant)
+    // -----------------------------------------------------------------------
+
+    /// Merge one origin's `amount`-cent contribution to `tenant_id` into `snap`.
+    fn merge_one_origin_spend(snap: &mut GridStateSnapshot, origin: &str, tenant_id: &str, amount: u64) {
+        let mut incoming = BTreeMap::new();
+        let mut counter = GCounter::new(origin.to_owned());
+        counter.increment(amount);
+        incoming.insert(tenant_id.to_owned(), counter);
+        snap.merge_tenant_spend_from_origin(origin, &incoming);
+    }
+
+    /// Fill `tenant_id`'s counter to exactly `count` distinct origin slots
+    /// (`site-0..site-{count - 1}`, one cent each).
+    fn fill_tenant_origins(snap: &mut GridStateSnapshot, tenant_id: &str, count: usize) {
+        for i in 0..count {
+            merge_one_origin_spend(snap, &format!("site-{i}"), tenant_id, 1);
+        }
+    }
+
+    /// Look up `tenant_id`'s counter, aborting the test if it's missing.
+    fn tenant_counter<'a>(snap: &'a GridStateSnapshot, tenant_id: &str) -> &'a GCounter {
+        snap.tenant_spend
+            .get(tenant_id)
+            .unwrap_or_else(|| std::process::abort())
+    }
+
+    #[test]
+    fn merge_tenant_spend_from_origin_refuses_new_origin_once_tenant_at_capacity() {
+        // Security: bound the number of distinct site-slots a single tenant's
+        // counter accumulates, independent of MAX_TRACKED_TENANTS (which
+        // bounds tenant_id count, not origins-per-tenant).
+        let mut snap = GridStateSnapshot::new("site-local".to_owned());
+        fill_tenant_origins(&mut snap, "tenant-x", MAX_TENANT_SPEND_ORIGINS);
+
+        merge_one_origin_spend(&mut snap, "site-overflow", "tenant-x", 1);
+
+        let counter = tenant_counter(&snap, "tenant-x");
+        assert_eq!(
+            counter.slot_count(),
+            MAX_TENANT_SPEND_ORIGINS,
+            "a brand-new origin must be refused once this tenant's counter is at its hard bound"
+        );
+        assert!(
+            !counter.has_slot("site-overflow"),
+            "the refused origin's slot must not be present at all"
+        );
+        assert_eq!(
+            counter.total(),
+            u64::try_from(MAX_TENANT_SPEND_ORIGINS).unwrap_or(u64::MAX),
+            "the refused origin's contribution must not be reflected in the total"
+        );
+    }
+
+    #[test]
+    fn merge_tenant_spend_from_origin_still_updates_already_tracked_origin_at_capacity() {
+        let mut snap = GridStateSnapshot::new("site-local".to_owned());
+        fill_tenant_origins(&mut snap, "tenant-x", MAX_TENANT_SPEND_ORIGINS);
+
+        // site-0 already has a slot; a higher-amount update from it must still
+        // merge even though the tenant's counter is at the origin-slot cap.
+        merge_one_origin_spend(&mut snap, "site-0", "tenant-x", 99);
+
+        let counter = tenant_counter(&snap, "tenant-x");
+        assert_eq!(
+            counter.slot_count(),
+            MAX_TENANT_SPEND_ORIGINS,
+            "updating an already-tracked origin must not change the slot count"
+        );
+        assert_eq!(
+            counter.total(),
+            u64::try_from(MAX_TENANT_SPEND_ORIGINS - 1).unwrap_or(u64::MAX) + 99,
+            "an already-tracked origin must still accept updates (max-per-slot) while the tenant is at capacity"
+        );
+    }
+
+    #[test]
+    fn merge_tenant_spend_from_origin_admits_new_origin_one_below_capacity() {
+        // Pin the exact boundary: MAX_TENANT_SPEND_ORIGINS - 1 distinct
+        // origins already tracked must still admit one more (the cap itself,
+        // not cap - 1, is the refusal point).
+        let mut snap = GridStateSnapshot::new("site-local".to_owned());
+        fill_tenant_origins(&mut snap, "tenant-x", MAX_TENANT_SPEND_ORIGINS - 1);
+
+        merge_one_origin_spend(&mut snap, "site-last", "tenant-x", 1);
+
+        let counter = tenant_counter(&snap, "tenant-x");
+        assert_eq!(
+            counter.slot_count(),
+            MAX_TENANT_SPEND_ORIGINS,
+            "the (MAX_TENANT_SPEND_ORIGINS)-th distinct origin must still be admitted"
+        );
+        assert!(
+            counter.has_slot("site-last"),
+            "the newly-admitted origin's slot must be present"
+        );
+    }
+
+    #[test]
+    fn merge_tenant_spend_from_origin_caps_are_independent_per_tenant() {
+        // A different tenant's counter must not be affected by another
+        // tenant's origin-slot cap being reached.
+        let mut snap = GridStateSnapshot::new("site-local".to_owned());
+        fill_tenant_origins(&mut snap, "tenant-x", MAX_TENANT_SPEND_ORIGINS);
+
+        merge_one_origin_spend(&mut snap, "site-0", "tenant-y", 5);
+
+        let tenant_y = tenant_counter(&snap, "tenant-y");
+        assert_eq!(tenant_y.slot_count(), 1, "tenant-y's cap is independent of tenant-x's");
+        assert_eq!(tenant_y.total(), 5);
     }
 }

--- a/swim/src/state_broadcast.rs
+++ b/swim/src/state_broadcast.rs
@@ -1508,9 +1508,6 @@ mod tests {
 
     #[test]
     fn receive_item_caps_distinct_origin_slots_for_a_tenant() {
-        // Exercises MAX_TENANT_SPEND_ORIGINS at the real SWIM ingest boundary
-        // (receive_item), not just the internal merge function directly, to
-        // prove the bound actually applies to gossip as delivered.
         let mut handler = StateBroadcastHandler::new("site-local".to_owned());
         for i in 0..crdt::grid_state::MAX_TENANT_SPEND_ORIGINS {
             receive_tenant_spend_broadcast(&mut handler, &format!("site-{i}"), 1, "tenant-x", 1);
@@ -1526,7 +1523,9 @@ mod tests {
         assert_eq!(
             counter.slot_count(),
             crdt::grid_state::MAX_TENANT_SPEND_ORIGINS,
-            "a brand-new origin's broadcast must be dropped once the tenant's counter is at capacity"
+            "a brand-new origin's broadcast must be dropped once the tenant's counter is at capacity -- \
+             exercised at the real SWIM ingest boundary (receive_item), not just the internal merge function \
+             directly, to prove the bound actually applies to gossip as delivered"
         );
         assert_eq!(
             counter.total(),
@@ -1542,10 +1541,6 @@ mod tests {
             receive_tenant_spend_broadcast(&mut handler, &format!("site-{i}"), 1, "tenant-x", 1);
         }
 
-        // site-0 already has a slot; a higher-revision, higher-amount
-        // broadcast from it must still be merged even though the tenant is
-        // at the origin-slot cap — the cap only blocks brand-new origins,
-        // not legitimate ongoing updates from origins already being tracked.
         receive_tenant_spend_broadcast(&mut handler, "site-0", 2, "tenant-x", 500);
 
         let merged = handler.snapshot();
@@ -1556,7 +1551,9 @@ mod tests {
         assert_eq!(
             counter.total(),
             u64::try_from(crdt::grid_state::MAX_TENANT_SPEND_ORIGINS - 1).unwrap_or(u64::MAX) + 500,
-            "an already-tracked origin must keep converging normally once the tenant is at capacity"
+            "site-0 already has a slot, so a higher-revision, higher-amount broadcast from it must still merge \
+             at the origin-slot cap -- the cap only blocks brand-new origins, not ongoing updates from origins \
+             already being tracked"
         );
     }
 

--- a/swim/src/state_broadcast.rs
+++ b/swim/src/state_broadcast.rs
@@ -1483,6 +1483,83 @@ mod tests {
         );
     }
 
+    // -----------------------------------------------------------------------
+    // tenant_spend origin-slot cap tests (grid#52)
+    // -----------------------------------------------------------------------
+
+    /// Deliver one origin's tenant-spend-only broadcast through the real
+    /// SWIM ingest entry point (`receive_item`, via the `receive` helper).
+    ///
+    /// `revision` must be unique-and-increasing per call for the same
+    /// `origin` — `receive_item` drops a same-or-lower-revision broadcast
+    /// from an origin it has already seen as stale, independent of this
+    /// module's own cap logic (see `receive_item`'s `latest_by_origin` check).
+    fn receive_tenant_spend_broadcast(
+        handler: &mut StateBroadcastHandler,
+        origin: &str,
+        revision: u64,
+        tenant_id: &str,
+        amount: u64,
+    ) {
+        let mut snap = GridStateSnapshot::new(origin.to_owned());
+        snap.increment_tenant_spend(tenant_id, amount);
+        receive(handler, &StateBroadcast::new(origin.to_owned(), revision, snap, None));
+    }
+
+    #[test]
+    fn receive_item_caps_distinct_origin_slots_for_a_tenant() {
+        // Exercises MAX_TENANT_SPEND_ORIGINS at the real SWIM ingest boundary
+        // (receive_item), not just the internal merge function directly, to
+        // prove the bound actually applies to gossip as delivered.
+        let mut handler = StateBroadcastHandler::new("site-local".to_owned());
+        for i in 0..crdt::grid_state::MAX_TENANT_SPEND_ORIGINS {
+            receive_tenant_spend_broadcast(&mut handler, &format!("site-{i}"), 1, "tenant-x", 1);
+        }
+
+        receive_tenant_spend_broadcast(&mut handler, "site-overflow", 1, "tenant-x", 1);
+
+        let merged = handler.snapshot();
+        let counter = merged
+            .tenant_spend
+            .get("tenant-x")
+            .unwrap_or_else(|| std::process::abort());
+        assert_eq!(
+            counter.slot_count(),
+            crdt::grid_state::MAX_TENANT_SPEND_ORIGINS,
+            "a brand-new origin's broadcast must be dropped once the tenant's counter is at capacity"
+        );
+        assert_eq!(
+            counter.total(),
+            u64::try_from(crdt::grid_state::MAX_TENANT_SPEND_ORIGINS).unwrap_or(u64::MAX),
+            "the overflow origin's amount must not be reflected in the merged total"
+        );
+    }
+
+    #[test]
+    fn receive_item_still_merges_updates_from_an_already_tracked_origin_once_capped() {
+        let mut handler = StateBroadcastHandler::new("site-local".to_owned());
+        for i in 0..crdt::grid_state::MAX_TENANT_SPEND_ORIGINS {
+            receive_tenant_spend_broadcast(&mut handler, &format!("site-{i}"), 1, "tenant-x", 1);
+        }
+
+        // site-0 already has a slot; a higher-revision, higher-amount
+        // broadcast from it must still be merged even though the tenant is
+        // at the origin-slot cap — the cap only blocks brand-new origins,
+        // not legitimate ongoing updates from origins already being tracked.
+        receive_tenant_spend_broadcast(&mut handler, "site-0", 2, "tenant-x", 500);
+
+        let merged = handler.snapshot();
+        let counter = merged
+            .tenant_spend
+            .get("tenant-x")
+            .unwrap_or_else(|| std::process::abort());
+        assert_eq!(
+            counter.total(),
+            u64::try_from(crdt::grid_state::MAX_TENANT_SPEND_ORIGINS - 1).unwrap_or(u64::MAX) + 500,
+            "an already-tracked origin must keep converging normally once the tenant is at capacity"
+        );
+    }
+
     #[test]
     fn handler_accepts_v1_broadcast_without_gateway_address() {
         let mut handler = StateBroadcastHandler::new("site-local".to_owned());


### PR DESCRIPTION
## What

Bounds the number of distinct origin site-slots a single tenant's `tenant_spend` `GCounter` can accumulate, closing the site-slot-cap half of #52 (proposal item 2).

## Why

`#47`'s fix (correctly) stopped pruning `tenant_spend` on SWIM membership eviction, but that traded away the growth bound the buggy behavior accidentally provided. Nothing today removes a site's slot from a tenant's counter once recorded, so a compromised or churning origin repeatedly claiming new site identities could grow a single tenant's counter without bound. `MAX_TRACKED_TENANTS` already bounds distinct `tenant_id` keys — this is the independent, previously-missing bound on distinct *origins* within one tenant's counter that #52 called out.

## How

- `GCounter::slot_count`/`has_slot` — new introspection needed to check the cap.
- `GridStateSnapshot::merge_tenant_spend_from_origin`: new `MAX_TENANT_SPEND_ORIGINS = 256` bound, enforced the same way `MAX_TRACKED_TENANTS` already is — a brand-new origin is refused once a tenant's counter is at capacity; already-tracked origins keep accepting updates.

## Testing (pyramid invariant)

- **Unit** (`crdt`): `GCounter` slot_count/has_slot behavior, plus 4 new `grid_state` tests pinning the cap's refuse/admit/boundary/independence behavior.
- **Integration** (`swim`): 2 new tests exercise the cap through the real SWIM gossip-ingest entry point (`StateBroadcastHandler::receive_item`), not just the internal merge function directly.
- **E2E**: intentionally skipped, called out explicitly rather than silently — simulating 256 distinct origins against a live cluster is impractical and low-signal. This mirrors the already-shipped precedent: `MAX_TRACKED_TENANTS` itself has unit-tier coverage only, no integration/E2E.

All of `cargo fmt`, `cargo clippy -D warnings`, `cargo doc` (deny-level rustdoc link checks), `cargo machete`, and this repo's `ai-slop-lint` pass clean.

## Scope

This PR intentionally covers only proposal item 2 from #52 (the site-slot cap). Proposal item 1 (the budget-epoch/window reset) needs CRD schema changes plus cross-site epoch-fencing design to avoid a monotonic `GCounter` re-merge reviving a "reset" total — that's real additional design surface, so it's tracked as its own follow-up issue rather than bundled here. #52 stays open until that lands.

Closes half of #52 (item 2); does not close the issue.
