### PR TITLE
feat(operator): stabilized provider admission with scrape-generation identity

### DIFF
--- a/charts/grid-operator/crds/gridnetwork.yaml
+++ b/charts/grid-operator/crds/gridnetwork.yaml
@@ -34,6 +34,84 @@ spec:
                 Defines the grid's seed peers, gateway associations, SWIM
                 tuning, and TLS secret references.
               properties:
+                admissionPolicy:
+                  description: |-
+                    Provider admission and pressure-recovery policy.
+
+                    When omitted, Grid preserves the historical instantaneous admission
+                    behaviour and providers without metrics remain eligible. New
+                    stabilized deployments should set this explicitly so missing metrics
+                    fail closed according to `missingMetrics`.
+                  nullable: true
+                  properties:
+                    missingMetrics:
+                      default: existingOnly
+                      description: Fail-closed state for missing or expired metrics.
+                      enum:
+                        - existingOnly
+                        - excluded
+                      type: string
+                    mode:
+                      default: instantaneous
+                      description: Admission evaluation mode.
+                      enum:
+                        - instantaneous
+                        - stabilized
+                      type: string
+                    pressure:
+                      default:
+                        enterThreshold: 0.85
+                        exitThreshold: 0.7
+                        failureThreshold: 2
+                        minimumStateDuration: 10s
+                        recoveryHoldDown: 30s
+                        successThreshold: 3
+                      description: Pressure and recovery thresholds.
+                      properties:
+                        enterThreshold:
+                          description: Pressure level at which a provider is considered saturated.
+                          format: double
+                          maximum: 1.0
+                          minimum: 0.0
+                          type: number
+                        exitThreshold:
+                          description: Lower pressure level required before recovery can begin.
+                          format: double
+                          maximum: 1.0
+                          minimum: 0.0
+                          type: number
+                        failureThreshold:
+                          description: Consecutive pressure observations required to enter `existingOnly`.
+                          format: uint32
+                          maximum: 100.0
+                          minimum: 1.0
+                          type: integer
+                        minimumStateDuration:
+                          description: Minimum time a state must remain active before changing.
+                          pattern: ^[1-9][0-9]*s$
+                          type: string
+                        recoveryHoldDown:
+                          description: Additional time to hold a recovering provider in `existingOnly`.
+                          pattern: ^[1-9][0-9]*s$
+                          type: string
+                        successThreshold:
+                          description: Consecutive healthy observations required to recover new admission.
+                          format: uint32
+                          maximum: 100.0
+                          minimum: 1.0
+                          type: integer
+                      required:
+                        - enterThreshold
+                        - exitThreshold
+                        - failureThreshold
+                        - minimumStateDuration
+                        - recoveryHoldDown
+                        - successThreshold
+                      type: object
+                      x-kubernetes-validations:
+                        - message: exitThreshold must be less than enterThreshold
+                          rule: self.exitThreshold < self.enterThreshold
+                  type: object
                 budgetPolicy:
                   description: |-
                     Budget policy configuration for per-tenant spend tracking.

--- a/charts/grid-site/templates/gridnetwork.yaml
+++ b/charts/grid-site/templates/gridnetwork.yaml
@@ -29,6 +29,10 @@ spec:
     strategy: {{ .strategy | quote }}
   {{- end }}
   {{- end }}
+  {{- with .Values.gridNetwork.admissionPolicy }}
+  admissionPolicy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- with .Values.gridNetwork.metricsRefreshInterval }}
   {{- if . }}
   metricsRefreshInterval: {{ . | quote }}

--- a/charts/grid-site/values.schema.json
+++ b/charts/grid-site/values.schema.json
@@ -49,6 +49,28 @@
             }
           }
         },
+        "admissionPolicy": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["mode", "pressure", "missingMetrics"],
+          "properties": {
+            "mode": { "type": "string", "enum": ["instantaneous", "stabilized"] },
+            "missingMetrics": { "type": "string", "enum": ["existingOnly", "excluded"] },
+            "pressure": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["enterThreshold", "exitThreshold", "failureThreshold", "successThreshold", "minimumStateDuration", "recoveryHoldDown"],
+              "properties": {
+                "enterThreshold": { "type": "number", "minimum": 0, "maximum": 1 },
+                "exitThreshold": { "type": "number", "minimum": 0, "maximum": 1 },
+                "failureThreshold": { "type": "integer", "minimum": 1, "maximum": 100 },
+                "successThreshold": { "type": "integer", "minimum": 1, "maximum": 100 },
+                "minimumStateDuration": { "type": "string", "pattern": "^[1-9][0-9]*s$" },
+                "recoveryHoldDown": { "type": "string", "pattern": "^[1-9][0-9]*s$" }
+              }
+            }
+          }
+        },
         "metricsRefreshInterval": {
           "type": "string",
           "pattern": "^([1-9][0-9]*s|[1-9][0-9]{3,}ms)$"

--- a/charts/grid-site/values.yaml
+++ b/charts/grid-site/values.yaml
@@ -6,6 +6,18 @@ gridNetwork:
   swim: {}
   tls: {}
   gatewayRefs: []
+  # New chart installations fail closed on missing metrics and stabilize
+  # pressure admission. Omit this block only for legacy instantaneous mode.
+  admissionPolicy:
+    mode: stabilized
+    pressure:
+      enterThreshold: 0.85
+      exitThreshold: 0.70
+      failureThreshold: 2
+      successThreshold: 3
+      minimumStateDuration: 10s
+      recoveryHoldDown: 30s
+    missingMetrics: existingOnly
 
 gridSite:
   name: ""

--- a/deploy/crds/gridnetwork.yaml
+++ b/deploy/crds/gridnetwork.yaml
@@ -34,6 +34,84 @@ spec:
                 Defines the grid's seed peers, gateway associations, SWIM
                 tuning, and TLS secret references.
               properties:
+                admissionPolicy:
+                  description: |-
+                    Provider admission and pressure-recovery policy.
+
+                    When omitted, Grid preserves the historical instantaneous admission
+                    behaviour and providers without metrics remain eligible. New
+                    stabilized deployments should set this explicitly so missing metrics
+                    fail closed according to `missingMetrics`.
+                  nullable: true
+                  properties:
+                    missingMetrics:
+                      default: existingOnly
+                      description: Fail-closed state for missing or expired metrics.
+                      enum:
+                        - existingOnly
+                        - excluded
+                      type: string
+                    mode:
+                      default: instantaneous
+                      description: Admission evaluation mode.
+                      enum:
+                        - instantaneous
+                        - stabilized
+                      type: string
+                    pressure:
+                      default:
+                        enterThreshold: 0.85
+                        exitThreshold: 0.7
+                        failureThreshold: 2
+                        minimumStateDuration: 10s
+                        recoveryHoldDown: 30s
+                        successThreshold: 3
+                      description: Pressure and recovery thresholds.
+                      properties:
+                        enterThreshold:
+                          description: Pressure level at which a provider is considered saturated.
+                          format: double
+                          maximum: 1.0
+                          minimum: 0.0
+                          type: number
+                        exitThreshold:
+                          description: Lower pressure level required before recovery can begin.
+                          format: double
+                          maximum: 1.0
+                          minimum: 0.0
+                          type: number
+                        failureThreshold:
+                          description: Consecutive pressure observations required to enter `existingOnly`.
+                          format: uint32
+                          maximum: 100.0
+                          minimum: 1.0
+                          type: integer
+                        minimumStateDuration:
+                          description: Minimum time a state must remain active before changing.
+                          pattern: ^[1-9][0-9]*s$
+                          type: string
+                        recoveryHoldDown:
+                          description: Additional time to hold a recovering provider in `existingOnly`.
+                          pattern: ^[1-9][0-9]*s$
+                          type: string
+                        successThreshold:
+                          description: Consecutive healthy observations required to recover new admission.
+                          format: uint32
+                          maximum: 100.0
+                          minimum: 1.0
+                          type: integer
+                      required:
+                        - enterThreshold
+                        - exitThreshold
+                        - failureThreshold
+                        - minimumStateDuration
+                        - recoveryHoldDown
+                        - successThreshold
+                      type: object
+                      x-kubernetes-validations:
+                        - message: exitThreshold must be less than enterThreshold
+                          rule: self.exitThreshold < self.enterThreshold
+                  type: object
                 budgetPolicy:
                   description: |-
                     Budget policy configuration for per-tenant spend tracking.

--- a/docs/architecture/routing.md
+++ b/docs/architecture/routing.md
@@ -395,7 +395,8 @@ before candidates reach the ordering phase.
 
 ### Admission state derivation
 
-Admission state is threshold-based from current metrics only:
+When `spec.admissionPolicy` is omitted, admission preserves the legacy
+instantaneous behavior:
 
 | Condition | State |
 |-----------|-------|
@@ -404,10 +405,19 @@ Admission state is threshold-based from current metrics only:
 | `queue_depth > 0.85` or `kv_cache_utilization > 0.90` | `existing_only` |
 | Otherwise | `new_and_existing` |
 
-Admission is a point-in-time snapshot of the metrics observed at reconcile
-time. Deployments that require hysteresis, hold-down timers, compare-and-swap
-coordination, or shared active-active admission state must provide those
-control-plane guarantees before enabling threshold-based admission.
+New installations from the `grid-site` Helm chart explicitly select the
+stabilized policy. Stabilized admission requires repeated pressure observations
+before entering `existing_only`, and repeated low-pressure observations plus a
+minimum state duration and recovery hold-down before returning to
+`new_and_existing`. Missing or expired metrics fail closed to `existing_only`
+by default (or `none` when `missingMetrics: excluded`). Hard health failures
+still move immediately to `none`. The evaluator is control-plane state keyed by
+provider identity; no admission check runs in the request path.
+
+The wire states remain `new_and_existing`, `existing_only`, and `none`, so this
+change is compatible with existing Praxis consumers. Restarting the operator
+resets the hysteresis counters and requires fresh observations before a
+restrictive provider is promoted.
 
 ### Locality tier derivation
 

--- a/docs/architecture/scoring.md
+++ b/docs/architecture/scoring.md
@@ -209,8 +209,11 @@ seconds is not a substitute for request-time load balancing.
 
 - No request-specific prefix affinity at the Grid layer.
 - No independent remote metric sample timestamp yet.
-- No score-switch margin, dwell timer, or recovery hold-down.
-- Admission thresholds are point-in-time comparisons without hysteresis.
+- Stabilized admission is available through `spec.admissionPolicy`; it uses
+  bounded pressure/recovery counters and hold-down timers, while omitting the
+  field preserves instantaneous compatibility behavior.
+- Ranking still has no independent score-switch margin or dwell timer; that is
+  separate from provider admission and remains future work.
 - Queue normalization depends on a correct `queueCapacity`.
 - A network-wide metric strategy is appropriate only when competing providers
   expose comparable telemetry; use `noMetrics` for heterogeneous providers.

--- a/operator/src/controller/grid_network.rs
+++ b/operator/src/controller/grid_network.rs
@@ -35,7 +35,7 @@ use crate::{
     error::OperatorError,
     resources::{
         consumer_config::{self, ConsumerConfigError},
-        overlay_envelope, provider_metrics, routing_overlay, secret,
+        overlay_envelope, provider_admission, provider_metrics, routing_overlay, secret,
         trust_bundle::{self, CertPemStatus},
     },
     swim::{MemberStatus, MembershipSnapshot},
@@ -75,6 +75,12 @@ pub struct OperatorCtx {
     /// wrapping `Arc`; the inner [`Mutex`] ensures safe concurrent access.
     pub(crate) metrics_cache: Mutex<provider_metrics::MetricsCache>,
 
+    /// Stateful admission memory keyed by provider routing identity.
+    ///
+    /// Admission is evaluated in the control plane and the resulting wire
+    /// state is copied into the overlay. It is never consulted by a request.
+    pub(crate) admission_memory: Mutex<provider_admission::AdmissionMemory>,
+
     /// Tracks the seed set announced on the last reconcile per `GridNetwork`.
     ///
     /// Keyed by `GridNetwork` name.  On each reconcile, the new seed set is
@@ -98,6 +104,7 @@ impl OperatorCtx {
             client,
             swim,
             metrics_cache: Mutex::new(provider_metrics::MetricsCache::new()),
+            admission_memory: Mutex::new(provider_admission::AdmissionMemory::default()),
             last_seeds: std::sync::Mutex::new(HashMap::new()),
         }
     }
@@ -267,9 +274,79 @@ pub async fn reconcile(network: Arc<GridNetwork>, ctx: Arc<OperatorCtx>) -> Resu
     // List providers once; share between routing overlay rendering and CRDT publishing.
     let providers = list_all_inference_providers(client).await?;
     let requeue_interval = requeue_interval_for_network(&network, &providers)?;
-    let raw_metrics =
-        provider_metrics::collect_provider_metrics(name, &providers, &ctx.metrics_cache, Instant::now(), Some(client))
-            .await;
+    let collected = provider_metrics::collect_provider_metrics_with_refresh_interval(
+        name,
+        &providers,
+        &ctx.metrics_cache,
+        Instant::now(),
+        requeue_interval,
+        Some(client),
+    )
+    .await;
+    let raw_metrics = collected.metrics;
+
+    let scoring_strategy = network
+        .spec
+        .scoring_policy
+        .as_ref()
+        .map_or(crate::crd::grid_network::ScoringStrategy::NoMetrics, |policy| {
+            policy.strategy
+        });
+    let admission_policy =
+        provider_admission::Policy::from_config(network.spec.admission_policy.as_ref(), scoring_strategy.into())
+            .map_err(OperatorError::InvalidResource)?;
+    let now = Instant::now();
+    let mut admission_states = HashMap::new();
+    let mut admission_keys = Vec::new();
+    {
+        let mut memory = ctx.admission_memory.lock().await;
+        for provider in providers
+            .iter()
+            .filter(|provider| provider.spec.grid_network_ref == name)
+        {
+            let Some(identity) = routing_overlay::routing_identity(provider) else {
+                continue;
+            };
+            let identity = identity.to_owned();
+            let memory_key = format!(
+                "{name}/{}/{}",
+                provider.metadata.uid.as_deref().map_or(identity.as_str(), |uid| uid),
+                identity
+            );
+            let signal_configured = match scoring_strategy {
+                crate::crd::grid_network::ScoringStrategy::QueueDepth => provider
+                    .spec
+                    .metrics_config
+                    .as_ref()
+                    .and_then(|config| config.signal_names.queue_depth.as_ref())
+                    .is_some(),
+                crate::crd::grid_network::ScoringStrategy::KvCachePressure => provider
+                    .spec
+                    .metrics_config
+                    .as_ref()
+                    .and_then(|config| config.signal_names.kv_cache_utilization.as_ref())
+                    .is_some(),
+                crate::crd::grid_network::ScoringStrategy::NoMetrics => false,
+            };
+            let observation = if signal_configured {
+                raw_metrics
+                    .get(&identity)
+                    .copied()
+                    .map_or(provider_admission::Observation::Missing, |metrics| {
+                        provider_admission::Observation::Fresh {
+                            revision: collected.generations.get(&identity).copied().unwrap_or(0),
+                            metrics,
+                        }
+                    })
+            } else {
+                provider_admission::Observation::NotConfigured
+            };
+            let state = memory.evaluate(&memory_key, observation, admission_policy, now);
+            admission_keys.push(memory_key);
+            admission_states.insert(identity, state);
+        }
+        memory.retain_network_keys(name, admission_keys.iter().cloned());
+    }
 
     let remote_crdt_providers: Vec<crdt::ProviderState> = ctx
         .swim
@@ -304,6 +381,7 @@ pub async fn reconcile(network: Arc<GridNetwork>, ctx: Arc<OperatorCtx>) -> Resu
         &remote_crdt_providers,
         &raw_metrics,
         &scoring_weights,
+        &admission_states,
     )
     .await?;
 
@@ -727,6 +805,7 @@ async fn reconcile_routing_overlay_inner(
     remote_crdt_providers: &[crdt::ProviderState],
     raw_metrics: &HashMap<String, scoring::BackendMetrics>,
     scoring_weights: &scoring::ScoringWeights,
+    admission_states: &HashMap<String, crate::resources::geography::AdmissionState>,
 ) -> Result<(Vec<ConsumerConfigStatus>, Vec<OverlayRevisionStatus>), OperatorError> {
     let network_name = grid_network_name(network)?;
 
@@ -770,7 +849,7 @@ async fn reconcile_routing_overlay_inner(
         }
 
         let timestamp = rfc3339_now();
-        let overlay = match routing_overlay::render_routing_overlay(
+        let overlay = match routing_overlay::render_routing_overlay_with_admission(
             network,
             &sites,
             providers,
@@ -779,6 +858,7 @@ async fn reconcile_routing_overlay_inner(
             metrics_arg,
             timestamp.as_deref(),
             scoring_weights,
+            Some(admission_states),
         ) {
             Ok(overlay) => overlay,
             Err(error) => {

--- a/operator/src/crd/grid_network.rs
+++ b/operator/src/crd/grid_network.rs
@@ -154,6 +154,99 @@ pub fn resolve_scoring_weights(policy: Option<&ScoringPolicyConfig>) -> scoring:
 }
 
 // ---------------------------------------------------------------------------
+// Admission policy
+// ---------------------------------------------------------------------------
+
+/// Controls whether provider admission reacts immediately or uses bounded
+/// hysteresis across reconciles.
+#[derive(Clone, Copy, Debug, Default, Deserialize, JsonSchema, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum AdmissionMode {
+    /// Apply the current observation immediately.  This is the compatibility
+    /// behaviour used when `admissionPolicy` is omitted.
+    #[default]
+    Instantaneous,
+    /// Require repeated pressure/recovery observations before changing state.
+    Stabilized,
+}
+
+/// Fail-closed state to use when configured provider metrics are unavailable.
+#[derive(Clone, Copy, Debug, Default, Deserialize, JsonSchema, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum MissingMetricsPolicy {
+    /// Preserve existing sessions but do not admit new ones.
+    #[default]
+    ExistingOnly,
+    /// Remove the provider from the published routing overlay.
+    Excluded,
+}
+
+/// Pressure and recovery hysteresis configuration.
+#[derive(Clone, Debug, Deserialize, JsonSchema, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[schemars(
+    deny_unknown_fields,
+    extend("x-kubernetes-validations" = [{
+        "rule": "self.exitThreshold < self.enterThreshold",
+        "message": "exitThreshold must be less than enterThreshold"
+    }])
+)]
+pub struct AdmissionPressureConfig {
+    /// Pressure level at which a provider is considered saturated.
+    #[schemars(range(min = 0.0, max = 1.0))]
+    pub enter_threshold: f64,
+    /// Lower pressure level required before recovery can begin.
+    #[schemars(range(min = 0.0, max = 1.0))]
+    pub exit_threshold: f64,
+    /// Consecutive pressure observations required to enter `existingOnly`.
+    #[schemars(range(min = 1, max = 100))]
+    pub failure_threshold: u32,
+    /// Consecutive healthy observations required to recover new admission.
+    #[schemars(range(min = 1, max = 100))]
+    pub success_threshold: u32,
+    /// Minimum time a state must remain active before changing.
+    #[schemars(regex(pattern = "^[1-9][0-9]*s$"))]
+    pub minimum_state_duration: String,
+    /// Additional time to hold a recovering provider in `existingOnly`.
+    #[schemars(regex(pattern = "^[1-9][0-9]*s$"))]
+    pub recovery_hold_down: String,
+}
+
+impl Default for AdmissionPressureConfig {
+    fn default() -> Self {
+        Self {
+            enter_threshold: 0.85,
+            exit_threshold: 0.70,
+            failure_threshold: 2,
+            success_threshold: 3,
+            minimum_state_duration: "10s".to_owned(),
+            recovery_hold_down: "30s".to_owned(),
+        }
+    }
+}
+
+/// Provider admission policy for routing overlays.
+#[derive(Clone, Debug, Default, Deserialize, JsonSchema, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[schemars(deny_unknown_fields)]
+pub struct AdmissionPolicyConfig {
+    /// Admission evaluation mode.
+    #[serde(default)]
+    pub mode: AdmissionMode,
+    /// Pressure and recovery thresholds.
+    #[serde(default)]
+    pub pressure: AdmissionPressureConfig,
+    /// Fail-closed state for missing or expired metrics.
+    #[serde(default = "default_missing_metrics_policy")]
+    pub missing_metrics: MissingMetricsPolicy,
+}
+
+/// Return the fail-closed default for omitted `missingMetrics`.
+fn default_missing_metrics_policy() -> MissingMetricsPolicy {
+    MissingMetricsPolicy::ExistingOnly
+}
+
+// ---------------------------------------------------------------------------
 // Budget policy
 // ---------------------------------------------------------------------------
 
@@ -437,6 +530,15 @@ pub struct GridNetworkSpec {
     /// See [`ScoringStrategy`] for the available provider-level strategies.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub scoring_policy: Option<ScoringPolicyConfig>,
+
+    /// Provider admission and pressure-recovery policy.
+    ///
+    /// When omitted, Grid preserves the historical instantaneous admission
+    /// behaviour and providers without metrics remain eligible. New
+    /// stabilized deployments should set this explicitly so missing metrics
+    /// fail closed according to `missingMetrics`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub admission_policy: Option<AdmissionPolicyConfig>,
 
     /// Maximum time between metric refreshes and score/ranking recalculation.
     ///

--- a/operator/src/resources/mod.rs
+++ b/operator/src/resources/mod.rs
@@ -27,6 +27,8 @@ pub mod credentials;
 pub mod overlay_bridge;
 /// Versioned overlay envelope for content-addressed revision tracking.
 pub mod overlay_envelope;
+/// Stateful provider admission and pressure-recovery evaluator.
+pub(crate) mod provider_admission;
 /// Provider metrics collection for the [`GridNetwork`] overlay renderer.
 ///
 /// [`GridNetwork`]: crate::crd::grid_network::GridNetwork

--- a/operator/src/resources/provider_admission.rs
+++ b/operator/src/resources/provider_admission.rs
@@ -1,0 +1,723 @@
+//! Stateful provider admission evaluation.
+//!
+//! This module is deliberately independent of Kubernetes and reconciliation.
+//! It turns one typed observation into a bounded wire admission state while
+//! retaining only the small amount of history needed for hysteresis.  The
+//! controller owns one [`AdmissionMemory`](crate::resources::provider_admission::AdmissionMemory)
+//! and supplies the reconciliation
+//! clock, so the evaluator is deterministic and straightforward to test.
+
+use std::{
+    collections::HashMap,
+    time::{Duration, Instant},
+};
+
+use crate::{
+    crd::grid_network::{AdmissionMode, AdmissionPolicyConfig, MissingMetricsPolicy, ScoringStrategy},
+    resources::geography::AdmissionState,
+};
+
+/// A metrics observation available to the admission evaluator.
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum Observation {
+    /// A fresh, successfully parsed provider observation.
+    Fresh {
+        /// Normalized metric values.
+        metrics: scoring::BackendMetrics,
+        /// Revision identifying the accepted observation sample.
+        revision: u64,
+    },
+    /// The active scoring strategy does not use a metric for this provider.
+    NotConfigured,
+    /// No usable observation was available for this provider.
+    Missing,
+}
+
+/// Metric selected by the active scoring strategy for admission pressure.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum PressureSignal {
+    /// Normalized pending queue pressure.
+    QueueDepth,
+    /// Normalized KV-cache utilization.
+    KvCachePressure,
+    /// No metric-driven admission is active.
+    None,
+}
+
+impl From<ScoringStrategy> for PressureSignal {
+    fn from(strategy: ScoringStrategy) -> Self {
+        match strategy {
+            ScoringStrategy::QueueDepth => Self::QueueDepth,
+            ScoringStrategy::KvCachePressure => Self::KvCachePressure,
+            ScoringStrategy::NoMetrics => Self::None,
+        }
+    }
+}
+
+/// Validated policy used by the pure evaluator.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) struct Policy {
+    /// Whether state changes are immediate or stabilized.
+    pub(crate) mode: AdmissionMode,
+    /// Pressure threshold for entering restricted admission.
+    pub(crate) enter_threshold: f64,
+    /// Lower pressure threshold for recovery.
+    pub(crate) exit_threshold: f64,
+    /// Required consecutive pressure observations.
+    pub(crate) failure_threshold: u32,
+    /// Required consecutive recovery observations.
+    pub(crate) success_threshold: u32,
+    /// Minimum duration of the current state.
+    pub(crate) minimum_state_duration: Duration,
+    /// Required recovery hold-down duration.
+    pub(crate) recovery_hold_down: Duration,
+    /// State used when metrics are unavailable.
+    pub(crate) missing_metrics: MissingMetricsPolicy,
+    /// Signal used to evaluate pressure and recovery.
+    pub(crate) pressure_signal: PressureSignal,
+}
+
+impl Policy {
+    /// Convert the CRD form into a validated evaluator policy.
+    #[expect(
+        clippy::too_many_lines,
+        reason = "validation keeps all admission policy constraints together"
+    )]
+    pub(crate) fn from_config(
+        config: Option<&AdmissionPolicyConfig>,
+        pressure_signal: PressureSignal,
+    ) -> Result<Self, String> {
+        let Some(config) = config else {
+            return Ok(Self {
+                mode: AdmissionMode::Instantaneous,
+                enter_threshold: 0.85,
+                exit_threshold: 0.70,
+                failure_threshold: 1,
+                success_threshold: 1,
+                minimum_state_duration: Duration::ZERO,
+                recovery_hold_down: Duration::ZERO,
+                // Omitted policy preserves the historical no-metrics default.
+                missing_metrics: MissingMetricsPolicy::ExistingOnly,
+                pressure_signal,
+            });
+        };
+        if !config.enter_exit_valid() {
+            return Err(
+                "admissionPolicy pressure thresholds must be finite, in [0,1], and exitThreshold < enterThreshold"
+                    .into(),
+            );
+        }
+        let minimum_state_duration =
+            parse_positive_seconds(&config.pressure.minimum_state_duration, "minimumStateDuration")?;
+        let recovery_hold_down = parse_positive_seconds(&config.pressure.recovery_hold_down, "recoveryHoldDown")?;
+        if config.pressure.failure_threshold == 0 || config.pressure.failure_threshold > 100 {
+            return Err("admissionPolicy pressure failureThreshold must be between 1 and 100".into());
+        }
+        if config.pressure.success_threshold == 0 || config.pressure.success_threshold > 100 {
+            return Err("admissionPolicy pressure successThreshold must be between 1 and 100".into());
+        }
+        Ok(Self {
+            mode: config.mode,
+            enter_threshold: config.pressure.enter_threshold,
+            exit_threshold: config.pressure.exit_threshold,
+            failure_threshold: config.pressure.failure_threshold,
+            success_threshold: config.pressure.success_threshold,
+            minimum_state_duration,
+            recovery_hold_down,
+            missing_metrics: config.missing_metrics,
+            pressure_signal,
+        })
+    }
+}
+
+impl AdmissionPolicyConfig {
+    /// True when both thresholds are finite, in `[0,1]`, and exit < enter.
+    fn enter_exit_valid(&self) -> bool {
+        self.pressure.enter_threshold.is_finite()
+            && self.pressure.exit_threshold.is_finite()
+            && (0.0..=1.0).contains(&self.pressure.enter_threshold)
+            && (0.0..=1.0).contains(&self.pressure.exit_threshold)
+            && self.pressure.exit_threshold < self.pressure.enter_threshold
+    }
+}
+
+/// Parse the intentionally bounded whole-second admission duration syntax.
+fn parse_positive_seconds(value: &str, field: &str) -> Result<Duration, String> {
+    let Some(number) = value.strip_suffix('s') else {
+        return Err(format!(
+            "admissionPolicy pressure {field} must use a positive whole-second duration"
+        ));
+    };
+    if number.is_empty() || number.starts_with('0') {
+        return Err(format!(
+            "admissionPolicy pressure {field} must use a positive whole-second duration"
+        ));
+    }
+    let seconds = number
+        .parse::<u64>()
+        .map_err(|error| format!("admissionPolicy pressure {field} is not a valid duration: {error}"))?;
+    if seconds == 0 {
+        return Err(format!("admissionPolicy pressure {field} must be greater than zero"));
+    }
+    Ok(Duration::from_secs(seconds))
+}
+
+/// Per-provider hysteresis state retained across reconciliation cycles.
+#[derive(Clone, Copy, Debug)]
+struct Entry {
+    /// Current published admission state.
+    state: AdmissionState,
+    /// Consecutive pressure observations.
+    pressure_observations: u32,
+    /// Consecutive recovery observations.
+    recovery_observations: u32,
+    /// Time at which the current state began.
+    state_since: Instant,
+    /// Time at which the current recovery streak began.
+    recovery_since: Option<Instant>,
+    /// Revision of the most recently processed fresh observation.
+    last_observation: Option<u64>,
+}
+
+/// Cross-reconcile admission state, keyed by a stable provider identity.
+#[derive(Debug, Default)]
+pub(crate) struct AdmissionMemory {
+    /// Per-provider state keyed by `{network}/{uid}/{routing_identity}`.
+    entries: HashMap<String, Entry>,
+}
+
+impl AdmissionMemory {
+    /// Evaluate and remember one provider's admission state.
+    #[expect(
+        clippy::too_many_lines,
+        reason = "the state machine keeps pressure, recovery, missing, and hard-failure transitions explicit"
+    )]
+    pub(crate) fn evaluate(
+        &mut self,
+        key: &str,
+        observation: Observation,
+        policy: Policy,
+        now: Instant,
+    ) -> AdmissionState {
+        if policy.mode == AdmissionMode::Instantaneous {
+            let state = instantaneous_state(observation, policy);
+            self.entries.insert(key.to_owned(), new_entry(state, now));
+            return state;
+        }
+
+        let initial_state = match observation {
+            Observation::Fresh { .. } | Observation::NotConfigured => AdmissionState::NewAndExisting,
+            Observation::Missing => missing_state(policy),
+        };
+        let entry = self
+            .entries
+            .entry(key.to_owned())
+            .or_insert_with(|| new_entry(initial_state, now));
+        if let Observation::Fresh { revision, .. } = observation {
+            if entry.last_observation == Some(revision) {
+                return entry.state;
+            }
+            entry.last_observation = Some(revision);
+        } else {
+            entry.last_observation = None;
+        }
+        let elapsed = now.saturating_duration_since(entry.state_since);
+        match observation {
+            Observation::NotConfigured => {
+                entry.pressure_observations = 0;
+                entry.recovery_observations = 0;
+                entry.recovery_since = None;
+                entry.state = AdmissionState::NewAndExisting;
+                entry.state_since = now;
+            },
+            Observation::Missing => {
+                entry.pressure_observations = 0;
+                entry.recovery_observations = 0;
+                entry.recovery_since = None;
+                entry.state = missing_state(policy);
+                entry.state_since = now;
+            },
+            Observation::Fresh { metrics, .. } if !metrics.healthy => {
+                entry.pressure_observations = 0;
+                entry.recovery_observations = 0;
+                entry.recovery_since = None;
+                entry.state = AdmissionState::Excluded;
+                entry.state_since = now;
+            },
+            Observation::Fresh { metrics, .. } => {
+                let pressure = pressure_value(metrics, policy) >= policy.enter_threshold;
+                let recovered = pressure_value(metrics, policy) <= policy.exit_threshold;
+                if entry.state == AdmissionState::NewAndExisting {
+                    entry.recovery_observations = 0;
+                    entry.recovery_since = None;
+                    entry.pressure_observations = if pressure {
+                        entry.pressure_observations.saturating_add(1)
+                    } else {
+                        0
+                    };
+                    if pressure
+                        && entry.pressure_observations >= policy.failure_threshold
+                        && elapsed >= policy.minimum_state_duration
+                    {
+                        entry.state = AdmissionState::ExistingOnly;
+                        entry.state_since = now;
+                        entry.pressure_observations = 0;
+                    }
+                } else if entry.state == AdmissionState::ExistingOnly {
+                    entry.pressure_observations = 0;
+                    if recovered {
+                        entry.recovery_observations = entry.recovery_observations.saturating_add(1);
+                        let recovery_since = *entry.recovery_since.get_or_insert(now);
+                        if entry.recovery_observations >= policy.success_threshold
+                            && now.saturating_duration_since(recovery_since) >= policy.recovery_hold_down
+                            && elapsed >= policy.minimum_state_duration
+                        {
+                            entry.state = AdmissionState::NewAndExisting;
+                            entry.state_since = now;
+                            entry.recovery_observations = 0;
+                            entry.recovery_since = None;
+                        }
+                    } else {
+                        entry.recovery_observations = 0;
+                        entry.recovery_since = None;
+                    }
+                } else {
+                    // Excluded providers require a fresh healthy observation
+                    // before they can re-enter the admission state machine.
+                    if recovered {
+                        entry.recovery_observations = entry.recovery_observations.saturating_add(1);
+                        let recovery_since = *entry.recovery_since.get_or_insert(now);
+                        if entry.recovery_observations >= policy.success_threshold
+                            && now.saturating_duration_since(recovery_since) >= policy.recovery_hold_down
+                            && elapsed >= policy.minimum_state_duration
+                        {
+                            entry.state = AdmissionState::NewAndExisting;
+                            entry.state_since = now;
+                            entry.recovery_observations = 0;
+                            entry.recovery_since = None;
+                        }
+                    } else {
+                        entry.recovery_observations = 0;
+                        entry.recovery_since = None;
+                    }
+                }
+            },
+        }
+        entry.state
+    }
+
+    /// Remove state for providers no longer present in one network.
+    pub(crate) fn retain_network_keys(&mut self, network_name: &str, keys: impl Iterator<Item = String>) {
+        let keys: std::collections::HashSet<String> = keys.collect();
+        let prefix = format!("{network_name}/");
+        self.entries
+            .retain(|key, _| !key.starts_with(&prefix) || keys.contains(key));
+    }
+}
+
+/// Create an admission-memory entry at the supplied clock instant.
+fn new_entry(state: AdmissionState, now: Instant) -> Entry {
+    Entry {
+        state,
+        pressure_observations: 0,
+        recovery_observations: 0,
+        state_since: now,
+        recovery_since: None,
+        last_observation: None,
+    }
+}
+
+/// Convert the configured missing-metrics policy to a wire state.
+fn missing_state(policy: Policy) -> AdmissionState {
+    if policy.pressure_signal == PressureSignal::None {
+        return AdmissionState::NewAndExisting;
+    }
+    match policy.missing_metrics {
+        MissingMetricsPolicy::ExistingOnly => AdmissionState::ExistingOnly,
+        MissingMetricsPolicy::Excluded => AdmissionState::Excluded,
+    }
+}
+
+/// Evaluate one observation without hysteresis.
+fn instantaneous_state(observation: Observation, policy: Policy) -> AdmissionState {
+    match observation {
+        Observation::Missing => missing_state(policy),
+        Observation::Fresh { metrics, .. } if !metrics.healthy => AdmissionState::Excluded,
+        Observation::Fresh { metrics, .. } if pressure_value(metrics, policy) >= policy.enter_threshold => {
+            AdmissionState::ExistingOnly
+        },
+        Observation::NotConfigured | Observation::Fresh { .. } => AdmissionState::NewAndExisting,
+    }
+}
+
+/// Return the normalized pressure selected by the active scoring strategy.
+fn pressure_value(metrics: scoring::BackendMetrics, policy: Policy) -> f64 {
+    match policy.pressure_signal {
+        PressureSignal::QueueDepth => metrics.queue_depth,
+        PressureSignal::KvCachePressure => metrics.kv_cache_utilization,
+        PressureSignal::None => 0.0,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn metrics(queue_depth: f64, kv_cache_utilization: f64, healthy: bool) -> scoring::BackendMetrics {
+        scoring::BackendMetrics {
+            error_rate: 0.0,
+            healthy,
+            kv_cache_utilization,
+            latency_p99_ms: 0.0,
+            prefix_cache_hit_ratio: 0.0,
+            queue_depth,
+        }
+    }
+
+    fn policy() -> Policy {
+        Policy {
+            mode: AdmissionMode::Stabilized,
+            enter_threshold: 0.85,
+            exit_threshold: 0.70,
+            failure_threshold: 2,
+            success_threshold: 3,
+            minimum_state_duration: Duration::from_secs(10),
+            recovery_hold_down: Duration::from_secs(30),
+            missing_metrics: MissingMetricsPolicy::ExistingOnly,
+            pressure_signal: PressureSignal::QueueDepth,
+        }
+    }
+
+    fn fresh(metrics: scoring::BackendMetrics, generation: u64) -> Observation {
+        Observation::Fresh {
+            revision: generation,
+            metrics,
+        }
+    }
+
+    #[test]
+    fn pressure_requires_repeated_observations() {
+        let start = Instant::now();
+        let mut memory = AdmissionMemory::default();
+        let p = policy();
+        assert_eq!(
+            memory.evaluate("p", fresh(metrics(0.90, 0.0, true), 1), p, start),
+            AdmissionState::NewAndExisting
+        );
+        assert_eq!(
+            memory.evaluate(
+                "p",
+                fresh(metrics(0.91, 0.0, true), 2),
+                p,
+                start + Duration::from_secs(10)
+            ),
+            AdmissionState::ExistingOnly
+        );
+    }
+
+    #[test]
+    fn missing_metrics_fail_closed_only_when_policy_is_explicit() {
+        let start = Instant::now();
+        let mut memory = AdmissionMemory::default();
+        let legacy = Policy {
+            mode: AdmissionMode::Instantaneous,
+            enter_threshold: 0.85,
+            exit_threshold: 0.70,
+            failure_threshold: 1,
+            success_threshold: 1,
+            minimum_state_duration: Duration::ZERO,
+            recovery_hold_down: Duration::ZERO,
+            missing_metrics: MissingMetricsPolicy::ExistingOnly,
+            pressure_signal: PressureSignal::None,
+        };
+        assert_eq!(
+            memory.evaluate("legacy", Observation::Missing, legacy, start),
+            AdmissionState::NewAndExisting
+        );
+        assert_eq!(
+            memory.evaluate("stabilized", Observation::Missing, policy(), start),
+            AdmissionState::ExistingOnly
+        );
+    }
+
+    #[test]
+    fn unhealthy_is_immediately_excluded() {
+        let start = Instant::now();
+        let mut memory = AdmissionMemory::default();
+        assert_eq!(
+            memory.evaluate("p", fresh(metrics(0.0, 0.0, false), 1), policy(), start),
+            AdmissionState::Excluded
+        );
+    }
+
+    #[test]
+    #[expect(clippy::too_many_lines, reason = "multi-phase state machine test")]
+    fn recovery_requires_count_and_hold_down() {
+        let start = Instant::now();
+        let mut memory = AdmissionMemory::default();
+        let p = policy();
+        memory.evaluate("p", fresh(metrics(0.90, 0.0, true), 1), p, start);
+        memory.evaluate(
+            "p",
+            fresh(metrics(0.91, 0.0, true), 2),
+            p,
+            start + Duration::from_secs(10),
+        );
+        assert_eq!(
+            memory.evaluate(
+                "p",
+                fresh(metrics(0.10, 0.1, true), 3),
+                p,
+                start + Duration::from_secs(20)
+            ),
+            AdmissionState::ExistingOnly
+        );
+        assert_eq!(
+            memory.evaluate(
+                "p",
+                fresh(metrics(0.11, 0.1, true), 4),
+                p,
+                start + Duration::from_secs(30)
+            ),
+            AdmissionState::ExistingOnly
+        );
+        assert_eq!(
+            memory.evaluate(
+                "p",
+                fresh(metrics(0.12, 0.1, true), 5),
+                p,
+                start + Duration::from_secs(50)
+            ),
+            AdmissionState::NewAndExisting
+        );
+    }
+
+    #[test]
+    fn queue_strategy_ignores_kv_pressure() {
+        let start = Instant::now();
+        let mut memory = AdmissionMemory::default();
+        let mut p = policy();
+        p.pressure_signal = PressureSignal::QueueDepth;
+        let observation = fresh(metrics(0.1, 0.99, true), 1);
+        assert_eq!(
+            memory.evaluate("p", observation, p, start),
+            AdmissionState::NewAndExisting
+        );
+    }
+
+    #[test]
+    fn kv_strategy_ignores_queue_pressure() {
+        let start = Instant::now();
+        let mut memory = AdmissionMemory::default();
+        let mut p = policy();
+        p.pressure_signal = PressureSignal::KvCachePressure;
+        let observation = fresh(metrics(0.99, 0.1, true), 1);
+        assert_eq!(
+            memory.evaluate("p", observation, p, start),
+            AdmissionState::NewAndExisting
+        );
+    }
+
+    #[test]
+    fn repeated_sample_does_not_advance_pressure_counter() {
+        let start = Instant::now();
+        let mut memory = AdmissionMemory::default();
+        let p = policy();
+        let sample = fresh(metrics(0.9, 0.1, true), 1);
+        assert_eq!(memory.evaluate("p", sample, p, start), AdmissionState::NewAndExisting);
+        assert_eq!(
+            memory.evaluate("p", sample, p, start + Duration::from_secs(10)),
+            AdmissionState::NewAndExisting
+        );
+        assert_eq!(
+            memory.evaluate(
+                "p",
+                fresh(metrics(0.91, 0.1, true), 2),
+                p,
+                start + Duration::from_secs(20)
+            ),
+            AdmissionState::ExistingOnly
+        );
+    }
+
+    #[test]
+    #[expect(clippy::too_many_lines, reason = "multi-phase state machine test")]
+    fn repeated_recovery_sample_does_not_advance_recovery_counter() {
+        let start = Instant::now();
+        let mut memory = AdmissionMemory::default();
+        let p = policy();
+        memory.evaluate("p", fresh(metrics(0.90, 0.0, true), 1), p, start);
+        memory.evaluate(
+            "p",
+            fresh(metrics(0.91, 0.0, true), 2),
+            p,
+            start + Duration::from_secs(10),
+        );
+        assert_eq!(
+            memory.evaluate(
+                "p",
+                fresh(metrics(0.10, 0.1, true), 3),
+                p,
+                start + Duration::from_secs(20)
+            ),
+            AdmissionState::ExistingOnly
+        );
+        // Same generation repeated — must not advance recovery counter.
+        let repeated = fresh(metrics(0.10, 0.1, true), 3);
+        assert_eq!(
+            memory.evaluate("p", repeated, p, start + Duration::from_secs(30)),
+            AdmissionState::ExistingOnly
+        );
+        assert_eq!(
+            memory.evaluate("p", repeated, p, start + Duration::from_secs(60)),
+            AdmissionState::ExistingOnly
+        );
+        // Distinct generations advance recovery normally.
+        assert_eq!(
+            memory.evaluate(
+                "p",
+                fresh(metrics(0.11, 0.1, true), 4),
+                p,
+                start + Duration::from_secs(70)
+            ),
+            AdmissionState::ExistingOnly
+        );
+        assert_eq!(
+            memory.evaluate(
+                "p",
+                fresh(metrics(0.12, 0.1, true), 5),
+                p,
+                start + Duration::from_secs(80)
+            ),
+            AdmissionState::NewAndExisting
+        );
+    }
+
+    #[test]
+    fn same_generation_does_not_increment_pressure_twice() {
+        let start = Instant::now();
+        let mut memory = AdmissionMemory::default();
+        let p = policy();
+        let m = metrics(0.90, 0.0, true);
+        assert_eq!(
+            memory.evaluate("p", fresh(m, 1), p, start),
+            AdmissionState::NewAndExisting
+        );
+        assert_eq!(
+            memory.evaluate("p", fresh(m, 1), p, start + Duration::from_secs(5)),
+            AdmissionState::NewAndExisting
+        );
+        assert_eq!(
+            memory.evaluate("p", fresh(m, 2), p, start + Duration::from_secs(10)),
+            AdmissionState::ExistingOnly
+        );
+    }
+
+    #[test]
+    fn new_generation_with_identical_values_increments_counters() {
+        let start = Instant::now();
+        let mut memory = AdmissionMemory::default();
+        let p = policy();
+        let m = metrics(0.90, 0.0, true);
+        assert_eq!(
+            memory.evaluate("p", fresh(m, 1), p, start),
+            AdmissionState::NewAndExisting
+        );
+        assert_eq!(
+            memory.evaluate("p", fresh(m, 2), p, start + Duration::from_secs(10)),
+            AdmissionState::ExistingOnly
+        );
+    }
+
+    #[test]
+    fn clamped_queue_values_count_as_distinct_scrapes() {
+        let start = Instant::now();
+        let mut memory = AdmissionMemory::default();
+        let p = policy();
+        let m = metrics(1.0, 0.0, true);
+        assert_eq!(
+            memory.evaluate("p", fresh(m, 1), p, start),
+            AdmissionState::NewAndExisting
+        );
+        assert_eq!(
+            memory.evaluate("p", fresh(m, 2), p, start + Duration::from_secs(10)),
+            AdmissionState::ExistingOnly
+        );
+    }
+
+    #[test]
+    #[expect(clippy::too_many_lines, reason = "multi-phase state machine test")]
+    fn stable_idle_scrapes_satisfy_recovery_threshold() {
+        let start = Instant::now();
+        let mut memory = AdmissionMemory::default();
+        let p = policy();
+        memory.evaluate("p", fresh(metrics(0.90, 0.0, true), 1), p, start);
+        memory.evaluate(
+            "p",
+            fresh(metrics(0.90, 0.0, true), 2),
+            p,
+            start + Duration::from_secs(10),
+        );
+        assert_eq!(
+            memory.evaluate(
+                "p",
+                fresh(metrics(0.10, 0.0, true), 3),
+                p,
+                start + Duration::from_secs(20)
+            ),
+            AdmissionState::ExistingOnly
+        );
+        let idle = metrics(0.0, 0.0, true);
+        assert_eq!(
+            memory.evaluate("p", fresh(idle, 4), p, start + Duration::from_secs(30)),
+            AdmissionState::ExistingOnly
+        );
+        assert_eq!(
+            memory.evaluate("p", fresh(idle, 5), p, start + Duration::from_secs(40)),
+            AdmissionState::ExistingOnly
+        );
+        assert_eq!(
+            memory.evaluate("p", fresh(idle, 6), p, start + Duration::from_secs(60)),
+            AdmissionState::NewAndExisting
+        );
+    }
+
+    #[test]
+    fn retaining_one_network_does_not_reset_another_network() {
+        let start = Instant::now();
+        let mut memory = AdmissionMemory::default();
+        let p = policy();
+
+        assert_eq!(
+            memory.evaluate("network-a/provider", fresh(metrics(0.90, 0.0, true), 1), p, start),
+            AdmissionState::NewAndExisting
+        );
+        assert_eq!(
+            memory.evaluate("network-b/provider", fresh(metrics(0.90, 0.0, true), 2), p, start),
+            AdmissionState::NewAndExisting
+        );
+
+        memory.retain_network_keys("network-a", ["network-a/provider".to_owned()].into_iter());
+
+        assert_eq!(
+            memory.evaluate(
+                "network-a/provider",
+                fresh(metrics(0.91, 0.0, true), 3),
+                p,
+                start + Duration::from_secs(10),
+            ),
+            AdmissionState::ExistingOnly
+        );
+        // network-b's counter was preserved (not reset), so this second distinct
+        // observation reaches failureThreshold=2 → ExistingOnly.
+        assert_eq!(
+            memory.evaluate(
+                "network-b/provider",
+                fresh(metrics(0.91, 0.0, true), 4),
+                p,
+                start + Duration::from_secs(10),
+            ),
+            AdmissionState::ExistingOnly
+        );
+    }
+}

--- a/operator/src/resources/provider_metrics.rs
+++ b/operator/src/resources/provider_metrics.rs
@@ -69,6 +69,8 @@ pub(crate) struct TimestampedMetrics {
     pub(crate) metrics: scoring::BackendMetrics,
     /// When the scrape completed successfully.
     pub(crate) scraped_at: Instant,
+    /// Monotonic scrape generation assigned when this sample was collected.
+    pub(crate) generation: u64,
 }
 
 /// Cross-reconcile cache for recently-scraped provider metrics.
@@ -76,7 +78,30 @@ pub(crate) struct TimestampedMetrics {
 /// Keyed by `(network_name, provider_routing_identity)`.  Entries are updated on
 /// every successful scrape and consulted when a subsequent scrape fails and the
 /// provider has `metricsConfig.stale_metrics_seconds` set.
-pub(crate) type MetricsCache = HashMap<(String, String), TimestampedMetrics>;
+pub(crate) struct MetricsCache {
+    /// Per-provider cached metrics keyed by `(network_name, routing_identity)`.
+    entries: HashMap<(String, String), TimestampedMetrics>,
+    /// Monotonic counter incremented on each scrape call.
+    next_generation: u64,
+}
+
+impl MetricsCache {
+    /// Create an empty cache with the generation counter starting at 1.
+    pub(crate) fn new() -> Self {
+        Self {
+            entries: HashMap::new(),
+            next_generation: 1,
+        }
+    }
+}
+
+/// Metrics collected from a single scrape call, with scrape-level identity.
+pub(crate) struct CollectedMetrics {
+    /// Parsed metrics keyed by provider routing identity.
+    pub(crate) metrics: HashMap<String, scoring::BackendMetrics>,
+    /// Scrape generation per provider, monotonically increasing per successful scrape.
+    pub(crate) generations: HashMap<String, u64>,
+}
 
 // ---------------------------------------------------------------------------
 // URL construction
@@ -159,6 +184,10 @@ pub(crate) fn parse_metrics_timeout(s: &str) -> Duration {
 
 /// Scrape and parse live metrics for providers in `network_name` that have `spec.metricsConfig`.
 ///
+/// This compatibility wrapper always performs a fresh collection. Production
+/// reconciliation should use [`collect_provider_metrics_with_refresh_interval`]
+/// so watch-triggered reconciles can reuse the current scrape generation.
+///
 /// Returns a map from provider routing identity (the value of
 /// `spec.routingClusterRef`, or `metadata.name` when absent) to
 /// [`scoring::BackendMetrics`].
@@ -187,31 +216,57 @@ pub(crate) fn parse_metrics_timeout(s: &str) -> Duration {
 ///
 /// `now` is passed in (rather than read from `Instant::now()`) so tests can
 /// control the clock without sleeping.
-#[expect(
-    clippy::cognitive_complexity,
-    clippy::too_many_lines,
-    clippy::large_stack_frames,
-    reason = "sequential per-provider scrape loop with early-continue guards, cache read/write, TLS resolution, and error logging"
-)]
+#[cfg(test)]
 pub(crate) async fn collect_provider_metrics(
     network_name: &str,
     providers: &[InferenceProvider],
     cache: &Mutex<MetricsCache>,
     now: Instant,
     client: Option<&kube::Client>,
-) -> HashMap<String, scoring::BackendMetrics> {
-    // Snapshot only the relevant cache entries (for this network) so the lock
-    // is held for microseconds rather than across network I/O.
-    let cache_snapshot: HashMap<String, TimestampedMetrics> = {
-        let guard = cache.lock().await;
-        guard
+) -> CollectedMetrics {
+    collect_provider_metrics_with_refresh_interval(network_name, providers, cache, now, Duration::ZERO, client).await
+}
+
+/// Collect provider metrics, reusing samples collected within `refresh_interval`.
+///
+/// Reconciliation can be triggered by an overlay write or another watch event
+/// before the next metrics refresh is due. Reusing the cached sample in that
+/// window is important: it preserves the sample generation and prevents one
+/// underlying EPP observation from advancing admission hysteresis twice.
+#[expect(
+    clippy::cognitive_complexity,
+    clippy::too_many_arguments,
+    clippy::too_many_lines,
+    clippy::large_stack_frames,
+    reason = "sequential per-provider scrape loop with cache reuse, TLS resolution, and error handling"
+)]
+pub(crate) async fn collect_provider_metrics_with_refresh_interval(
+    network_name: &str,
+    providers: &[InferenceProvider],
+    cache: &Mutex<MetricsCache>,
+    now: Instant,
+    refresh_interval: Duration,
+    client: Option<&kube::Client>,
+) -> CollectedMetrics {
+    // Snapshot the relevant cache entries and allocate a generation for this
+    // refresh cycle. Cached samples reused below retain their own generation.
+    // The lock is held for microseconds rather than across network I/O.
+    let (cache_snapshot, scrape_generation) = {
+        let mut guard = cache.lock().await;
+        let generation = guard.next_generation;
+        guard.next_generation = generation.wrapping_add(1);
+        let snapshot: HashMap<String, TimestampedMetrics> = guard
+            .entries
             .iter()
             .filter(|((net, _), _)| net == network_name)
             .map(|((_, id), tm)| (id.clone(), tm.clone()))
-            .collect()
+            .collect();
+        drop(guard);
+        (snapshot, generation)
     };
 
     let mut result = HashMap::new();
+    let mut generations: HashMap<String, u64> = HashMap::new();
     let mut cache_updates: Vec<((String, String), TimestampedMetrics)> = Vec::new();
 
     for provider in providers {
@@ -251,11 +306,26 @@ pub(crate) async fn collect_provider_metrics(
         let timeout = parse_metrics_timeout(&mc.timeout);
         let names = metric_names_from_config(&mc.signal_names, mc.pool_name.as_deref(), mc.queue_capacity);
 
+        if refresh_interval > Duration::ZERO
+            && let Some(cached) = cache_snapshot.get(identity)
+            && now.saturating_duration_since(cached.scraped_at) < refresh_interval
+        {
+            result.insert(identity.to_owned(), cached.metrics);
+            generations.insert(identity.to_owned(), cached.generation);
+            continue;
+        }
+
         let tls_config = match resolve_tls_config(mc.tls.as_ref(), client, identity).await {
             Ok(cfg) => cfg,
             Err((_reason, e)) => {
-                let used_cache =
-                    try_cached_metrics(identity, mc.stale_metrics_seconds, &cache_snapshot, now, &mut result);
+                let used_cache = try_cached_metrics(
+                    identity,
+                    mc.stale_metrics_seconds,
+                    &cache_snapshot,
+                    now,
+                    &mut result,
+                    &mut generations,
+                );
                 if used_cache {
                     tracing::debug!(
                         provider = identity,
@@ -270,6 +340,7 @@ pub(crate) async fn collect_provider_metrics(
                             "metrics TLS resolution failed; provider excluded from routing"
                         );
                         result.insert(identity.to_owned(), UNOBSERVABLE_METRICS);
+                        generations.insert(identity.to_owned(), scrape_generation);
                     } else {
                         tracing::warn!(
                             provider = identity,
@@ -295,17 +366,25 @@ pub(crate) async fn collect_provider_metrics(
                     TimestampedMetrics {
                         metrics: bm,
                         scraped_at: now,
+                        generation: scrape_generation,
                     },
                 ));
                 result.insert(identity.to_owned(), bm);
+                generations.insert(identity.to_owned(), scrape_generation);
             },
             Err(e) => {
                 let reason_str = scrape_result
                     .as_ref()
                     .err()
                     .map_or("MetricsScrapeError", |e| classify_scrape_error(e));
-                let used_cache =
-                    try_cached_metrics(identity, mc.stale_metrics_seconds, &cache_snapshot, now, &mut result);
+                let used_cache = try_cached_metrics(
+                    identity,
+                    mc.stale_metrics_seconds,
+                    &cache_snapshot,
+                    now,
+                    &mut result,
+                    &mut generations,
+                );
                 if used_cache {
                     tracing::debug!(
                         provider = identity,
@@ -324,6 +403,7 @@ pub(crate) async fn collect_provider_metrics(
                             "metrics scrape failed; provider excluded from routing"
                         );
                         result.insert(identity.to_owned(), UNOBSERVABLE_METRICS);
+                        generations.insert(identity.to_owned(), scrape_generation);
                     } else {
                         tracing::warn!(
                             provider = identity,
@@ -342,11 +422,14 @@ pub(crate) async fn collect_provider_metrics(
     if !cache_updates.is_empty() {
         let mut guard = cache.lock().await;
         for (key, val) in cache_updates {
-            guard.insert(key, val);
+            guard.entries.insert(key, val);
         }
     }
 
-    result
+    CollectedMetrics {
+        metrics: result,
+        generations,
+    }
 }
 
 /// Attempt to populate `result` with a cached metric sample for `identity`.
@@ -354,14 +437,18 @@ pub(crate) async fn collect_provider_metrics(
 /// Returns `true` if a valid cached sample was found and inserted; `false` if
 /// no grace period is configured, the cache has no entry, or the entry is
 /// too old.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "generations mirror added alongside existing result out-param"
+)]
 fn try_cached_metrics(
     identity: &str,
     stale_metrics_seconds: Option<u32>,
     cache_snapshot: &HashMap<String, TimestampedMetrics>,
     now: Instant,
     result: &mut HashMap<String, scoring::BackendMetrics>,
+    generations: &mut HashMap<String, u64>,
 ) -> bool {
-    // Zero is treated as absent defensively (schema already rejects 0).
     let Some(ttl_secs) = stale_metrics_seconds.filter(|&s| s > 0) else {
         return false;
     };
@@ -374,6 +461,7 @@ fn try_cached_metrics(
         return false;
     }
     result.insert(identity.to_owned(), cached.metrics);
+    generations.insert(identity.to_owned(), cached.generation);
     true
 }
 
@@ -685,7 +773,7 @@ mod tests {
         let provider = provider_fixture("prov-a", "http://127.0.0.1:9999", None);
         let result = collect_provider_metrics("net", &[provider], &empty_cache(), Instant::now(), None).await;
         assert!(
-            result.is_empty(),
+            result.metrics.is_empty(),
             "provider without metricsConfig must not appear in metrics map"
         );
     }
@@ -694,7 +782,10 @@ mod tests {
     async fn collect_metrics_blank_endpoint_is_skipped() {
         let provider = provider_fixture("prov-a", "", Some(mc_with_queue("my_queue")));
         let result = collect_provider_metrics("net", &[provider], &empty_cache(), Instant::now(), None).await;
-        assert!(result.is_empty(), "provider with blank endpoint must not be scraped");
+        assert!(
+            result.metrics.is_empty(),
+            "provider with blank endpoint must not be scraped"
+        );
     }
 
     #[tokio::test]
@@ -705,10 +796,14 @@ mod tests {
 
         let result = collect_provider_metrics("net", &[provider], &empty_cache(), Instant::now(), None).await;
         assert!(
-            result.contains_key("prov-a"),
+            result.metrics.contains_key("prov-a"),
             "provider must appear in metrics map after successful scrape"
         );
-        let bm = result.get("prov-a").copied().unwrap_or_else(|| std::process::abort());
+        let bm = result
+            .metrics
+            .get("prov-a")
+            .copied()
+            .unwrap_or_else(|| std::process::abort());
         assert!(bm.queue_depth.is_finite(), "queue_depth must be finite");
         assert!(
             bm.queue_depth >= 0.0 && bm.queue_depth <= 1.0,
@@ -742,11 +837,11 @@ mod tests {
 
         let result = collect_provider_metrics("net", &[provider], &empty_cache(), Instant::now(), None).await;
         assert!(
-            result.contains_key("site-x"),
+            result.metrics.contains_key("site-x"),
             "metrics must be keyed by routingClusterRef, not metadata.name"
         );
         assert!(
-            !result.contains_key("prov-a"),
+            !result.metrics.contains_key("prov-a"),
             "metadata.name must not be used as key when routingClusterRef is set"
         );
     }
@@ -756,7 +851,7 @@ mod tests {
         let provider = provider_fixture("prov-a", "http://127.0.0.1:1", Some(mc_with_queue("my_queue")));
         let result = collect_provider_metrics("net", &[provider], &empty_cache(), Instant::now(), None).await;
         assert!(
-            !result.contains_key("prov-a"),
+            !result.metrics.contains_key("prov-a"),
             "plaintext provider scrape failure must not insert unobservable metrics"
         );
     }
@@ -767,7 +862,7 @@ mod tests {
         let provider = provider_fixture("prov-a", &base_url, Some(mc_with_queue("my_queue")));
         let result = collect_provider_metrics("net", &[provider], &empty_cache(), Instant::now(), None).await;
         assert!(
-            !result.contains_key("prov-a"),
+            !result.metrics.contains_key("prov-a"),
             "plaintext provider non-2xx response must not insert unobservable metrics"
         );
     }
@@ -781,10 +876,14 @@ mod tests {
 
         let result = collect_provider_metrics("net", &[provider], &empty_cache(), Instant::now(), None).await;
         assert!(
-            result.contains_key("prov-a"),
+            result.metrics.contains_key("prov-a"),
             "malformed body must still produce a metrics entry"
         );
-        let bm = result.get("prov-a").copied().unwrap_or_else(|| std::process::abort());
+        let bm = result
+            .metrics
+            .get("prov-a")
+            .copied()
+            .unwrap_or_else(|| std::process::abort());
         assert!(
             bm.queue_depth.is_finite(),
             "malformed body must produce finite queue_depth"
@@ -810,20 +909,88 @@ mod tests {
         let prov_b = provider_fixture("prov-b", &url_b, Some(mc_with_queue("my_queue")));
 
         let result = collect_provider_metrics("net", &[prov_a, prov_b], &empty_cache(), Instant::now(), None).await;
-        assert!(result.contains_key("prov-a"), "prov-a must be in metrics map");
-        assert!(result.contains_key("prov-b"), "prov-b must be in metrics map");
+        assert!(result.metrics.contains_key("prov-a"), "prov-a must be in metrics map");
+        assert!(result.metrics.contains_key("prov-b"), "prov-b must be in metrics map");
         assert!(
             result
+                .metrics
                 .get("prov-a")
                 .copied()
                 .unwrap_or_else(|| std::process::abort())
                 .queue_depth
                 < result
+                    .metrics
                     .get("prov-b")
                     .copied()
                     .unwrap_or_else(|| std::process::abort())
                     .queue_depth,
             "prov-a (queue=0.1) must have lower queue_depth than prov-b (queue=0.9)"
+        );
+    }
+
+    #[tokio::test]
+    async fn refresh_interval_reuses_generation_for_watch_reconcile() {
+        let url = start_test_server(ok_response("my_queue 0.9\n")).await;
+        let provider = provider_fixture("prov-a", &url, Some(mc_with_queue("my_queue")));
+        let cache = empty_cache();
+        let t0 = Instant::now();
+
+        let first = collect_provider_metrics_with_refresh_interval(
+            "net",
+            std::slice::from_ref(&provider),
+            &cache,
+            t0,
+            Duration::from_secs(10),
+            None,
+        )
+        .await;
+        let second = collect_provider_metrics_with_refresh_interval(
+            "net",
+            std::slice::from_ref(&provider),
+            &cache,
+            t0 + Duration::from_secs(1),
+            Duration::from_secs(10),
+            None,
+        )
+        .await;
+
+        assert_eq!(
+            first.generations.get("prov-a"),
+            second.generations.get("prov-a"),
+            "a watch-triggered reconcile within the refresh interval must reuse the scrape generation"
+        );
+    }
+
+    #[tokio::test]
+    async fn refresh_interval_allocates_new_generation_after_expiry() {
+        let url = start_test_server(ok_response("my_queue 0.9\n")).await;
+        let provider = provider_fixture("prov-a", &url, Some(mc_with_queue("my_queue")));
+        let cache = empty_cache();
+        let t0 = Instant::now();
+
+        let first = collect_provider_metrics_with_refresh_interval(
+            "net",
+            std::slice::from_ref(&provider),
+            &cache,
+            t0,
+            Duration::from_secs(10),
+            None,
+        )
+        .await;
+        let second = collect_provider_metrics_with_refresh_interval(
+            "net",
+            std::slice::from_ref(&provider),
+            &cache,
+            t0 + Duration::from_secs(11),
+            Duration::from_secs(10),
+            None,
+        )
+        .await;
+
+        assert_ne!(
+            first.generations.get("prov-a"),
+            second.generations.get("prov-a"),
+            "a later metrics refresh must receive a new scrape generation"
         );
     }
 
@@ -835,7 +1002,7 @@ mod tests {
 
         let result = collect_provider_metrics("other-net", &[provider], &empty_cache(), Instant::now(), None).await;
         assert!(
-            result.is_empty(),
+            result.metrics.is_empty(),
             "provider from a different GridNetwork must not be scraped"
         );
     }
@@ -845,6 +1012,7 @@ mod tests {
     // -----------------------------------------------------------------------
 
     #[tokio::test]
+    #[expect(clippy::too_many_lines, reason = "cache seeding + assertion")]
     async fn stale_cache_used_within_ttl_on_scrape_failure() {
         // Seed the cache with a known good sample from T=0.
         let t0 = Instant::now();
@@ -852,7 +1020,7 @@ mod tests {
         let cache = empty_cache();
         {
             let mut guard = cache.lock().await;
-            guard.insert(
+            guard.entries.insert(
                 ("net".to_owned(), "prov-a".to_owned()),
                 TimestampedMetrics {
                     metrics: scoring::BackendMetrics {
@@ -864,16 +1032,21 @@ mod tests {
                         error_rate: 0.0,
                     },
                     scraped_at: t0,
+                    generation: 0,
                 },
             );
         }
         // Scrape fails (port 1 is always refused); cache is within 60 s TTL.
         let result = collect_provider_metrics("net", &[provider], &cache, t0, None).await;
         assert!(
-            result.contains_key("prov-a"),
+            result.metrics.contains_key("prov-a"),
             "failed scrape within TTL must use cached metrics"
         );
-        let cached_bm = result.get("prov-a").copied().unwrap_or_else(|| std::process::abort());
+        let cached_bm = result
+            .metrics
+            .get("prov-a")
+            .copied()
+            .unwrap_or_else(|| std::process::abort());
         assert!(
             (cached_bm.queue_depth - 0.42).abs() < f64::EPSILON,
             "cached queue_depth must be returned"
@@ -889,7 +1062,7 @@ mod tests {
         let cache = empty_cache();
         {
             let mut guard = cache.lock().await;
-            guard.insert(
+            guard.entries.insert(
                 ("net".to_owned(), "prov-a".to_owned()),
                 TimestampedMetrics {
                     metrics: scoring::BackendMetrics {
@@ -901,13 +1074,14 @@ mod tests {
                         error_rate: 0.0,
                     },
                     scraped_at: t0,
+                    generation: 0,
                 },
             );
         }
         // Clock advanced past TTL → cache entry is expired → plaintext provider omitted.
         let result = collect_provider_metrics("net", &[provider], &cache, t_after_ttl, None).await;
         assert!(
-            !result.contains_key("prov-a"),
+            !result.metrics.contains_key("prov-a"),
             "expired cache on plaintext provider must not insert unobservable metrics"
         );
     }
@@ -918,7 +1092,7 @@ mod tests {
         let cache = empty_cache();
         {
             let mut guard = cache.lock().await;
-            guard.insert(
+            guard.entries.insert(
                 ("net".to_owned(), "prov-a".to_owned()),
                 TimestampedMetrics {
                     metrics: scoring::BackendMetrics {
@@ -930,12 +1104,13 @@ mod tests {
                         error_rate: 0.0,
                     },
                     scraped_at: Instant::now(),
+                    generation: 0,
                 },
             );
         }
         let result = collect_provider_metrics("net", &[provider], &cache, Instant::now(), None).await;
         assert!(
-            !result.contains_key("prov-a"),
+            !result.metrics.contains_key("prov-a"),
             "plaintext provider without stale_metrics_seconds must not insert unobservable metrics"
         );
     }
@@ -955,6 +1130,7 @@ mod tests {
         let cached_queue_depth = cache
             .lock()
             .await
+            .entries
             .get(&("net".to_owned(), "prov-a".to_owned()))
             .map(|tm| tm.metrics.queue_depth);
         assert!(cached_queue_depth.is_some(), "successful scrape must write to cache");
@@ -970,7 +1146,7 @@ mod tests {
         let cache = empty_cache();
         {
             let mut guard = cache.lock().await;
-            guard.insert(
+            guard.entries.insert(
                 ("net".to_owned(), "prov-a".to_owned()),
                 TimestampedMetrics {
                     metrics: scoring::BackendMetrics {
@@ -982,12 +1158,13 @@ mod tests {
                         error_rate: 0.0,
                     },
                     scraped_at: Instant::now(),
+                    generation: 0,
                 },
             );
         }
         let result = collect_provider_metrics("net", &[provider], &cache, Instant::now(), None).await;
         assert!(
-            !result.contains_key("prov-a"),
+            !result.metrics.contains_key("prov-a"),
             "plaintext provider with zero TTL must not insert unobservable metrics"
         );
     }

--- a/operator/src/resources/routing_overlay.rs
+++ b/operator/src/resources/routing_overlay.rs
@@ -928,6 +928,7 @@ fn build_admission_map(
     providers: &[InferenceProvider],
     remote_crdt_providers: &[crdt::ProviderState],
     metrics: Option<&HashMap<&str, scoring::BackendMetrics>>,
+    precomputed: Option<&HashMap<String, AdmissionState>>,
 ) -> HashMap<String, AdmissionState> {
     let mut map = HashMap::new();
     for provider in providers {
@@ -936,7 +937,12 @@ fn build_admission_map(
         }
         if let Some(key) = routing_identity(provider) {
             let m = metrics.and_then(|mmap| mmap.get(key));
-            map.insert(key.to_owned(), super::geography::derive_admission_state(m));
+            map.insert(
+                key.to_owned(),
+                precomputed
+                    .and_then(|states| states.get(key).copied())
+                    .unwrap_or_else(|| super::geography::derive_admission_state(m)),
+            );
         }
     }
     for provider in remote_crdt_providers {
@@ -1091,10 +1097,6 @@ fn locality_sort_key(tier: Option<LocalityTier>) -> u8 {
     clippy::too_many_arguments,
     reason = "seven parameters represent distinct overlay inputs; a wrapper struct would obscure the data flow"
 )]
-#[expect(
-    clippy::too_many_lines,
-    reason = "sequential render steps: ordering, collect, enrich, filter, sort, dedup, rank; splitting would hide the pipeline"
-)]
 pub fn render_routing_overlay(
     network: &GridNetwork,
     sites: &[GridSite],
@@ -1104,6 +1106,46 @@ pub fn render_routing_overlay(
     metrics: Option<&HashMap<&str, scoring::BackendMetrics>>,
     generated_at: Option<&str>,
     weights: &scoring::ScoringWeights,
+) -> Result<RoutingOverlay, String> {
+    render_routing_overlay_with_admission(
+        network,
+        sites,
+        providers,
+        remote_crdt_providers,
+        local_site,
+        metrics,
+        generated_at,
+        weights,
+        None,
+    )
+}
+
+/// Render an overlay using controller-owned admission states for local
+/// providers. The compatibility wrapper above retains the pure renderer API
+/// used by callers and tests that do not have reconcile memory.
+///
+/// # Errors
+///
+/// Returns an error when the network or an eligible provider lacks the
+/// metadata required to construct a valid routing candidate.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "admission states are a distinct control-plane input"
+)]
+#[expect(
+    clippy::too_many_lines,
+    reason = "sequential render steps: ordering, collect, enrich, filter, sort, dedup, rank; splitting would hide the pipeline"
+)]
+pub fn render_routing_overlay_with_admission(
+    network: &GridNetwork,
+    sites: &[GridSite],
+    providers: &[InferenceProvider],
+    remote_crdt_providers: &[crdt::ProviderState],
+    local_site: &str,
+    metrics: Option<&HashMap<&str, scoring::BackendMetrics>>,
+    generated_at: Option<&str>,
+    weights: &scoring::ScoringWeights,
+    precomputed_admission: Option<&HashMap<String, AdmissionState>>,
 ) -> Result<RoutingOverlay, String> {
     let network_name = network
         .metadata
@@ -1120,7 +1162,13 @@ pub fn render_routing_overlay(
         weights,
     );
 
-    let admission_map = build_admission_map(network_name, providers, remote_crdt_providers, metrics);
+    let admission_map = build_admission_map(
+        network_name,
+        providers,
+        remote_crdt_providers,
+        metrics,
+        precomputed_admission,
+    );
 
     // Find the consumer site to get its labels for access policy evaluation
     let consumer_site_labels = sites


### PR DESCRIPTION
## Summary

- Add a stateful admission evaluator with bounded hysteresis: repeated pressure observations before entering `existingOnly`, and repeated recovery observations plus hold-down before returning to `new_and_existing`.
- Replace value-derived metric hashing with a monotonic scrape-generation identity so clamped metric values do not prevent pressure or recovery counters from advancing.
- Add `admissionPolicy` to the GridNetwork CRD, Helm chart values/schema, and architecture documentation.

## Validation

- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo +nightly-2026-03-28 fmt --all -- --check`
- [x] `cargo machete`
- [x] `git diff --check`
- [x] CRD parity: `deploy/crds/` and `charts/grid-operator/crds/` are identical
- [x] Admission and provider-metrics unit tests
- [x] Kind harness validation with queue and KV pressure, recovery, scrape fallback, health withdrawal, restart, no-metrics compatibility, and network isolation

Runtime validation artifacts remain local and are intentionally excluded from the production commit.
