### PR TITLE
docs(architecture): clarify SWIM is site-to-site and single-site Grid Site behavior

### DIFF
--- a/docs/architecture/crds.md
+++ b/docs/architecture/crds.md
@@ -399,6 +399,19 @@ prove that a Praxis gateway has loaded the latest routing config or authorized
 provider-side traffic. Data-plane readiness is verified separately at request
 time by provider gateway filters.
 
+**Single-site / combined-site deployments:** Site discovery is driven by *remote*
+SWIM peers - the `Pending -> Discovered` transition above requires a remote peer
+observed Alive. A single or combined cluster has no peers, so its own `GridSite`
+stays `Pending` with reason `AwaitingDiscovery`. **This is expected and does not
+block local serving:** local `InferenceProvider`s are eligible regardless of
+`GridSite.status.phase`; only *remote* CRDT provider records are phase-gated (see
+"Routing eligibility" above). Do not add SWIM seeds or extra operator replicas to
+try to force the site `Active` - there is no second site to discover, and a lone
+operator legitimately runs a single-node mesh with zero peers. The `Active` phase
+and its mTLS gateway probe (`spec.egress` + `spec.trust`) apply to reaching
+*remote* sites, or a manually-configured peer gateway endpoint. See
+[Architecture Overview -> Single-Site and Combined Deployments](overview.md#single-site-and-combined-deployments).
+
 See [Routing eligibility](routing.md#routing-eligibility) for the full gating rule.
 
 Example status — Mutual TLS verified:

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -287,6 +287,36 @@ key group, but stronger sender/origin binding is still hardening work.  Do not
 treat distributed CRDT state as fully security-sensitive routing input until
 that work is complete.
 
+## Single-Site and Combined Deployments
+
+SWIM membership is **site-granular**: each Grid operator is a single SWIM node
+carrying its site's identity, and SWIM members are *other sites'* operators - not
+the gateways, providers, or pods inside a site. Seeds (`GridNetwork.spec.seeds`)
+point at other sites, and the operator filters out its own address, so a lone
+site legitimately forms a **single-node mesh with zero peers**.
+
+```text
+Multi-site                              Single / combined site
+--------------------------------        ------------------------------
+site-a operator -- SWIM -- site-b       one operator -- SWIM (self only)
+    |                        |              |
+ local providers        local providers   several gateways / providers
+                                          (NOT SWIM members)
+```
+
+Two things that commonly surprise people on a single or combined cluster:
+
+- **Zero SWIM peers is expected, not a failure.** There is no second site to
+  discover, so do not add SWIM seeds or extra operator replicas to "make
+  discovery work."
+- **Local routing does not require `GridSite.status.phase == Active`.** Local
+  `InferenceProvider`s are eligible regardless of GridSite phase; only *remote*
+  (cross-site CRDT) provider records are phase-gated. So a single-site deployment
+  routes to its local providers even while its own `GridSite` is `Pending`.
+
+See the [GridSite lifecycle](crds.md#gridsite) for the phase machine and this
+single-site behavior.
+
 ## Routing Overlays
 
 For each gateway reference on a `GridNetwork`, the operator writes a


### PR DESCRIPTION
Single-site/combined deployments legitimately run a one-node SWIM mesh with zero peers, so the local GridSite stays Pending with reason AwaitingDiscovery. That is expected and does not block local routing: local InferenceProviders are eligible regardless of GridSite phase; only remote CRDT provider records are phase-gated.

Add a 'Single-Site and Combined Deployments' section to the architecture overview and a single-site note to the GridSite lifecycle so single-cluster users do not mistake Pending for a discovery failure or try to add SWIM peers/replicas to fix it.