### PR TITLE
fix: (breaking): type gateway.port as an integer

### DIFF
--- a/charts/grid-operator/values.schema.json
+++ b/charts/grid-operator/values.schema.json
@@ -213,7 +213,9 @@
           "description": "Gateway Kubernetes Service name for discovery."
         },
         "port": {
-          "type": "string",
+          "type": ["integer", "null"],
+          "minimum": 1,
+          "maximum": 65535,
           "description": "Gateway port for discovery."
         }
       }

--- a/charts/grid-operator/values.yaml
+++ b/charts/grid-operator/values.yaml
@@ -101,7 +101,7 @@ gateway:
   serviceName: ""
   # -- Gateway port for operator-to-gateway discovery. Maps to
   # GRID_GATEWAY_PORT.
-  port: ""
+  port: null
 
 # -- Probe timing configuration.
 health:

--- a/examples/helm/existing-clusters/combined-site/values/east-a-operator.yaml
+++ b/examples/helm/existing-clusters/combined-site/values/east-a-operator.yaml
@@ -23,4 +23,4 @@ swim:
 
 gateway:
   serviceName: consumer-gateway
-  port: "8080"
+  port: 8080

--- a/examples/helm/existing-clusters/combined-site/values/east-b-operator.yaml
+++ b/examples/helm/existing-clusters/combined-site/values/east-b-operator.yaml
@@ -21,4 +21,4 @@ swim:
 
 gateway:
   serviceName: consumer-gateway
-  port: "8080"
+  port: 8080

--- a/examples/helm/existing-clusters/combined-site/values/west-a-operator.yaml
+++ b/examples/helm/existing-clusters/combined-site/values/west-a-operator.yaml
@@ -21,4 +21,4 @@ swim:
 
 gateway:
   serviceName: consumer-gateway
-  port: "8080"
+  port: 8080

--- a/examples/helm/existing-clusters/combined-site/values/west-b-operator.yaml
+++ b/examples/helm/existing-clusters/combined-site/values/west-b-operator.yaml
@@ -21,4 +21,4 @@ swim:
 
 gateway:
   serviceName: consumer-gateway
-  port: "8080"
+  port: 8080

--- a/examples/helm/existing-clusters/dedicated-edge/values/east-consumer-operator.yaml
+++ b/examples/helm/existing-clusters/dedicated-edge/values/east-consumer-operator.yaml
@@ -24,4 +24,4 @@ swim:
 gateway:
   # The Praxis consumer gateway Service name in the same namespace.
   serviceName: consumer-gateway
-  port: "8080"
+  port: 8080

--- a/examples/helm/existing-clusters/dedicated-edge/values/east-provider-operator.yaml
+++ b/examples/helm/existing-clusters/dedicated-edge/values/east-provider-operator.yaml
@@ -21,4 +21,4 @@ swim:
 
 gateway:
   serviceName: provider-gateway
-  port: "8443"
+  port: 8443

--- a/examples/helm/existing-clusters/dedicated-edge/values/west-consumer-operator.yaml
+++ b/examples/helm/existing-clusters/dedicated-edge/values/west-consumer-operator.yaml
@@ -21,4 +21,4 @@ swim:
 
 gateway:
   serviceName: consumer-gateway
-  port: "8080"
+  port: 8080

--- a/examples/helm/existing-clusters/dedicated-edge/values/west-provider-operator.yaml
+++ b/examples/helm/existing-clusters/dedicated-edge/values/west-provider-operator.yaml
@@ -21,4 +21,4 @@ swim:
 
 gateway:
   serviceName: provider-gateway
-  port: "8443"
+  port: 8443

--- a/scripts/verify-helm-chart.sh
+++ b/scripts/verify-helm-chart.sh
@@ -116,7 +116,13 @@ try_template "$CHART_DIR" "SA annotations" \
 try_template "$CHART_DIR" "hostile podLabels" \
   --set-string 'podLabels.app\.kubernetes\.io/name=hostile'
 try_template "$CHART_DIR" "gateway discovery" \
-  --set-string gateway.serviceName=edge-gateway --set-string gateway.port=8080
+  --set-string gateway.serviceName=edge-gateway --set gateway.port=8080
+try_reject "$CHART_DIR" "gateway.port as a string" \
+  --set-string gateway.port=8080
+try_reject "$CHART_DIR" "gateway.port out of range" \
+  --set gateway.port=99999
+try_reject "$CHART_DIR" "gateway.port non-numeric" \
+  --set-string gateway.port=bananas
 
 # ── Verify selector protection ──────────────────────────────────────
 echo ""


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`gateway.port` has no schema validation today: it accepts any string, and an
invalid value is silently discarded at runtime by
`parse::<u16>().ok().unwrap_or(DEFAULT_PORT)` (`operator/src/gateway.rs:125`), so
a typo gives a working-looking install on the wrong port.

This types it as an integer in `1-65535` and defaults it to `null`, and updates
the eight in-repo example values files and the gateway-discovery case in
`verify-helm-chart.sh`.

Breaking: values files that quote the port (`gateway.port: "8080"`) are now
rejected and must use an unquoted integer (`gateway.port: 8080`) - one character
per occurrence, but an existing values file fails on upgrade until edited.

No template change: `templates/deployment.yaml:75` already renders
`{{ .Values.gateway.port | quote }}`, so rendered output is byte-identical for
any currently valid value. `verify-helm-chart.sh` reports 165 passed / 0 failed
(153/9 before the examples were updated), with three new rejection cases for
string, out-of-range, and non-numeric ports.

**Which issue(s) this PR fixes**:

Part of #72
