### PR TITLE
fix(swim): verify ECDSA P-256 signatures on pinned-origin state broadcasts (grid#75, partial)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2262,11 +2262,14 @@ dependencies = [
  "crdt",
  "foca",
  "rand",
+ "rcgen",
+ "ring",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "x509-parser",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ k8s-openapi = { version = "0.27.1", features = ["v1_32"] }
 kube = { version = "3.1.0", features = ["client", "derive", "runtime", "rustls-tls"] }
 prometheus = "0.14"
 rcgen = "0.14.8"
+ring = "0.17"
 rustls = { version = "0.23", default-features = false, features = ["logging", "std", "tls12"] }
 schemars = "1.2.1"
 sha2 = "0.10"
@@ -53,6 +54,7 @@ tracing = "0.1.44"
 rand = { version = "0.9", features = ["small_rng"] }
 tracing-subscriber = { version = "0.3.23", features = ["env-filter", "json"] }
 uuid = { version = "1.23.4", features = ["v4"] }
+x509-parser = "0.18"
 zeroize = "1.8"
 
 [profile.release]

--- a/operator/src/controller/grid_network.rs
+++ b/operator/src/controller/grid_network.rs
@@ -399,7 +399,7 @@ pub async fn reconcile(network: Arc<GridNetwork>, ctx: Arc<OperatorCtx>) -> Resu
 
     // Publish real InferenceProvider-derived CRDT state so peers learn this site's providers.
     let distributed_provider_count = if let Some(swim) = ctx.swim.as_ref().filter(|handle| handle.is_running()) {
-        publish_real_provider_state(swim, name, &providers, &raw_metrics);
+        publish_real_provider_state(swim, name, &grid_id, &providers, &raw_metrics);
         count_remote_provider_records(swim, name)
     } else {
         0
@@ -1569,9 +1569,15 @@ fn provider_revision(provider: &InferenceProvider) -> u64 {
 /// remote sites can learn which providers exist and avoid routing to unhealthy
 /// ones.  The routing overlay layer already filters `Unavailable` providers
 /// from local routing decisions.
+///
+/// `grid_id` (the caller's already-[`resolve_grid_id`]d value) is attached to
+/// the broadcast so a signature over this `GridNetwork`'s state cannot be
+/// replayed as valid for a different `GridNetwork` sharing the same
+/// cluster's `SwimHandle` — see [`swim::StateBroadcast::grid_id`].
 fn publish_real_provider_state(
     swim: &SwimHandle,
     network_name: &str,
+    grid_id: &str,
     providers: &[InferenceProvider],
     raw_metrics: &HashMap<String, scoring::BackendMetrics>,
 ) {
@@ -1609,7 +1615,8 @@ fn publish_real_provider_state(
     // Use the highest provider revision as this origin's broadcast revision.
     // Duplicate unchanged broadcasts are idempotent; newer Kubernetes writes
     // advance resourceVersion and therefore advance the broadcast revision.
-    let bc = StateBroadcast::new(site_name.to_owned(), max_revision, snap, gateway_address);
+    let bc = StateBroadcast::new(site_name.to_owned(), max_revision, snap, gateway_address)
+        .with_grid_id(Some(grid_id.to_owned()));
     if let Err(e) = swim.publish_state_broadcast(bc) {
         tracing::debug!(error = %e, "CRDT broadcast channel unavailable — runtime not yet receiving");
     }

--- a/operator/src/swim_runtime.rs
+++ b/operator/src/swim_runtime.rs
@@ -1215,6 +1215,11 @@ fn canonical_state_payload(broadcast: &swim::StateBroadcast) -> Result<Vec<u8>, 
 /// that joins before it has any local `GridNetwork` can still advertise its
 /// data-plane gateway address to peers.  The broadcast carries an empty CRDT
 /// snapshot and only updates the peer gateway-address map.
+///
+/// Deliberately leaves [`swim::StateBroadcast::grid_id`] as `None`: this
+/// broadcast can fire before the node has joined any `GridNetwork`, so no
+/// `grid_id` is available yet here. `publish_real_provider_state` in the
+/// `grid_network` controller attaches `grid_id` once a `GridNetwork` exists.
 fn publish_gateway_address_broadcast(node: &mut SwimNode, site_name: &str, revision: u64, gateway_address: &str) {
     let broadcast = swim::StateBroadcast::new(
         site_name.to_owned(),

--- a/swim/Cargo.toml
+++ b/swim/Cargo.toml
@@ -14,13 +14,16 @@ bytes = { workspace = true }
 crdt = { path = "../crdt" }
 foca = { workspace = true }
 rand = { workspace = true }
+ring = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }
 tracing = { workspace = true }
 
 [dev-dependencies]
+rcgen = { workspace = true }
 serde_json = { workspace = true }
+x509-parser = { workspace = true }
 
 [lints]
 workspace = true

--- a/swim/src/lib.rs
+++ b/swim/src/lib.rs
@@ -26,6 +26,8 @@ pub mod identity;
 pub mod node;
 /// Foca runtime adapter with accumulated output.
 pub mod runtime;
+/// ECDSA P-256 sign/verify primitives for SWIM state broadcasts.
+pub mod signing;
 /// State snapshot payloads for SWIM custom broadcasts.
 pub mod state_broadcast;
 
@@ -33,7 +35,8 @@ pub use event::MemberEvent;
 pub use identity::NodeId;
 pub use node::SwimNode;
 pub use runtime::{AccumulatedOutput, GridRuntime};
+pub use signing::{SigningError, VerificationError};
 pub use state_broadcast::{
     STATE_BROADCAST_VERSION, STATE_BROADCAST_VERSION_V1, StateBroadcast, StateBroadcastError, StateBroadcastHandler,
-    StateBroadcastKey,
+    StateBroadcastKey, TrustStore,
 };

--- a/swim/src/lib.rs
+++ b/swim/src/lib.rs
@@ -37,6 +37,6 @@ pub use node::SwimNode;
 pub use runtime::{AccumulatedOutput, GridRuntime};
 pub use signing::{SigningError, VerificationError};
 pub use state_broadcast::{
-    STATE_BROADCAST_VERSION, STATE_BROADCAST_VERSION_V1, StateBroadcast, StateBroadcastError, StateBroadcastHandler,
-    StateBroadcastKey, TrustStore,
+    MAX_PINNED_KEYS_PER_ORIGIN, STATE_BROADCAST_VERSION, STATE_BROADCAST_VERSION_V1, StateBroadcast,
+    StateBroadcastError, StateBroadcastHandler, StateBroadcastKey, TooManyPinnedKeys, TrustStore,
 };

--- a/swim/src/node.rs
+++ b/swim/src/node.rs
@@ -16,7 +16,10 @@ use tokio::sync::watch;
 use crate::{
     AccumulatedOutput, GridRuntime, NodeId,
     runtime::TimerEvent,
-    state_broadcast::{DEFAULT_MAX_RETAINED_ORIGINS, OriginStateHandle, StateBroadcast, StateBroadcastHandler},
+    state_broadcast::{
+        DEFAULT_MAX_RETAINED_ORIGINS, MAX_PINNED_KEYS_PER_ORIGIN, OriginStateHandle, StateBroadcast,
+        StateBroadcastHandler, TooManyPinnedKeys, TrustStore,
+    },
 };
 
 // ---------------------------------------------------------------------------
@@ -66,6 +69,10 @@ pub struct SwimNode {
 
     /// Immediate control path for coordinated per-origin state eviction.
     origin_state: OriginStateHandle,
+
+    /// Sender for the pinned-identity trust store read by the broadcast
+    /// handler inside `foca`. See [`SwimNode::pin_origin`].
+    trust_store_tx: watch::Sender<TrustStore>,
 }
 
 impl SwimNode {
@@ -108,6 +115,7 @@ impl SwimNode {
         let state_rx = handler.subscribe();
         let gateway_addrs_rx = handler.subscribe_gateway_addrs();
         let cert_pems_rx = handler.subscribe_cert_pems();
+        let trust_store_tx = handler.trust_store_sender();
 
         Self {
             foca: foca::Foca::with_custom_broadcast(identity, grid_config(), rng, codec, handler),
@@ -116,12 +124,58 @@ impl SwimNode {
             gateway_addrs_rx,
             cert_pems_rx,
             origin_state,
+            trust_store_tx,
         }
     }
 
     /// Immediately remove provider, metadata, and revision state for one origin.
     pub fn evict_origin(&self, origin: &str) {
         self.origin_state.remove_origin(origin);
+    }
+
+    /// Pin `origin` to a bounded set of accepted raw ECDSA P-256 public keys.
+    ///
+    /// If `origin` has no existing pin (or its existing pin is empty),
+    /// immediately purges any state already merged from that origin via
+    /// [`evict_origin`](Self::evict_origin) before installing the new pin —
+    /// so state accepted from `origin` while it was unauthenticated cannot
+    /// silently remain trusted once signature enforcement begins for it.
+    /// Updating an *existing* non-empty pin (e.g. adding a next key during
+    /// rotation, or dropping a retired one) does not purge state, since
+    /// that update never crosses the unauthenticated-to-authenticated
+    /// boundary.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TooManyPinnedKeys`] if `keys` has more than
+    /// [`MAX_PINNED_KEYS_PER_ORIGIN`] entries, without changing the trust
+    /// store.
+    pub fn pin_origin(&self, origin: String, keys: Vec<Vec<u8>>) -> Result<(), TooManyPinnedKeys> {
+        if keys.len() > MAX_PINNED_KEYS_PER_ORIGIN {
+            return Err(TooManyPinnedKeys {
+                origin,
+                supplied: keys.len(),
+            });
+        }
+        let was_unpinned = self.trust_store_tx.borrow().get(&origin).is_none_or(Vec::is_empty);
+        if was_unpinned {
+            self.evict_origin(&origin);
+        }
+        self.trust_store_tx.send_modify(|store| {
+            store.insert(origin, keys);
+        });
+        Ok(())
+    }
+
+    /// Remove `origin`'s pin, returning it to unenforced (pass-through) status.
+    ///
+    /// Does not purge `origin`'s currently merged state — unpinning is a
+    /// deliberate relaxation, not a security event, and the state was
+    /// already accepted under whatever enforcement applied when it arrived.
+    pub fn unpin_origin(&self, origin: &str) {
+        self.trust_store_tx.send_modify(|store| {
+            store.remove(origin);
+        });
     }
 
     /// Feed an incoming UDP packet to foca.
@@ -373,6 +427,195 @@ mod tests {
         let bc = StateBroadcast::new("site-a".to_owned(), 1, snap, None);
         node.publish_state_broadcast(&bc)
             .unwrap_or_else(|_| std::process::abort());
+    }
+
+    // -----------------------------------------------------------------------
+    // Trust-store pinning
+    // -----------------------------------------------------------------------
+
+    /// Generate an ECDSA P-256 signing key plus the raw SPKI EC point a
+    /// verifier needs, independent of *how* a real deployment would source
+    /// or pin this key material (grid#75, still open).
+    fn generate_signing_key_and_pubkey() -> (Vec<u8>, Vec<u8>) {
+        let key_pair = rcgen::KeyPair::generate().unwrap_or_else(|_| std::process::abort());
+        let pkcs8_der = key_pair.serialize_der();
+        let params = rcgen::CertificateParams::new(vec!["spike.grid.internal".to_owned()])
+            .unwrap_or_else(|_| std::process::abort());
+        let cert = params.self_signed(&key_pair).unwrap_or_else(|_| std::process::abort());
+        let (_, parsed) = x509_parser::parse_x509_certificate(cert.der()).unwrap_or_else(|_| std::process::abort());
+        let raw_pubkey = parsed.public_key().subject_public_key.as_ref().to_vec();
+        (pkcs8_der, raw_pubkey)
+    }
+
+    /// Return the current wall-clock time in milliseconds since the Unix
+    /// epoch, for constructing test broadcasts with a fresh `signed_at_ms`.
+    fn now_ms() -> u64 {
+        u64::try_from(
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_else(|_| std::process::abort())
+                .as_millis(),
+        )
+        .unwrap_or_else(|_| std::process::abort())
+    }
+
+    #[test]
+    fn pin_origin_rejects_more_than_the_max_pinned_keys() {
+        let (node, _) = make_node("site-b", 19_230);
+
+        let result = node.pin_origin("site-p".to_owned(), vec![vec![1], vec![2], vec![3]]);
+
+        assert!(
+            matches!(&result, Err(TooManyPinnedKeys { origin, supplied }) if origin == "site-p" && *supplied == 3),
+            "pinning 3 keys (over MAX_PINNED_KEYS_PER_ORIGIN=2) must be rejected, got {result:?}"
+        );
+    }
+
+    #[test]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "establishes membership, publishes unpinned state, then pins and re-checks purge in one proof"
+    )]
+    fn pin_origin_purges_previously_unauthenticated_state_from_that_origin() {
+        let id_a = local_id("site-a", 19_231);
+        let id_b = local_id("site-b", 19_232);
+        let (mut node_a, _) = make_node("site-a", 19_231);
+        let (mut node_b, _) = make_node("site-b", 19_232);
+        establish_membership(&mut node_a, &mut node_b, &id_a, &id_b);
+
+        // A publishes unsigned state; B has no pin for A yet, so it merges.
+        node_a
+            .publish_state_broadcast(&StateBroadcast::new(
+                "site-a".to_owned(),
+                1,
+                provider_snap("site-a", 0.4),
+                None,
+            ))
+            .unwrap_or_else(|_| std::process::abort());
+        for msg in &node_a.gossip().messages {
+            if msg.addr == id_b.socket_addr() {
+                drop(node_b.handle_data(&msg.data));
+            }
+        }
+        assert!(
+            node_b
+                .state_snapshot()
+                .provider("net", "site-a", "provider-1")
+                .is_some(),
+            "B must have accepted A's unsigned, unpinned state"
+        );
+
+        let (_key, pubkey) = generate_signing_key_and_pubkey();
+        node_b
+            .pin_origin("site-a".to_owned(), vec![pubkey])
+            .unwrap_or_else(|_| std::process::abort());
+
+        assert!(
+            node_b
+                .state_snapshot()
+                .provider("net", "site-a", "provider-1")
+                .is_none(),
+            "pinning a previously-unpinned origin for the first time must purge its unauthenticated state"
+        );
+    }
+
+    #[test]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "establishes membership, pins, signs+publishes, and re-pins with a rotated key set in one proof"
+    )]
+    fn pin_origin_rotation_update_does_not_purge_already_authenticated_state() {
+        let id_a = local_id("site-a", 19_233);
+        let id_b = local_id("site-b", 19_234);
+        let (mut node_a, _) = make_node("site-a", 19_233);
+        let (mut node_b, _) = make_node("site-b", 19_234);
+        establish_membership(&mut node_a, &mut node_b, &id_a, &id_b);
+
+        let (signing_key, current_pubkey) = generate_signing_key_and_pubkey();
+        node_b
+            .pin_origin("site-a".to_owned(), vec![current_pubkey.clone()])
+            .unwrap_or_else(|_| std::process::abort());
+
+        let unsigned = StateBroadcast::new("site-a".to_owned(), 1, provider_snap("site-a", 0.5), None)
+            .with_signed_at(Some(now_ms()));
+        let signature = crate::signing::sign_ecdsa_p256(
+            &signing_key,
+            &unsigned.signable_bytes().unwrap_or_else(|_| std::process::abort()),
+        )
+        .unwrap_or_else(|_| std::process::abort());
+        node_a
+            .publish_state_broadcast(&unsigned.with_signature(Some(signature)))
+            .unwrap_or_else(|_| std::process::abort());
+        for msg in &node_a.gossip().messages {
+            if msg.addr == id_b.socket_addr() {
+                drop(node_b.handle_data(&msg.data));
+            }
+        }
+        assert!(
+            node_b
+                .state_snapshot()
+                .provider("net", "site-a", "provider-1")
+                .is_some(),
+            "B must have accepted A's correctly signed, pinned state"
+        );
+
+        // Rotation: add a next key alongside the current one. This is an
+        // update to an existing non-empty pin, not a first-time pin.
+        let (_next_key, next_pubkey) = generate_signing_key_and_pubkey();
+        node_b
+            .pin_origin("site-a".to_owned(), vec![current_pubkey, next_pubkey])
+            .unwrap_or_else(|_| std::process::abort());
+
+        assert!(
+            node_b
+                .state_snapshot()
+                .provider("net", "site-a", "provider-1")
+                .is_some(),
+            "rotating an already-pinned origin's key set must not purge its already-authenticated state"
+        );
+    }
+
+    #[test]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "establishes membership, publishes state, then unpins and re-checks retention in one proof"
+    )]
+    fn unpin_origin_does_not_purge_existing_state() {
+        let id_a = local_id("site-a", 19_235);
+        let id_b = local_id("site-b", 19_236);
+        let (mut node_a, _) = make_node("site-a", 19_235);
+        let (mut node_b, _) = make_node("site-b", 19_236);
+        establish_membership(&mut node_a, &mut node_b, &id_a, &id_b);
+
+        node_a
+            .publish_state_broadcast(&StateBroadcast::new(
+                "site-a".to_owned(),
+                1,
+                provider_snap("site-a", 0.6),
+                None,
+            ))
+            .unwrap_or_else(|_| std::process::abort());
+        for msg in &node_a.gossip().messages {
+            if msg.addr == id_b.socket_addr() {
+                drop(node_b.handle_data(&msg.data));
+            }
+        }
+        assert!(
+            node_b
+                .state_snapshot()
+                .provider("net", "site-a", "provider-1")
+                .is_some()
+        );
+
+        node_b.unpin_origin("site-a");
+
+        assert!(
+            node_b
+                .state_snapshot()
+                .provider("net", "site-a", "provider-1")
+                .is_some(),
+            "unpinning an origin must not purge its currently merged state"
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/swim/src/signing.rs
+++ b/swim/src/signing.rs
@@ -127,4 +127,25 @@ mod tests {
 
         assert!(matches!(result, Err(SigningError::InvalidKey)));
     }
+
+    #[test]
+    fn invalid_key_error_message_is_descriptive() {
+        assert!(SigningError::InvalidKey.to_string().contains("PKCS8"));
+    }
+
+    #[test]
+    fn signing_failed_error_message_is_descriptive() {
+        // SigningFailed only arises from an RNG failure inside ring's sign
+        // call, which cannot be triggered deterministically through this
+        // module's public API. Constructed directly to verify the message
+        // wording, matching this codebase's `..._error_formats_correctly`
+        // convention for defensive error variants (see e.g.
+        // `node::tests::state_broadcast_error_formats_correctly`).
+        assert!(SigningError::SigningFailed.to_string().contains("signing"));
+    }
+
+    #[test]
+    fn verification_invalid_error_message_is_descriptive() {
+        assert!(VerificationError::Invalid.to_string().contains("verification"));
+    }
 }

--- a/swim/src/signing.rs
+++ b/swim/src/signing.rs
@@ -1,0 +1,130 @@
+//! ECDSA P-256 sign/verify primitives for SWIM state broadcasts.
+//!
+//! Deliberately decoupled from *where* key material comes from: callers
+//! supply raw PKCS8 DER (for signing) or a raw uncompressed EC point (for
+//! verification) and this module only performs the cryptographic operation.
+//! Sourcing and pinning key material against a [`GridSite`] identity is an
+//! operator-level concern tracked separately.
+//!
+//! [`GridSite`]: https://github.com/praxis-proxy/grid/issues/75
+
+use ring::{
+    rand::SystemRandom,
+    signature::{ECDSA_P256_SHA256_ASN1, ECDSA_P256_SHA256_ASN1_SIGNING, EcdsaKeyPair, UnparsedPublicKey},
+};
+
+/// Errors produced while signing a payload.
+#[derive(Debug, thiserror::Error)]
+pub enum SigningError {
+    /// The supplied PKCS8 DER key material was rejected by the signing backend.
+    #[error("invalid PKCS8 signing key")]
+    InvalidKey,
+
+    /// Signing failed for a reason the backend does not disclose in detail.
+    #[error("signing operation failed")]
+    SigningFailed,
+}
+
+/// Errors produced while verifying a payload's signature.
+#[derive(Debug, thiserror::Error)]
+pub enum VerificationError {
+    /// The signature does not match the payload under the supplied public key.
+    #[error("signature verification failed")]
+    Invalid,
+}
+
+/// Sign `payload` with an ECDSA P-256 key supplied as PKCS8 DER.
+///
+/// Returns the signature in ASN.1 DER form (~70-72 bytes for P-256).
+///
+/// # Errors
+///
+/// Returns [`SigningError::InvalidKey`] if `pkcs8_der` is not a valid ECDSA
+/// P-256 PKCS8 key, or [`SigningError::SigningFailed`] if the underlying RNG
+/// or signing operation fails.
+pub fn sign_ecdsa_p256(pkcs8_der: &[u8], payload: &[u8]) -> Result<Vec<u8>, SigningError> {
+    let rng = SystemRandom::new();
+    let key_pair = EcdsaKeyPair::from_pkcs8(&ECDSA_P256_SHA256_ASN1_SIGNING, pkcs8_der, &rng)
+        .map_err(|_key_rejected| SigningError::InvalidKey)?;
+    let signature = key_pair
+        .sign(&rng, payload)
+        .map_err(|_signing_failed| SigningError::SigningFailed)?;
+    Ok(signature.as_ref().to_vec())
+}
+
+/// Verify `signature` over `payload` under an ECDSA P-256 public key
+/// supplied as a raw uncompressed EC point (the `subjectPublicKey` bit
+/// string contents of an X.509 SPKI structure, sec1 uncompressed form).
+///
+/// # Errors
+///
+/// Returns [`VerificationError::Invalid`] when the signature does not
+/// verify, including when `raw_pubkey` is malformed.
+pub fn verify_ecdsa_p256(raw_pubkey: &[u8], payload: &[u8], signature: &[u8]) -> Result<(), VerificationError> {
+    let verifier = UnparsedPublicKey::new(&ECDSA_P256_SHA256_ASN1, raw_pubkey);
+    verifier
+        .verify(payload, signature)
+        .map_err(|_unspecified| VerificationError::Invalid)
+}
+
+#[cfg(test)]
+mod tests {
+    use rcgen::KeyPair;
+
+    use super::*;
+
+    // Test Utilities
+
+    /// Generate an ECDSA P-256 keypair plus the raw SPKI EC point ring
+    /// expects for verification, mirroring how a `GridSite`'s certificate
+    /// key material is produced by `certs::generate`.
+    fn generate_key_and_raw_pubkey() -> (Vec<u8>, Vec<u8>) {
+        let key_pair = KeyPair::generate().unwrap_or_else(|_| std::process::abort());
+        let pkcs8_der = key_pair.serialize_der();
+        let params = rcgen::CertificateParams::new(vec!["spike.grid.internal".to_owned()])
+            .unwrap_or_else(|_| std::process::abort());
+        let cert = params.self_signed(&key_pair).unwrap_or_else(|_| std::process::abort());
+        let (_, parsed) = x509_parser::parse_x509_certificate(cert.der()).unwrap_or_else(|_| std::process::abort());
+        let raw_pubkey = parsed.public_key().subject_public_key.as_ref().to_vec();
+        (pkcs8_der, raw_pubkey)
+    }
+
+    #[test]
+    fn sign_then_verify_round_trips_for_a_matching_key_and_payload() {
+        let (pkcs8_der, raw_pubkey) = generate_key_and_raw_pubkey();
+        let payload = b"origin-site-a|revision=1";
+
+        let signature = sign_ecdsa_p256(&pkcs8_der, payload).unwrap_or_else(|_| std::process::abort());
+
+        verify_ecdsa_p256(&raw_pubkey, payload, &signature).unwrap_or_else(|_| std::process::abort());
+    }
+
+    #[test]
+    fn verify_rejects_a_signature_over_a_different_payload() {
+        let (pkcs8_der, raw_pubkey) = generate_key_and_raw_pubkey();
+        let signature = sign_ecdsa_p256(&pkcs8_der, b"revision=1").unwrap_or_else(|_| std::process::abort());
+
+        let result = verify_ecdsa_p256(&raw_pubkey, b"revision=2", &signature);
+
+        assert!(matches!(result, Err(VerificationError::Invalid)));
+    }
+
+    #[test]
+    fn verify_rejects_a_signature_from_an_unrelated_key() {
+        let (pkcs8_der, _) = generate_key_and_raw_pubkey();
+        let (_, other_raw_pubkey) = generate_key_and_raw_pubkey();
+        let payload = b"origin-site-a|revision=1";
+        let signature = sign_ecdsa_p256(&pkcs8_der, payload).unwrap_or_else(|_| std::process::abort());
+
+        let result = verify_ecdsa_p256(&other_raw_pubkey, payload, &signature);
+
+        assert!(matches!(result, Err(VerificationError::Invalid)));
+    }
+
+    #[test]
+    fn sign_rejects_malformed_pkcs8_key_material() {
+        let result = sign_ecdsa_p256(b"not-a-real-key", b"payload");
+
+        assert!(matches!(result, Err(SigningError::InvalidKey)));
+    }
+}

--- a/swim/src/state_broadcast.rs
+++ b/swim/src/state_broadcast.rs
@@ -116,6 +116,22 @@ struct BroadcastExtension {
     signature: Option<Vec<u8>>,
 }
 
+/// Extension format used by peers that predate the `signature` field.
+///
+/// bincode is not self-describing, so decoding a two-field payload as
+/// [`BroadcastExtension`] fails partway through the third field rather than
+/// falling back to `#[serde(default)]` — `decode` tries this shape before
+/// falling further back to the original bare-`String` format, so a rolling
+/// update does not silently drop or misdecode `gateway_address`/
+/// `site_cert_pem` from not-yet-upgraded peers.
+#[derive(Serialize, Deserialize)]
+struct PreSignatureBroadcastExtension {
+    /// Optional data-plane gateway address.
+    gateway_address: Option<String>,
+    /// Optional public site certificate PEM — never a private key.
+    site_cert_pem: Option<String>,
+}
+
 impl StateBroadcast {
     /// Create a versioned state broadcast.
     ///
@@ -274,9 +290,14 @@ impl StateBroadcast {
     /// Decode this broadcast from bincode bytes.
     ///
     /// Decodes the base v1 payload, then tries to decode any trailing bytes as
-    /// a `BroadcastExtension` struct.  Falls back to the previous bare-`String`
-    /// format for `gateway_address` when the struct decode fails, ensuring
-    /// interoperability with older peers that use the first extension format.
+    /// a `BroadcastExtension` struct.  Because bincode is not self-describing,
+    /// a three-field extension decode does not simply come back `Ok` with
+    /// `signature: None` when reading bytes from an older, two-field peer —
+    /// it fails partway through the missing field.  Falls back in turn to the
+    /// two-field pre-signature extension format, then to the
+    /// original bare-`String` format for `gateway_address`, ensuring
+    /// interoperability with peers running any prior wire format during a
+    /// rolling update.
     ///
     /// Payloads without any extension decode with `gateway_address = None` and
     /// `site_cert_pem = None`.
@@ -290,21 +311,7 @@ impl StateBroadcast {
             bincode::serde::decode_from_slice(bytes, bincode::config::standard())?;
 
         let remaining = bytes.get(consumed..).unwrap_or(&[]);
-        let (gateway_address, site_cert_pem, signature) = if remaining.is_empty() {
-            (None, None, None)
-        } else {
-            // Try the current extension struct format.
-            match bincode::serde::decode_from_slice::<BroadcastExtension, _>(remaining, bincode::config::standard()) {
-                Ok((ext, _)) => (ext.gateway_address, ext.site_cert_pem, ext.signature),
-                Err(_) => {
-                    // Compatibility fallback: bare String encoding for gateway_address only.
-                    match bincode::serde::decode_from_slice::<String, _>(remaining, bincode::config::standard()) {
-                        Ok((gw, _)) => (Some(gw), None, None),
-                        Err(_) => (None, None, None),
-                    }
-                },
-            }
-        };
+        let (gateway_address, site_cert_pem, signature) = Self::decode_extension(remaining);
 
         Ok(Self {
             version: v1.version,
@@ -315,6 +322,31 @@ impl StateBroadcast {
             site_cert_pem,
             signature,
         })
+    }
+
+    /// Decode the trailing extension bytes, falling back across every prior
+    /// wire format in turn. See [`decode`](Self::decode) for why a naive
+    /// single-shot struct decode is not enough during a rolling update.
+    fn decode_extension(remaining: &[u8]) -> (Option<String>, Option<String>, Option<Vec<u8>>) {
+        if remaining.is_empty() {
+            return (None, None, None);
+        }
+        if let Ok((ext, _)) =
+            bincode::serde::decode_from_slice::<BroadcastExtension, _>(remaining, bincode::config::standard())
+        {
+            return (ext.gateway_address, ext.site_cert_pem, ext.signature);
+        }
+        if let Ok((ext, _)) = bincode::serde::decode_from_slice::<PreSignatureBroadcastExtension, _>(
+            remaining,
+            bincode::config::standard(),
+        ) {
+            return (ext.gateway_address, ext.site_cert_pem, None);
+        }
+        // Compatibility fallback: bare String encoding for gateway_address only.
+        match bincode::serde::decode_from_slice::<String, _>(remaining, bincode::config::standard()) {
+            Ok((gw, _)) => (Some(gw), None, None),
+            Err(_) => (None, None, None),
+        }
     }
 }
 
@@ -908,6 +940,33 @@ mod tests {
             .unwrap_or_else(|_| std::process::abort())
     }
 
+    /// Encode a base v1 payload plus a two-field pre-signature extension,
+    /// mirroring the wire bytes a peer running the extension format that
+    /// predates the `signature` field would have sent.
+    fn encode_v1_plus_pre_signature_extension(
+        origin_site: &str,
+        revision: u64,
+        gateway_address: Option<String>,
+        site_cert_pem: Option<String>,
+    ) -> Vec<u8> {
+        let v1 = StateBroadcastV1 {
+            version: STATE_BROADCAST_VERSION,
+            origin_site: origin_site.to_owned(),
+            revision,
+            snapshot: snapshot(origin_site, revision, 0.4),
+        };
+        let mut bytes =
+            bincode::serde::encode_to_vec(&v1, bincode::config::standard()).unwrap_or_else(|_| std::process::abort());
+        let ext = PreSignatureBroadcastExtension {
+            gateway_address,
+            site_cert_pem,
+        };
+        let ext_bytes =
+            bincode::serde::encode_to_vec(&ext, bincode::config::standard()).unwrap_or_else(|_| std::process::abort());
+        bytes.extend_from_slice(&ext_bytes);
+        bytes
+    }
+
     /// Generate an ECDSA P-256 signing key plus the raw SPKI EC point a
     /// verifier needs, independent of *how* a real deployment would source
     /// or pin this key material (grid#75, still open).
@@ -1079,6 +1138,39 @@ mod tests {
             .unwrap_or_else(|| std::process::abort());
         assert_eq!(decoded.version, STATE_BROADCAST_VERSION_V1, "version without gateway");
         assert_eq!(provider.metrics.queue_depth, Some(0.1), "metric value");
+    }
+
+    #[test]
+    fn decode_recovers_gateway_and_cert_from_a_pre_signature_two_field_extension() {
+        // Simulates a broadcast sent by a peer running the two-field
+        // `BroadcastExtension` (gateway_address, site_cert_pem) that predates
+        // the `signature` field added in this PR. bincode is not
+        // self-describing: decoding those bytes as the current three-field
+        // struct hits `UnexpectedEnd` while reading `signature`, and
+        // `#[serde(default)]` never gets a chance to apply because the `?`
+        // inside serde's generated `visit_seq` propagates that error first.
+        // A rolling update must not silently drop `gateway_address`/
+        // `site_cert_pem` for every broadcast from a not-yet-upgraded peer.
+        let bytes = encode_v1_plus_pre_signature_extension(
+            "site-old-peer",
+            3,
+            Some("10.0.0.9:8443".to_owned()),
+            Some("-----BEGIN CERTIFICATE-----legacy-----END CERTIFICATE-----".to_owned()),
+        );
+
+        let decoded = StateBroadcast::decode(&bytes).unwrap_or_else(|_| std::process::abort());
+
+        assert_eq!(
+            decoded.gateway_address.as_deref(),
+            Some("10.0.0.9:8443"),
+            "gateway_address from a pre-signature peer must survive decode, not be silently dropped"
+        );
+        assert_eq!(
+            decoded.site_cert_pem.as_deref(),
+            Some("-----BEGIN CERTIFICATE-----legacy-----END CERTIFICATE-----"),
+            "site_cert_pem from a pre-signature peer must survive decode, not be silently dropped"
+        );
+        assert_eq!(decoded.signature, None, "a pre-signature peer never sends a signature");
     }
 
     #[test]

--- a/swim/src/state_broadcast.rs
+++ b/swim/src/state_broadcast.rs
@@ -63,7 +63,25 @@ pub struct StateBroadcast {
     /// `None` when the originating operator has no TLS certificate configured.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub site_cert_pem: Option<String>,
+
+    /// ECDSA P-256 signature (ASN.1 DER) over [`signable_bytes`](Self::signable_bytes).
+    ///
+    /// `None` when the originating site has no signing key configured, or
+    /// during the rollout window before every peer signs broadcasts. A
+    /// receiver only requires this field once it holds a pinned identity for
+    /// `origin_site`; see [`StateBroadcastHandler::receive_item`].
+    ///
+    /// [`StateBroadcastHandler::receive_item`]: foca::BroadcastHandler::receive_item
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub signature: Option<Vec<u8>>,
 }
+
+/// Raw uncompressed EC point, keyed by origin site name.
+///
+/// Deliberately opaque to *how* a pinned identity was established — that is
+/// an operator-level concern (see [`crate::signing`]).  An origin with no
+/// entry here is not yet enforced against a signature.
+pub type TrustStore = BTreeMap<String, Vec<u8>>;
 
 /// Base wire-format struct.
 ///
@@ -92,6 +110,10 @@ struct BroadcastExtension {
     gateway_address: Option<String>,
     /// Optional public site certificate PEM — never a private key.
     site_cert_pem: Option<String>,
+    /// Optional ECDSA P-256 signature over the base payload plus the other
+    /// extension fields. Absent on older peers and pre-rollout broadcasts.
+    #[serde(default)]
+    signature: Option<Vec<u8>>,
 }
 
 impl StateBroadcast {
@@ -114,6 +136,7 @@ impl StateBroadcast {
             snapshot,
             gateway_address,
             site_cert_pem: None,
+            signature: None,
         }
     }
 
@@ -124,6 +147,31 @@ impl StateBroadcast {
     pub fn with_cert(mut self, site_cert_pem: Option<String>) -> Self {
         self.site_cert_pem = site_cert_pem;
         self
+    }
+
+    /// Attach a signature computed over [`signable_bytes`](Self::signable_bytes).
+    ///
+    /// Callers are responsible for computing `signature` (typically via
+    /// [`crate::signing::sign_ecdsa_p256`] over `self.signable_bytes()`)
+    /// before attaching it; this method performs no verification.
+    #[must_use]
+    pub fn with_signature(mut self, signature: Option<Vec<u8>>) -> Self {
+        self.signature = signature;
+        self
+    }
+
+    /// Return the canonical bytes this broadcast's signature covers.
+    ///
+    /// Equal to [`encode`](Self::encode) of this broadcast with `signature`
+    /// cleared, so a signature can never cover itself.
+    ///
+    /// # Errors
+    ///
+    /// Returns a bincode encode error if the snapshot cannot be serialized.
+    pub fn signable_bytes(&self) -> Result<Vec<u8>, bincode::error::EncodeError> {
+        let mut unsigned = self.clone();
+        unsigned.signature = None;
+        unsigned.encode()
     }
 
     /// Return this broadcast's invalidation key.
@@ -211,10 +259,11 @@ impl StateBroadcast {
             snapshot: self.snapshot.clone(),
         };
         let mut bytes = bincode::serde::encode_to_vec(&v1, bincode::config::standard())?;
-        if self.gateway_address.is_some() || self.site_cert_pem.is_some() {
+        if self.gateway_address.is_some() || self.site_cert_pem.is_some() || self.signature.is_some() {
             let ext = BroadcastExtension {
                 gateway_address: self.gateway_address.clone(),
                 site_cert_pem: self.site_cert_pem.clone(),
+                signature: self.signature.clone(),
             };
             let ext_bytes = bincode::serde::encode_to_vec(&ext, bincode::config::standard())?;
             bytes.extend_from_slice(&ext_bytes);
@@ -241,17 +290,17 @@ impl StateBroadcast {
             bincode::serde::decode_from_slice(bytes, bincode::config::standard())?;
 
         let remaining = bytes.get(consumed..).unwrap_or(&[]);
-        let (gateway_address, site_cert_pem) = if remaining.is_empty() {
-            (None, None)
+        let (gateway_address, site_cert_pem, signature) = if remaining.is_empty() {
+            (None, None, None)
         } else {
             // Try the current extension struct format.
             match bincode::serde::decode_from_slice::<BroadcastExtension, _>(remaining, bincode::config::standard()) {
-                Ok((ext, _)) => (ext.gateway_address, ext.site_cert_pem),
+                Ok((ext, _)) => (ext.gateway_address, ext.site_cert_pem, ext.signature),
                 Err(_) => {
                     // Compatibility fallback: bare String encoding for gateway_address only.
                     match bincode::serde::decode_from_slice::<String, _>(remaining, bincode::config::standard()) {
-                        Ok((gw, _)) => (Some(gw), None),
-                        Err(_) => (None, None),
+                        Ok((gw, _)) => (Some(gw), None, None),
+                        Err(_) => (None, None, None),
                     }
                 },
             }
@@ -264,6 +313,7 @@ impl StateBroadcast {
             snapshot: v1.snapshot,
             gateway_address,
             site_cert_pem,
+            signature,
         })
     }
 }
@@ -334,6 +384,29 @@ pub enum StateBroadcastError {
         expected: u16,
         /// Actual version.
         actual: u16,
+    },
+
+    /// The origin has a pinned identity but the broadcast carries no signature.
+    #[error("state broadcast from pinned origin {origin_site} carries no signature")]
+    MissingSignature {
+        /// Site that originated the broadcast.
+        origin_site: String,
+    },
+
+    /// The broadcast's signature does not verify against the pinned identity.
+    #[error("state broadcast from pinned origin {origin_site} failed signature verification")]
+    SignatureInvalid {
+        /// Site that originated the broadcast.
+        origin_site: String,
+    },
+
+    /// The broadcast's own bytes could not be re-encoded to check its signature.
+    #[error("state broadcast from origin {origin_site} could not be re-encoded for signature verification: {source}")]
+    SignableEncode {
+        /// Site that originated the broadcast.
+        origin_site: String,
+        /// Underlying encode error.
+        source: bincode::error::EncodeError,
     },
 }
 
@@ -453,6 +526,17 @@ pub struct StateBroadcastHandler {
     /// Watch channel for broadcasting public cert PEM updates to observers.
     cert_pems_tx: watch::Sender<BTreeMap<String, String>>,
 
+    /// Sender half of the pinned-identity trust store.
+    ///
+    /// Exposed via [`trust_store_sender`](Self::trust_store_sender) so a
+    /// caller (e.g. the operator, once it has established which certificate
+    /// pins an origin site's signing identity) can populate or update
+    /// entries at runtime, after this handler has been moved into foca.
+    trust_store_tx: watch::Sender<TrustStore>,
+
+    /// Receiver half read synchronously by [`receive_item`](foca::BroadcastHandler::receive_item).
+    trust_store_rx: watch::Receiver<TrustStore>,
+
     /// Hard bound for per-origin revision and metadata maps.
     max_origins: usize,
 }
@@ -479,6 +563,7 @@ impl StateBroadcastHandler {
         let (tx, _) = watch::channel(GridStateSnapshot::new(site_id));
         let (gw_tx, _) = watch::channel(BTreeMap::new());
         let (cert_tx, _) = watch::channel(BTreeMap::new());
+        let (trust_tx, trust_rx) = watch::channel(TrustStore::new());
         let max_origins = max_origins.max(1);
         let retained = Arc::new(Mutex::new(RetainedOrigins::default()));
         let control = OriginStateHandle {
@@ -493,10 +578,25 @@ impl StateBroadcastHandler {
                 retained,
                 gateway_addrs_tx: gw_tx,
                 cert_pems_tx: cert_tx,
+                trust_store_tx: trust_tx,
+                trust_store_rx: trust_rx,
                 max_origins,
             },
             control,
         )
+    }
+
+    /// Return a sender for updating the pinned-identity trust store.
+    ///
+    /// Clone and hold this to push pinned identities in after `self` has
+    /// been moved into foca. An origin site with no entry is not yet
+    /// enforced against a signature — see [`receive_item`]'s doc comment for
+    /// the rollout-transition rationale.
+    ///
+    /// [`receive_item`]: foca::BroadcastHandler::receive_item
+    #[must_use]
+    pub fn trust_store_sender(&self) -> watch::Sender<TrustStore> {
+        self.trust_store_tx.clone()
     }
 
     /// Return a receiver for the live merged grid-state snapshot.
@@ -644,6 +744,38 @@ impl StateBroadcastHandler {
         });
     }
 
+    /// Reject a broadcast that fails signature verification against a
+    /// pinned identity.
+    ///
+    /// An origin with **no** entry in the trust store passes through
+    /// unchecked — this is deliberate: it lets a signed-broadcast rollout
+    /// proceed incrementally as origins are pinned one at a time, rather
+    /// than requiring a synchronized flag-day cutover. Once nerdalert's
+    /// key-source question (grid#75) is resolved and the operator starts
+    /// populating pins, this becomes the enforcement point; until then it is
+    /// a no-op for every unpinned origin.
+    fn verify_signature_if_pinned(&self, broadcast: &StateBroadcast) -> Result<(), StateBroadcastError> {
+        let Some(pinned_pubkey) = self.trust_store_rx.borrow().get(&broadcast.origin_site).cloned() else {
+            return Ok(());
+        };
+        let Some(signature) = broadcast.signature.as_ref() else {
+            return Err(StateBroadcastError::MissingSignature {
+                origin_site: broadcast.origin_site.clone(),
+            });
+        };
+        let signable = broadcast
+            .signable_bytes()
+            .map_err(|source| StateBroadcastError::SignableEncode {
+                origin_site: broadcast.origin_site.clone(),
+                source,
+            })?;
+        crate::signing::verify_ecdsa_p256(&pinned_pubkey, &signable, signature).map_err(|_invalid| {
+            StateBroadcastError::SignatureInvalid {
+                origin_site: broadcast.origin_site.clone(),
+            }
+        })
+    }
+
     /// Enforce the hard origin bound before accepting an unknown origin.
     fn make_room_for(&self, incoming_origin: &str) {
         let origins = self.known_origins();
@@ -677,6 +809,7 @@ impl foca::BroadcastHandler<NodeId> for StateBroadcastHandler {
                 actual: broadcast.version,
             });
         }
+        self.verify_signature_if_pinned(&broadcast)?;
         self.make_room_for(&broadcast.origin_site);
 
         // Metadata-only broadcasts (gateway address or cert PEM, empty CRDT
@@ -765,6 +898,117 @@ mod tests {
         handler
             .receive_item(&bytes, None)
             .unwrap_or_else(|_| std::process::abort())
+    }
+
+    /// Generate an ECDSA P-256 signing key plus the raw SPKI EC point a
+    /// verifier needs, independent of *how* a real deployment would source
+    /// or pin this key material (grid#75, still open).
+    fn generate_signing_key_and_pubkey() -> (Vec<u8>, Vec<u8>) {
+        let key_pair = rcgen::KeyPair::generate().unwrap_or_else(|_| std::process::abort());
+        let pkcs8_der = key_pair.serialize_der();
+        let params = rcgen::CertificateParams::new(vec!["spike.grid.internal".to_owned()])
+            .unwrap_or_else(|_| std::process::abort());
+        let cert = params.self_signed(&key_pair).unwrap_or_else(|_| std::process::abort());
+        let (_, parsed) = x509_parser::parse_x509_certificate(cert.der()).unwrap_or_else(|_| std::process::abort());
+        let raw_pubkey = parsed.public_key().subject_public_key.as_ref().to_vec();
+        (pkcs8_der, raw_pubkey)
+    }
+
+    #[test]
+    fn receive_item_accepts_a_correctly_signed_broadcast_from_a_pinned_origin() {
+        let (mut handler, _control) = StateBroadcastHandler::with_capacity("site-local".to_owned(), 8);
+        let (pkcs8_der, raw_pubkey) = generate_signing_key_and_pubkey();
+        handler
+            .trust_store_sender()
+            .send_modify(|store| drop(store.insert("site-p".to_owned(), raw_pubkey)));
+
+        let unsigned = StateBroadcast::new("site-p".to_owned(), 1, snapshot("site-p", 1, 0.1), None);
+        let signature = crate::signing::sign_ecdsa_p256(
+            &pkcs8_der,
+            &unsigned.signable_bytes().unwrap_or_else(|_| std::process::abort()),
+        )
+        .unwrap_or_else(|_| std::process::abort());
+        let signed = unsigned.with_signature(Some(signature));
+
+        let key = receive(&mut handler, &signed);
+
+        assert!(
+            key.is_some(),
+            "a correctly signed broadcast from a pinned origin must be accepted"
+        );
+        assert!(
+            handler.snapshot().provider("net", "site-p", "provider").is_some(),
+            "the signed broadcast's provider state must be merged"
+        );
+    }
+
+    #[test]
+    fn receive_item_rejects_an_unsigned_broadcast_from_a_pinned_origin() {
+        let (mut handler, _control) = StateBroadcastHandler::with_capacity("site-local".to_owned(), 8);
+        let (_pkcs8_der, raw_pubkey) = generate_signing_key_and_pubkey();
+        handler
+            .trust_store_sender()
+            .send_modify(|store| drop(store.insert("site-p".to_owned(), raw_pubkey)));
+        let unsigned = StateBroadcast::new("site-p".to_owned(), 1, snapshot("site-p", 1, 0.1), None);
+        let bytes = unsigned.encode().unwrap_or_else(|_| std::process::abort());
+
+        let result = handler.receive_item(&bytes, None);
+
+        assert!(
+            matches!(&result, Err(StateBroadcastError::MissingSignature { origin_site }) if origin_site.as_str() == "site-p"),
+            "an unsigned broadcast from a pinned origin must be rejected, got {result:?}"
+        );
+        assert!(
+            handler.snapshot().provider("net", "site-p", "provider").is_none(),
+            "a rejected broadcast must not be merged into the snapshot"
+        );
+    }
+
+    #[test]
+    fn receive_item_rejects_a_broadcast_signed_by_the_wrong_key_for_a_pinned_origin() {
+        let (mut handler, _control) = StateBroadcastHandler::with_capacity("site-local".to_owned(), 8);
+        let (_correct_key, pinned_pubkey) = generate_signing_key_and_pubkey();
+        let (wrong_key, _wrong_pubkey) = generate_signing_key_and_pubkey();
+        handler
+            .trust_store_sender()
+            .send_modify(|store| drop(store.insert("site-p".to_owned(), pinned_pubkey)));
+
+        let unsigned = StateBroadcast::new("site-p".to_owned(), 1, snapshot("site-p", 1, 0.1), None);
+        let signature = crate::signing::sign_ecdsa_p256(
+            &wrong_key,
+            &unsigned.signable_bytes().unwrap_or_else(|_| std::process::abort()),
+        )
+        .unwrap_or_else(|_| std::process::abort());
+        let bytes = unsigned
+            .with_signature(Some(signature))
+            .encode()
+            .unwrap_or_else(|_| std::process::abort());
+
+        let result = handler.receive_item(&bytes, None);
+
+        assert!(
+            matches!(&result, Err(StateBroadcastError::SignatureInvalid { origin_site }) if origin_site.as_str() == "site-p"),
+            "a broadcast signed by a key other than the pinned one must be rejected, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn receive_item_still_merges_an_unsigned_broadcast_from_an_origin_with_no_pinned_identity() {
+        // Guards the incremental-rollout property documented on
+        // `verify_signature_if_pinned`: no synchronized flag-day cutover.
+        let (mut handler, _control) = StateBroadcastHandler::with_capacity("site-local".to_owned(), 8);
+        let unsigned = StateBroadcast::new("site-p".to_owned(), 1, snapshot("site-p", 1, 0.1), None);
+
+        let key = receive(&mut handler, &unsigned);
+
+        assert!(
+            key.is_some(),
+            "an unsigned broadcast from an unpinned origin must still be accepted"
+        );
+        assert!(
+            handler.snapshot().provider("net", "site-p", "provider").is_some(),
+            "the unsigned broadcast's provider state must be merged while the origin is unpinned"
+        );
     }
 
     #[test]

--- a/swim/src/state_broadcast.rs
+++ b/swim/src/state_broadcast.rs
@@ -755,25 +755,33 @@ impl StateBroadcastHandler {
     /// populating pins, this becomes the enforcement point; until then it is
     /// a no-op for every unpinned origin.
     fn verify_signature_if_pinned(&self, broadcast: &StateBroadcast) -> Result<(), StateBroadcastError> {
+        /// Rejection log message shared by every failure branch below.
+        ///
+        /// Deliberately carries no payload contents, matching grid#75's
+        /// review request for bounded rejection metrics that never log
+        /// broadcast bodies; `reason` stays a small closed set of values.
+        const REJECTED: &str = "rejecting pinned-origin state broadcast";
+
         let Some(pinned_pubkey) = self.trust_store_rx.borrow().get(&broadcast.origin_site).cloned() else {
             return Ok(());
         };
+        let origin_site = broadcast.origin_site.clone();
         let Some(signature) = broadcast.signature.as_ref() else {
-            return Err(StateBroadcastError::MissingSignature {
-                origin_site: broadcast.origin_site.clone(),
-            });
+            tracing::warn!(origin_site = %origin_site, reason = "missing_signature", REJECTED);
+            return Err(StateBroadcastError::MissingSignature { origin_site });
         };
-        let signable = broadcast
-            .signable_bytes()
-            .map_err(|source| StateBroadcastError::SignableEncode {
-                origin_site: broadcast.origin_site.clone(),
-                source,
-            })?;
-        crate::signing::verify_ecdsa_p256(&pinned_pubkey, &signable, signature).map_err(|_invalid| {
-            StateBroadcastError::SignatureInvalid {
-                origin_site: broadcast.origin_site.clone(),
-            }
-        })
+        let signable = match broadcast.signable_bytes() {
+            Ok(bytes) => bytes,
+            Err(source) => {
+                tracing::warn!(origin_site = %origin_site, reason = "signable_encode", REJECTED);
+                return Err(StateBroadcastError::SignableEncode { origin_site, source });
+            },
+        };
+        if crate::signing::verify_ecdsa_p256(&pinned_pubkey, &signable, signature).is_err() {
+            tracing::warn!(origin_site = %origin_site, reason = "signature_invalid", REJECTED);
+            return Err(StateBroadcastError::SignatureInvalid { origin_site });
+        }
+        Ok(())
     }
 
     /// Enforce the hard origin bound before accepting an unknown origin.

--- a/swim/src/state_broadcast.rs
+++ b/swim/src/state_broadcast.rs
@@ -1001,6 +1001,47 @@ mod tests {
     }
 
     #[test]
+    fn missing_signature_error_message_names_the_origin() {
+        let err = StateBroadcastError::MissingSignature {
+            origin_site: "site-p".to_owned(),
+        };
+        assert!(
+            err.to_string().contains("site-p"),
+            "error message must name the origin site"
+        );
+    }
+
+    #[test]
+    fn signature_invalid_error_message_names_the_origin() {
+        let err = StateBroadcastError::SignatureInvalid {
+            origin_site: "site-p".to_owned(),
+        };
+        assert!(
+            err.to_string().contains("site-p"),
+            "error message must name the origin site"
+        );
+    }
+
+    #[test]
+    fn signable_encode_error_message_names_the_origin_and_wraps_the_source() {
+        // A genuine bincode encode failure on `StateBroadcast`'s own fields
+        // (String/u64/u16/GridStateSnapshot, encoded to an in-memory Vec<u8>
+        // with no writer I/O) has no reachable trigger through this crate's
+        // public API; constructed directly to verify the message wording,
+        // matching this codebase's `..._error_formats_correctly` convention
+        // for defensive error variants (see e.g.
+        // `node::tests::state_broadcast_error_formats_correctly`).
+        let err = StateBroadcastError::SignableEncode {
+            origin_site: "site-p".to_owned(),
+            source: bincode::error::EncodeError::UnexpectedEnd,
+        };
+        assert!(
+            err.to_string().contains("site-p"),
+            "error message must name the origin site"
+        );
+    }
+
+    #[test]
     fn receive_item_still_merges_an_unsigned_broadcast_from_an_origin_with_no_pinned_identity() {
         // Guards the incremental-rollout property documented on
         // `verify_signature_if_pinned`: no synchronized flag-day cutover.

--- a/swim/src/state_broadcast.rs
+++ b/swim/src/state_broadcast.rs
@@ -8,6 +8,7 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
     sync::{Arc, Mutex, MutexGuard, PoisonError},
+    time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
 use crdt::GridStateSnapshot;
@@ -33,6 +34,40 @@ pub const STATE_BROADCAST_VERSION: u16 = STATE_BROADCAST_VERSION_V1;
 
 /// Default hard bound for distinct origins retained by one broadcast handler.
 pub const DEFAULT_MAX_RETAINED_ORIGINS: usize = 1_024;
+
+/// Domain-separation prefix mixed into every state-broadcast signature.
+///
+/// Binds a signature to this exact protocol, message type, and wire-format
+/// version, so it can never be replayed as valid input to a different
+/// signing context even if the same ECDSA key were ever reused elsewhere.
+///
+/// Scopes a signature to *this protocol*, not to a particular
+/// `GridNetwork`: that narrower scoping is [`StateBroadcast::grid_id`]'s
+/// job, since a node can publish a broadcast before joining any
+/// `GridNetwork` and so cannot always supply one. Anything broader than a
+/// single cluster's `GridNetwork`s — cross-deployment or per-peer mesh
+/// identity — remains out of scope for this constant and for `grid_id`
+/// alike.
+const SIGNATURE_DOMAIN: &[u8] = b"praxis-grid/swim/state-broadcast/v1";
+
+/// Maximum age, in milliseconds, of a pinned origin's signed broadcast
+/// timestamp before it is rejected as stale.
+///
+/// Set to several orders of magnitude above the default 5-second SWIM probe
+/// interval (`default_probe_interval` in `operator/src/crd/grid_network.rs`),
+/// comfortably covering ordinary gossip fan-out delay while still bounding a
+/// captured signature's replay window to minutes rather than leaving it
+/// unbounded. See [`StateBroadcast::signed_at_ms`] for what this window does
+/// and does not defend against.
+pub const MAX_BROADCAST_AGE_MS: u64 = 5 * 60 * 1_000;
+
+/// Maximum amount, in milliseconds, a pinned origin's signed broadcast
+/// timestamp may be ahead of this node's own clock before it is rejected.
+///
+/// Tolerates ordinary clock drift between SWIM peers without opening a
+/// window for a broadcast timestamped far in the future to keep outrunning
+/// [`MAX_BROADCAST_AGE_MS`] on every receiving peer.
+pub const MAX_CLOCK_SKEW_AHEAD_MS: u64 = 30_000;
 
 /// Broadcast envelope carrying one CRDT grid-state snapshot.
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -74,14 +109,85 @@ pub struct StateBroadcast {
     /// [`StateBroadcastHandler::receive_item`]: foca::BroadcastHandler::receive_item
     #[serde(skip_serializing_if = "Option::is_none")]
     pub signature: Option<Vec<u8>>,
+
+    /// Wall-clock time this broadcast was signed, in milliseconds since the
+    /// Unix epoch.
+    ///
+    /// `None` under the same conditions as [`signature`](Self::signature)
+    /// — no signing key configured, or the pre-rollout window. Included in
+    /// [`signable_bytes`](Self::signable_bytes) so a captured signature
+    /// cannot be re-attached to a forged, more-recent timestamp. A receiver
+    /// holding a pinned identity for `origin_site` rejects a signature whose
+    /// timestamp is more than [`MAX_BROADCAST_AGE_MS`] in the past, or more
+    /// than [`MAX_CLOCK_SKEW_AHEAD_MS`] in the future, bounding how long a
+    /// captured, validly signed broadcast can be replayed as current.
+    ///
+    /// Bounds only the *replay window*, not full replay elimination: this
+    /// value is never persisted, so a process restart resets every
+    /// receiver's notion of "now" relative to nothing durable. Full replay
+    /// elimination needs a persisted, monotonic revision floor surviving
+    /// restarts, which this in-memory crate does not provide.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub signed_at_ms: Option<u64>,
+
+    /// Identifier of the `GridNetwork` this broadcast's state belongs to.
+    ///
+    /// Included in [`signable_bytes`](Self::signable_bytes) so a signature
+    /// is scoped to one `GridNetwork`: issue [#48] documents that a single
+    /// cluster can run multiple `GridNetwork`s as separate tenants,
+    /// environments, or trust domains with independent provider
+    /// inventories, yet one `SwimHandle` is shared across every
+    /// `GridNetwork` reconcile on that cluster. Without this field, a
+    /// signature valid for one `GridNetwork` would also verify, bit for
+    /// bit, as a broadcast claiming to belong to another `GridNetwork` on
+    /// the same cluster — a cross-tenant replay that would defeat #48's
+    /// stated isolation guarantee.
+    ///
+    /// `None` for broadcasts published before a node has joined any
+    /// `GridNetwork` (e.g. a bare gateway-address advertisement — see
+    /// `publish_gateway_address_broadcast` in the operator crate), and for
+    /// broadcasts from operators old enough to predate this field.
+    ///
+    /// [#48]: https://github.com/praxis-proxy/grid/issues/48
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub grid_id: Option<String>,
 }
 
-/// Raw uncompressed EC point, keyed by origin site name.
+/// Maximum number of raw public keys retained per pinned origin.
 ///
-/// Deliberately opaque to *how* a pinned identity was established — that is
-/// an operator-level concern (see [`crate::signing`]).  An origin with no
-/// entry here is not yet enforced against a signature.
-pub type TrustStore = BTreeMap<String, Vec<u8>>;
+/// Mirrors `GridSiteTrustPolicy.canonical_fingerprints`'s dual-pin bound for
+/// mTLS certificate rotation (`operator/src/crd/grid_site.rs`): one slot for
+/// the current signing key and one for a next key during a bounded rotation
+/// overlap window.
+pub const MAX_PINNED_KEYS_PER_ORIGIN: usize = 2;
+
+/// Bounded set of accepted raw ECDSA P-256 public keys, keyed by origin site
+/// name.
+///
+/// Each value holds up to [`MAX_PINNED_KEYS_PER_ORIGIN`] raw uncompressed EC
+/// points. A broadcast's signature verifies if it is valid under **any** key
+/// in its origin's pinned set — this is what makes bounded key rotation
+/// possible without an instantaneous flag-day cutover: a site publishes a
+/// next key alongside its current one, callers add the next key to the pin
+/// set, and once every peer has observed the rotation the old key is
+/// dropped. Deliberately opaque to *how* a pinned identity was established —
+/// that is an operator-level concern (see [`crate::signing`]). An origin
+/// with no entry, or an empty entry, is not yet enforced against a
+/// signature. Prefer [`crate::node::SwimNode::pin_origin`] over mutating
+/// this map directly through [`StateBroadcastHandler::trust_store_sender`]:
+/// `pin_origin` also purges any state accepted from an origin before it had
+/// a pin, which a raw `watch::Sender::send`/`send_modify` call does not.
+pub type TrustStore = BTreeMap<String, Vec<Vec<u8>>>;
+
+/// A caller supplied more than [`MAX_PINNED_KEYS_PER_ORIGIN`] keys for one origin.
+#[derive(Debug, thiserror::Error)]
+#[error("origin {origin} was pinned with {supplied} keys, exceeding the max of {MAX_PINNED_KEYS_PER_ORIGIN}")]
+pub struct TooManyPinnedKeys {
+    /// Origin site the caller attempted to pin.
+    pub origin: String,
+    /// Number of keys the caller supplied.
+    pub supplied: usize,
+}
 
 /// Base wire-format struct.
 ///
@@ -114,16 +220,56 @@ struct BroadcastExtension {
     /// extension fields. Absent on older peers and pre-rollout broadcasts.
     #[serde(default)]
     signature: Option<Vec<u8>>,
+    /// Optional wall-clock signing timestamp, milliseconds since the Unix
+    /// epoch. Absent on older peers and pre-rollout broadcasts.
+    #[serde(default)]
+    signed_at_ms: Option<u64>,
+    /// Optional owning `GridNetwork` identifier. Absent on older peers,
+    /// pre-rollout broadcasts, and broadcasts published before a node has
+    /// joined any `GridNetwork`.
+    #[serde(default)]
+    grid_id: Option<String>,
 }
+
+/// Extension format used by peers that predate both the `signed_at_ms` and
+/// `grid_id` fields.
+///
+/// bincode is not self-describing, so decoding a three-field payload as the
+/// current five-field [`BroadcastExtension`] fails partway through the
+/// fourth field rather than falling back to `#[serde(default)]` — `decode`
+/// tries this shape before falling further back through every prior wire
+/// format, so a rolling update does not silently drop or misdecode
+/// `gateway_address`/`site_cert_pem`/`signature` from not-yet-upgraded peers.
+#[derive(Serialize, Deserialize)]
+struct PreTimestampBroadcastExtension {
+    /// Optional data-plane gateway address.
+    gateway_address: Option<String>,
+    /// Optional public site certificate PEM — never a private key.
+    site_cert_pem: Option<String>,
+    /// Optional ECDSA P-256 signature over the base payload plus the other
+    /// extension fields. Absent on older peers and pre-rollout broadcasts.
+    #[serde(default)]
+    signature: Option<Vec<u8>>,
+}
+
+/// Decoded extension fields:
+/// `(gateway_address, site_cert_pem, signature, signed_at_ms, grid_id)`.
+type DecodedExtension = (
+    Option<String>,
+    Option<String>,
+    Option<Vec<u8>>,
+    Option<u64>,
+    Option<String>,
+);
 
 /// Extension format used by peers that predate the `signature` field.
 ///
 /// bincode is not self-describing, so decoding a two-field payload as
-/// [`BroadcastExtension`] fails partway through the third field rather than
-/// falling back to `#[serde(default)]` — `decode` tries this shape before
-/// falling further back to the original bare-`String` format, so a rolling
-/// update does not silently drop or misdecode `gateway_address`/
-/// `site_cert_pem` from not-yet-upgraded peers.
+/// [`PreTimestampBroadcastExtension`] fails partway through the third field
+/// rather than falling back to `#[serde(default)]` — `decode` tries that
+/// shape before falling further back to this one, then to the original
+/// bare-`String` format, so a rolling update does not silently drop or
+/// misdecode `gateway_address`/`site_cert_pem` from not-yet-upgraded peers.
 #[derive(Serialize, Deserialize)]
 struct PreSignatureBroadcastExtension {
     /// Optional data-plane gateway address.
@@ -153,6 +299,8 @@ impl StateBroadcast {
             gateway_address,
             site_cert_pem: None,
             signature: None,
+            signed_at_ms: None,
+            grid_id: None,
         }
     }
 
@@ -176,10 +324,39 @@ impl StateBroadcast {
         self
     }
 
+    /// Attach the wall-clock signing timestamp (milliseconds since the Unix
+    /// epoch).
+    ///
+    /// Set this **before** computing [`signable_bytes`](Self::signable_bytes)
+    /// so the timestamp itself is covered by the signature — see
+    /// [`signed_at_ms`](Self::signed_at_ms)'s doc comment for why an
+    /// unsigned timestamp would defeat the freshness check it exists to
+    /// support.
+    #[must_use]
+    pub fn with_signed_at(mut self, signed_at_ms: Option<u64>) -> Self {
+        self.signed_at_ms = signed_at_ms;
+        self
+    }
+
+    /// Attach the owning `GridNetwork` identifier.
+    ///
+    /// Set this **before** computing [`signable_bytes`](Self::signable_bytes)
+    /// so the identifier is covered by the signature — see
+    /// [`grid_id`](Self::grid_id)'s doc comment for the cross-`GridNetwork`
+    /// replay this scoping closes.
+    #[must_use]
+    pub fn with_grid_id(mut self, grid_id: Option<String>) -> Self {
+        self.grid_id = grid_id;
+        self
+    }
+
     /// Return the canonical bytes this broadcast's signature covers.
     ///
-    /// Equal to [`encode`](Self::encode) of this broadcast with `signature`
-    /// cleared, so a signature can never cover itself.
+    /// Prefixed with a fixed domain-separation tag followed by
+    /// [`encode`](Self::encode) of this broadcast with `signature` cleared,
+    /// so a signature can never cover itself and can never be replayed as
+    /// valid input to a different signing context even if the same key were
+    /// ever reused elsewhere.
     ///
     /// # Errors
     ///
@@ -187,7 +364,9 @@ impl StateBroadcast {
     pub fn signable_bytes(&self) -> Result<Vec<u8>, bincode::error::EncodeError> {
         let mut unsigned = self.clone();
         unsigned.signature = None;
-        unsigned.encode()
+        let mut signable = SIGNATURE_DOMAIN.to_vec();
+        signable.extend(unsigned.encode()?);
+        Ok(signable)
     }
 
     /// Return this broadcast's invalidation key.
@@ -275,11 +454,18 @@ impl StateBroadcast {
             snapshot: self.snapshot.clone(),
         };
         let mut bytes = bincode::serde::encode_to_vec(&v1, bincode::config::standard())?;
-        if self.gateway_address.is_some() || self.site_cert_pem.is_some() || self.signature.is_some() {
+        if self.gateway_address.is_some()
+            || self.site_cert_pem.is_some()
+            || self.signature.is_some()
+            || self.signed_at_ms.is_some()
+            || self.grid_id.is_some()
+        {
             let ext = BroadcastExtension {
                 gateway_address: self.gateway_address.clone(),
                 site_cert_pem: self.site_cert_pem.clone(),
                 signature: self.signature.clone(),
+                signed_at_ms: self.signed_at_ms,
+                grid_id: self.grid_id.clone(),
             };
             let ext_bytes = bincode::serde::encode_to_vec(&ext, bincode::config::standard())?;
             bytes.extend_from_slice(&ext_bytes);
@@ -291,9 +477,10 @@ impl StateBroadcast {
     ///
     /// Decodes the base v1 payload, then tries to decode any trailing bytes as
     /// a `BroadcastExtension` struct.  Because bincode is not self-describing,
-    /// a three-field extension decode does not simply come back `Ok` with
-    /// `signature: None` when reading bytes from an older, two-field peer —
-    /// it fails partway through the missing field.  Falls back in turn to the
+    /// a five-field extension decode does not simply come back `Ok` with
+    /// `grid_id: None` when reading bytes from an older, three-field
+    /// peer — it fails partway through the missing fields.  Falls back in
+    /// turn to the three-field pre-timestamp extension format, then the
     /// two-field pre-signature extension format, then to the
     /// original bare-`String` format for `gateway_address`, ensuring
     /// interoperability with peers running any prior wire format during a
@@ -311,7 +498,7 @@ impl StateBroadcast {
             bincode::serde::decode_from_slice(bytes, bincode::config::standard())?;
 
         let remaining = bytes.get(consumed..).unwrap_or(&[]);
-        let (gateway_address, site_cert_pem, signature) = Self::decode_extension(remaining);
+        let (gateway_address, site_cert_pem, signature, signed_at_ms, grid_id) = Self::decode_extension(remaining);
 
         Ok(Self {
             version: v1.version,
@@ -321,31 +508,45 @@ impl StateBroadcast {
             gateway_address,
             site_cert_pem,
             signature,
+            signed_at_ms,
+            grid_id,
         })
     }
 
     /// Decode the trailing extension bytes, falling back across every prior
     /// wire format in turn. See [`decode`](Self::decode) for why a naive
     /// single-shot struct decode is not enough during a rolling update.
-    fn decode_extension(remaining: &[u8]) -> (Option<String>, Option<String>, Option<Vec<u8>>) {
+    fn decode_extension(remaining: &[u8]) -> DecodedExtension {
         if remaining.is_empty() {
-            return (None, None, None);
+            return (None, None, None, None, None);
         }
         if let Ok((ext, _)) =
             bincode::serde::decode_from_slice::<BroadcastExtension, _>(remaining, bincode::config::standard())
         {
-            return (ext.gateway_address, ext.site_cert_pem, ext.signature);
+            return (
+                ext.gateway_address,
+                ext.site_cert_pem,
+                ext.signature,
+                ext.signed_at_ms,
+                ext.grid_id,
+            );
+        }
+        if let Ok((ext, _)) = bincode::serde::decode_from_slice::<PreTimestampBroadcastExtension, _>(
+            remaining,
+            bincode::config::standard(),
+        ) {
+            return (ext.gateway_address, ext.site_cert_pem, ext.signature, None, None);
         }
         if let Ok((ext, _)) = bincode::serde::decode_from_slice::<PreSignatureBroadcastExtension, _>(
             remaining,
             bincode::config::standard(),
         ) {
-            return (ext.gateway_address, ext.site_cert_pem, None);
+            return (ext.gateway_address, ext.site_cert_pem, None, None, None);
         }
         // Compatibility fallback: bare String encoding for gateway_address only.
         match bincode::serde::decode_from_slice::<String, _>(remaining, bincode::config::standard()) {
-            Ok((gw, _)) => (Some(gw), None, None),
-            Err(_) => (None, None, None),
+            Ok((gw, _)) => (Some(gw), None, None, None, None),
+            Err(_) => (None, None, None, None, None),
         }
     }
 }
@@ -439,6 +640,22 @@ pub enum StateBroadcastError {
         origin_site: String,
         /// Underlying encode error.
         source: bincode::error::EncodeError,
+    },
+
+    /// The origin has a pinned identity but the broadcast carries no signing timestamp.
+    #[error("state broadcast from pinned origin {origin_site} carries no signing timestamp")]
+    MissingTimestamp {
+        /// Site that originated the broadcast.
+        origin_site: String,
+    },
+
+    /// The broadcast's signing timestamp falls outside the accepted freshness window.
+    #[error(
+        "state broadcast from pinned origin {origin_site} has a signing timestamp outside the accepted freshness window"
+    )]
+    TimestampOutOfWindow {
+        /// Site that originated the broadcast.
+        origin_site: String,
     },
 }
 
@@ -564,6 +781,10 @@ pub struct StateBroadcastHandler {
     /// caller (e.g. the operator, once it has established which certificate
     /// pins an origin site's signing identity) can populate or update
     /// entries at runtime, after this handler has been moved into foca.
+    /// Prefer [`crate::node::SwimNode::pin_origin`] over mutating this
+    /// sender directly: pinning through the raw sender does not purge state
+    /// merged from an origin before it was pinned, which is a correctness
+    /// gap for a signature to close, not just an inconvenience.
     trust_store_tx: watch::Sender<TrustStore>,
 
     /// Receiver half read synchronously by [`receive_item`](foca::BroadcastHandler::receive_item).
@@ -624,6 +845,13 @@ impl StateBroadcastHandler {
     /// been moved into foca. An origin site with no entry is not yet
     /// enforced against a signature — see [`receive_item`]'s doc comment for
     /// the rollout-transition rationale.
+    ///
+    /// This is the low-level primitive [`crate::node::SwimNode::pin_origin`]
+    /// is built on. Prefer `pin_origin` for real use: sending directly
+    /// through this sender skips the purge of state merged from an origin
+    /// before it had a pin. This accessor stays public for tests and for
+    /// callers that hold a bare [`StateBroadcastHandler`] outside a
+    /// [`SwimNode`](crate::node::SwimNode).
     ///
     /// [`receive_item`]: foca::BroadcastHandler::receive_item
     #[must_use]
@@ -779,13 +1007,25 @@ impl StateBroadcastHandler {
     /// Reject a broadcast that fails signature verification against a
     /// pinned identity.
     ///
-    /// An origin with **no** entry in the trust store passes through
-    /// unchecked — this is deliberate: it lets a signed-broadcast rollout
-    /// proceed incrementally as origins are pinned one at a time, rather
-    /// than requiring a synchronized flag-day cutover. Once nerdalert's
-    /// key-source question (grid#75) is resolved and the operator starts
-    /// populating pins, this becomes the enforcement point; until then it is
-    /// a no-op for every unpinned origin.
+    /// An origin with **no** entry (or an empty entry) in the trust store
+    /// passes through unchecked — this is deliberate: it lets a
+    /// signed-broadcast rollout proceed incrementally as origins are pinned
+    /// one at a time, rather than requiring a synchronized flag-day
+    /// cutover. Once nerdalert's key-source question (grid#75) is resolved
+    /// and the operator starts populating pins, this becomes the
+    /// enforcement point; until then it is a no-op for every unpinned
+    /// origin. An origin pinned to more than one key (rotation overlap)
+    /// verifies against **any** key in its set.
+    #[expect(
+        clippy::too_many_lines,
+        reason = "signature-presence, timestamp-presence, signature-validity, and freshness-window checks form one \
+                  atomic gate with a shared rejection log message"
+    )]
+    #[expect(
+        clippy::cognitive_complexity,
+        reason = "four independent rejection branches over one broadcast, each with its own log statement, \
+                  read more branchily than they actually are"
+    )]
     fn verify_signature_if_pinned(&self, broadcast: &StateBroadcast) -> Result<(), StateBroadcastError> {
         /// Rejection log message shared by every failure branch below.
         ///
@@ -794,13 +1034,23 @@ impl StateBroadcastHandler {
         /// broadcast bodies; `reason` stays a small closed set of values.
         const REJECTED: &str = "rejecting pinned-origin state broadcast";
 
-        let Some(pinned_pubkey) = self.trust_store_rx.borrow().get(&broadcast.origin_site).cloned() else {
+        let pinned_keys = self
+            .trust_store_rx
+            .borrow()
+            .get(&broadcast.origin_site)
+            .cloned()
+            .unwrap_or_default();
+        if pinned_keys.is_empty() {
             return Ok(());
-        };
+        }
         let origin_site = broadcast.origin_site.clone();
         let Some(signature) = broadcast.signature.as_ref() else {
             tracing::warn!(origin_site = %origin_site, reason = "missing_signature", REJECTED);
             return Err(StateBroadcastError::MissingSignature { origin_site });
+        };
+        let Some(signed_at_ms) = broadcast.signed_at_ms else {
+            tracing::warn!(origin_site = %origin_site, reason = "missing_timestamp", REJECTED);
+            return Err(StateBroadcastError::MissingTimestamp { origin_site });
         };
         let signable = match broadcast.signable_bytes() {
             Ok(bytes) => bytes,
@@ -809,27 +1059,75 @@ impl StateBroadcastHandler {
                 return Err(StateBroadcastError::SignableEncode { origin_site, source });
             },
         };
-        if crate::signing::verify_ecdsa_p256(&pinned_pubkey, &signable, signature).is_err() {
+        let verified = pinned_keys
+            .iter()
+            .any(|key| crate::signing::verify_ecdsa_p256(key, &signable, signature).is_ok());
+        if !verified {
             tracing::warn!(origin_site = %origin_site, reason = "signature_invalid", REJECTED);
             return Err(StateBroadcastError::SignatureInvalid { origin_site });
+        }
+        if !Self::within_freshness_window(signed_at_ms) {
+            tracing::warn!(origin_site = %origin_site, reason = "timestamp_out_of_window", REJECTED);
+            return Err(StateBroadcastError::TimestampOutOfWindow { origin_site });
         }
         Ok(())
     }
 
+    /// Return true when `signed_at_ms` falls within the accepted freshness
+    /// window relative to this node's own clock.
+    ///
+    /// A [`SystemTime::now`] that somehow predates the Unix epoch (a
+    /// pathologically misconfigured clock) is treated as epoch zero rather
+    /// than propagating an error — every positive `signed_at_ms` then falls
+    /// outside the window and is rejected, failing closed rather than
+    /// disabling the freshness check entirely.
+    fn within_freshness_window(signed_at_ms: u64) -> bool {
+        let now_ms = u64::try_from(
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or(Duration::ZERO)
+                .as_millis(),
+        )
+        .unwrap_or(u64::MAX);
+        let not_too_old = now_ms.saturating_sub(signed_at_ms) <= MAX_BROADCAST_AGE_MS;
+        let not_too_far_future = signed_at_ms.saturating_sub(now_ms) <= MAX_CLOCK_SKEW_AHEAD_MS;
+        not_too_old && not_too_far_future
+    }
+
     /// Enforce the hard origin bound before accepting an unknown origin.
+    ///
+    /// Never evicts a pinned origin's retained state: a signature pin is an
+    /// authenticated fact about that origin, and evicting it would silently
+    /// discard the anti-replay value of the origin's tracked revision (see
+    /// [`verify_signature_if_pinned`](Self::verify_signature_if_pinned)) the
+    /// moment memory pressure forces a choice. If every retained origin is
+    /// pinned, the incoming origin is accepted anyway without evicting
+    /// anything — the map temporarily exceeds `max_origins` by at most one
+    /// rather than dropping an authenticated peer's state.
     fn make_room_for(&self, incoming_origin: &str) {
         let origins = self.known_origins();
         if origins.contains(incoming_origin) || origins.len() < self.max_origins {
             return;
         }
-        if let Some(origin) = origins.into_iter().next() {
+        let trust_store = self.trust_store_rx.borrow();
+        let Some(origin) = origins
+            .into_iter()
+            .find(|origin| trust_store.get(origin).is_none_or(Vec::is_empty))
+        else {
             tracing::warn!(
-                evicted_origin = %origin,
                 max_origins = self.max_origins,
-                "SWIM state origin capacity reached; evicting retained origin"
+                "SWIM state origin capacity reached and every retained origin is pinned; \
+                 accepting the new origin without evicting an authenticated peer"
             );
-            self.remove_origin(&origin);
-        }
+            return;
+        };
+        drop(trust_store);
+        tracing::warn!(
+            evicted_origin = %origin,
+            max_origins = self.max_origins,
+            "SWIM state origin capacity reached; evicting retained origin"
+        );
+        self.remove_origin(&origin);
     }
 }
 
@@ -967,6 +1265,47 @@ mod tests {
         bytes
     }
 
+    /// Encode a base v1 payload plus a three-field pre-timestamp extension,
+    /// mirroring the wire bytes a peer running the extension format that
+    /// predates the `signed_at_ms` field would have sent.
+    fn encode_v1_plus_pre_timestamp_extension(
+        origin_site: &str,
+        revision: u64,
+        gateway_address: Option<String>,
+        site_cert_pem: Option<String>,
+        signature: Option<Vec<u8>>,
+    ) -> Vec<u8> {
+        let v1 = StateBroadcastV1 {
+            version: STATE_BROADCAST_VERSION,
+            origin_site: origin_site.to_owned(),
+            revision,
+            snapshot: snapshot(origin_site, revision, 0.4),
+        };
+        let mut bytes =
+            bincode::serde::encode_to_vec(&v1, bincode::config::standard()).unwrap_or_else(|_| std::process::abort());
+        let ext = PreTimestampBroadcastExtension {
+            gateway_address,
+            site_cert_pem,
+            signature,
+        };
+        let ext_bytes =
+            bincode::serde::encode_to_vec(&ext, bincode::config::standard()).unwrap_or_else(|_| std::process::abort());
+        bytes.extend_from_slice(&ext_bytes);
+        bytes
+    }
+
+    /// Return the current wall-clock time in milliseconds since the Unix
+    /// epoch, for constructing test broadcasts with a fresh `signed_at_ms`.
+    fn now_ms() -> u64 {
+        u64::try_from(
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_else(|_| std::process::abort())
+                .as_millis(),
+        )
+        .unwrap_or_else(|_| std::process::abort())
+    }
+
     /// Generate an ECDSA P-256 signing key plus the raw SPKI EC point a
     /// verifier needs, independent of *how* a real deployment would source
     /// or pin this key material (grid#75, still open).
@@ -987,9 +1326,10 @@ mod tests {
         let (pkcs8_der, raw_pubkey) = generate_signing_key_and_pubkey();
         handler
             .trust_store_sender()
-            .send_modify(|store| drop(store.insert("site-p".to_owned(), raw_pubkey)));
+            .send_modify(|store| drop(store.insert("site-p".to_owned(), vec![raw_pubkey])));
 
-        let unsigned = StateBroadcast::new("site-p".to_owned(), 1, snapshot("site-p", 1, 0.1), None);
+        let unsigned = StateBroadcast::new("site-p".to_owned(), 1, snapshot("site-p", 1, 0.1), None)
+            .with_signed_at(Some(now_ms()));
         let signature = crate::signing::sign_ecdsa_p256(
             &pkcs8_der,
             &unsigned.signable_bytes().unwrap_or_else(|_| std::process::abort()),
@@ -1015,7 +1355,7 @@ mod tests {
         let (_pkcs8_der, raw_pubkey) = generate_signing_key_and_pubkey();
         handler
             .trust_store_sender()
-            .send_modify(|store| drop(store.insert("site-p".to_owned(), raw_pubkey)));
+            .send_modify(|store| drop(store.insert("site-p".to_owned(), vec![raw_pubkey])));
         let unsigned = StateBroadcast::new("site-p".to_owned(), 1, snapshot("site-p", 1, 0.1), None);
         let bytes = unsigned.encode().unwrap_or_else(|_| std::process::abort());
 
@@ -1038,9 +1378,10 @@ mod tests {
         let (wrong_key, _wrong_pubkey) = generate_signing_key_and_pubkey();
         handler
             .trust_store_sender()
-            .send_modify(|store| drop(store.insert("site-p".to_owned(), pinned_pubkey)));
+            .send_modify(|store| drop(store.insert("site-p".to_owned(), vec![pinned_pubkey])));
 
-        let unsigned = StateBroadcast::new("site-p".to_owned(), 1, snapshot("site-p", 1, 0.1), None);
+        let unsigned = StateBroadcast::new("site-p".to_owned(), 1, snapshot("site-p", 1, 0.1), None)
+            .with_signed_at(Some(now_ms()));
         let signature = crate::signing::sign_ecdsa_p256(
             &wrong_key,
             &unsigned.signable_bytes().unwrap_or_else(|_| std::process::abort()),
@@ -1056,6 +1397,357 @@ mod tests {
         assert!(
             matches!(&result, Err(StateBroadcastError::SignatureInvalid { origin_site }) if origin_site.as_str() == "site-p"),
             "a broadcast signed by a key other than the pinned one must be rejected, got {result:?}"
+        );
+    }
+
+    #[test]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "verifies acceptance under both the 'next' and 'current' pinned keys in one proof"
+    )]
+    fn receive_item_accepts_a_broadcast_signed_by_either_key_in_a_rotated_pin_set() {
+        // Bounded key rotation: an origin pinned to [current, next] must
+        // verify against a signature made with *either* key, mirroring
+        // canonical_fingerprints' current+next mTLS pin overlap window.
+        let (mut handler, _control) = StateBroadcastHandler::with_capacity("site-local".to_owned(), 8);
+        let (current_key, current_pubkey) = generate_signing_key_and_pubkey();
+        let (next_key, next_pubkey) = generate_signing_key_and_pubkey();
+        handler
+            .trust_store_sender()
+            .send_modify(|store| drop(store.insert("site-p".to_owned(), vec![current_pubkey, next_pubkey])));
+
+        let unsigned_from_next = StateBroadcast::new("site-p".to_owned(), 1, snapshot("site-p", 1, 0.1), None)
+            .with_signed_at(Some(now_ms()));
+        let signature_from_next = crate::signing::sign_ecdsa_p256(
+            &next_key,
+            &unsigned_from_next
+                .signable_bytes()
+                .unwrap_or_else(|_| std::process::abort()),
+        )
+        .unwrap_or_else(|_| std::process::abort());
+        let signed_by_next = unsigned_from_next.with_signature(Some(signature_from_next));
+
+        assert!(
+            receive(&mut handler, &signed_by_next).is_some(),
+            "a broadcast signed by the 'next' key in a rotated pin set must be accepted"
+        );
+
+        let unsigned_from_current = StateBroadcast::new("site-p".to_owned(), 2, snapshot("site-p", 2, 0.2), None)
+            .with_signed_at(Some(now_ms()));
+        let signature_from_current = crate::signing::sign_ecdsa_p256(
+            &current_key,
+            &unsigned_from_current
+                .signable_bytes()
+                .unwrap_or_else(|_| std::process::abort()),
+        )
+        .unwrap_or_else(|_| std::process::abort());
+        let signed_by_current = unsigned_from_current.with_signature(Some(signature_from_current));
+
+        assert!(
+            receive(&mut handler, &signed_by_current).is_some(),
+            "a broadcast signed by the 'current' key in a rotated pin set must also be accepted"
+        );
+    }
+
+    #[test]
+    fn receive_item_rejects_a_signed_broadcast_missing_a_timestamp_from_a_pinned_origin() {
+        let (mut handler, _control) = StateBroadcastHandler::with_capacity("site-local".to_owned(), 8);
+        let (pkcs8_der, raw_pubkey) = generate_signing_key_and_pubkey();
+        handler
+            .trust_store_sender()
+            .send_modify(|store| drop(store.insert("site-p".to_owned(), vec![raw_pubkey])));
+
+        let unsigned = StateBroadcast::new("site-p".to_owned(), 1, snapshot("site-p", 1, 0.1), None);
+        let signature = crate::signing::sign_ecdsa_p256(
+            &pkcs8_der,
+            &unsigned.signable_bytes().unwrap_or_else(|_| std::process::abort()),
+        )
+        .unwrap_or_else(|_| std::process::abort());
+        let bytes = unsigned
+            .with_signature(Some(signature))
+            .encode()
+            .unwrap_or_else(|_| std::process::abort());
+
+        let result = handler.receive_item(&bytes, None);
+
+        assert!(
+            matches!(&result, Err(StateBroadcastError::MissingTimestamp { origin_site }) if origin_site.as_str() == "site-p"),
+            "a signed broadcast with no signing timestamp from a pinned origin must be rejected, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn receive_item_rejects_a_signed_broadcast_with_a_stale_timestamp_from_a_pinned_origin() {
+        let (mut handler, _control) = StateBroadcastHandler::with_capacity("site-local".to_owned(), 8);
+        let (pkcs8_der, raw_pubkey) = generate_signing_key_and_pubkey();
+        handler
+            .trust_store_sender()
+            .send_modify(|store| drop(store.insert("site-p".to_owned(), vec![raw_pubkey])));
+        let stale_at = now_ms().saturating_sub(MAX_BROADCAST_AGE_MS + 1_000);
+
+        let unsigned = StateBroadcast::new("site-p".to_owned(), 1, snapshot("site-p", 1, 0.1), None)
+            .with_signed_at(Some(stale_at));
+        let signature = crate::signing::sign_ecdsa_p256(
+            &pkcs8_der,
+            &unsigned.signable_bytes().unwrap_or_else(|_| std::process::abort()),
+        )
+        .unwrap_or_else(|_| std::process::abort());
+        let bytes = unsigned
+            .with_signature(Some(signature))
+            .encode()
+            .unwrap_or_else(|_| std::process::abort());
+
+        let result = handler.receive_item(&bytes, None);
+
+        assert!(
+            matches!(&result, Err(StateBroadcastError::TimestampOutOfWindow { origin_site }) if origin_site.as_str() == "site-p"),
+            "a signed broadcast with a stale timestamp from a pinned origin must be rejected, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn receive_item_rejects_a_signed_broadcast_with_a_far_future_timestamp_from_a_pinned_origin() {
+        let (mut handler, _control) = StateBroadcastHandler::with_capacity("site-local".to_owned(), 8);
+        let (pkcs8_der, raw_pubkey) = generate_signing_key_and_pubkey();
+        handler
+            .trust_store_sender()
+            .send_modify(|store| drop(store.insert("site-p".to_owned(), vec![raw_pubkey])));
+        let future_at = now_ms() + MAX_CLOCK_SKEW_AHEAD_MS + 1_000;
+
+        let unsigned = StateBroadcast::new("site-p".to_owned(), 1, snapshot("site-p", 1, 0.1), None)
+            .with_signed_at(Some(future_at));
+        let signature = crate::signing::sign_ecdsa_p256(
+            &pkcs8_der,
+            &unsigned.signable_bytes().unwrap_or_else(|_| std::process::abort()),
+        )
+        .unwrap_or_else(|_| std::process::abort());
+        let bytes = unsigned
+            .with_signature(Some(signature))
+            .encode()
+            .unwrap_or_else(|_| std::process::abort());
+
+        let result = handler.receive_item(&bytes, None);
+
+        assert!(
+            matches!(&result, Err(StateBroadcastError::TimestampOutOfWindow { origin_site }) if origin_site.as_str() == "site-p"),
+            "a signed broadcast with a far-future timestamp from a pinned origin must be rejected, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn within_freshness_window_accepts_a_timestamp_comfortably_within_max_age() {
+        let now = now_ms();
+        assert!(
+            StateBroadcastHandler::within_freshness_window(now.saturating_sub(MAX_BROADCAST_AGE_MS - 1_000)),
+            "a timestamp just inside MAX_BROADCAST_AGE_MS old must be within the window"
+        );
+    }
+
+    #[test]
+    fn within_freshness_window_rejects_a_timestamp_older_than_max_age() {
+        let now = now_ms();
+        assert!(
+            !StateBroadcastHandler::within_freshness_window(now.saturating_sub(MAX_BROADCAST_AGE_MS + 1_000)),
+            "a timestamp older than MAX_BROADCAST_AGE_MS must fall outside the window"
+        );
+    }
+
+    #[test]
+    fn within_freshness_window_accepts_a_timestamp_comfortably_ahead_within_clock_skew() {
+        let now = now_ms();
+        assert!(
+            StateBroadcastHandler::within_freshness_window(now + MAX_CLOCK_SKEW_AHEAD_MS - 1_000),
+            "a timestamp just inside MAX_CLOCK_SKEW_AHEAD_MS ahead must be within the window"
+        );
+    }
+
+    #[test]
+    fn within_freshness_window_rejects_a_timestamp_further_ahead_than_clock_skew() {
+        let now = now_ms();
+        assert!(
+            !StateBroadcastHandler::within_freshness_window(now + MAX_CLOCK_SKEW_AHEAD_MS + 1_000),
+            "a timestamp further ahead than MAX_CLOCK_SKEW_AHEAD_MS must fall outside the window"
+        );
+    }
+
+    #[test]
+    fn missing_timestamp_error_message_names_the_origin() {
+        let err = StateBroadcastError::MissingTimestamp {
+            origin_site: "site-p".to_owned(),
+        };
+        assert!(
+            err.to_string().contains("site-p"),
+            "error message must name the origin site"
+        );
+    }
+
+    #[test]
+    fn timestamp_out_of_window_error_message_names_the_origin() {
+        let err = StateBroadcastError::TimestampOutOfWindow {
+            origin_site: "site-p".to_owned(),
+        };
+        assert!(
+            err.to_string().contains("site-p"),
+            "error message must name the origin site"
+        );
+    }
+
+    /// Build and receive a correctly signed broadcast for a pinned origin.
+    fn receive_signed(
+        handler: &mut StateBroadcastHandler,
+        origin: &str,
+        revision: u64,
+        signing_key: &[u8],
+    ) -> Option<StateBroadcastKey> {
+        let unsigned = StateBroadcast::new(origin.to_owned(), revision, snapshot(origin, revision, 0.1), None)
+            .with_signed_at(Some(now_ms()));
+        let signature = crate::signing::sign_ecdsa_p256(
+            signing_key,
+            &unsigned.signable_bytes().unwrap_or_else(|_| std::process::abort()),
+        )
+        .unwrap_or_else(|_| std::process::abort());
+        receive(handler, &unsigned.with_signature(Some(signature)))
+    }
+
+    #[test]
+    fn make_room_for_never_evicts_a_pinned_origin() {
+        let (mut handler, _control) = StateBroadcastHandler::with_capacity("site-local".to_owned(), 2);
+        let (signing_key, pubkey) = generate_signing_key_and_pubkey();
+        handler
+            .trust_store_sender()
+            .send_modify(|store| drop(store.insert("site-pinned".to_owned(), vec![pubkey])));
+
+        drop(receive_signed(&mut handler, "site-pinned", 1, &signing_key));
+        for (origin, revision) in [("site-unpinned", 2), ("site-new", 3)] {
+            let broadcast = StateBroadcast::new(origin.to_owned(), revision, snapshot(origin, revision, 0.1), None);
+            drop(receive(&mut handler, &broadcast));
+        }
+
+        let origins = handler.known_origins();
+        assert!(
+            origins.contains("site-pinned"),
+            "a pinned origin must never be evicted for capacity, got {origins:?}"
+        );
+        assert!(
+            !origins.contains("site-unpinned"),
+            "an unpinned origin must be evicted ahead of a pinned one, got {origins:?}"
+        );
+    }
+
+    #[test]
+    fn make_room_for_accepts_a_new_origin_without_evicting_when_every_retained_origin_is_pinned() {
+        let (mut handler, _control) = StateBroadcastHandler::with_capacity("site-local".to_owned(), 2);
+        for origin in ["site-pinned-a", "site-pinned-b"] {
+            let (signing_key, pubkey) = generate_signing_key_and_pubkey();
+            handler
+                .trust_store_sender()
+                .send_modify(|store| drop(store.insert(origin.to_owned(), vec![pubkey])));
+            drop(receive_signed(&mut handler, origin, 1, &signing_key));
+        }
+
+        let broadcast = StateBroadcast::new("site-new".to_owned(), 1, snapshot("site-new", 1, 0.1), None);
+        drop(receive(&mut handler, &broadcast));
+
+        let origins = handler.known_origins();
+        assert!(
+            origins.contains("site-pinned-a") && origins.contains("site-pinned-b"),
+            "both pinned origins must survive even though capacity was reached, got {origins:?}"
+        );
+        assert!(
+            origins.contains("site-new"),
+            "the new origin must still be accepted even though nothing could be evicted, got {origins:?}"
+        );
+    }
+
+    #[test]
+    fn signable_bytes_domain_prefix_is_load_bearing_not_decorative() {
+        // Proves the domain-separation prefix actually participates in what
+        // gets signed: a signature computed over signable_bytes() (prefix +
+        // payload) must not verify against the bare, unprefixed encode() of
+        // the same broadcast.
+        let (key, pubkey) = generate_signing_key_and_pubkey();
+        let broadcast = StateBroadcast::new("site-p".to_owned(), 1, snapshot("site-p", 1, 0.1), None);
+        let signature = crate::signing::sign_ecdsa_p256(
+            &key,
+            &broadcast.signable_bytes().unwrap_or_else(|_| std::process::abort()),
+        )
+        .unwrap_or_else(|_| std::process::abort());
+        let bare_encoded = broadcast.encode().unwrap_or_else(|_| std::process::abort());
+
+        let result = crate::signing::verify_ecdsa_p256(&pubkey, &bare_encoded, &signature);
+
+        assert!(
+            result.is_err(),
+            "a signature over the domain-prefixed signable_bytes() must not verify against the bare encoded payload"
+        );
+    }
+
+    #[test]
+    fn signable_bytes_differ_for_broadcasts_that_differ_only_by_grid_id() {
+        // Same origin_site, revision, and snapshot -- the only difference is
+        // which GridNetwork the broadcast claims to belong to. If these
+        // produced identical signable bytes, a signature valid for one
+        // GridNetwork would silently double as valid for another sharing
+        // the same cluster's SwimHandle (issue #48's per-tenant isolation).
+        let base = StateBroadcast::new("site-p".to_owned(), 1, snapshot("site-p", 1, 0.1), None);
+        let for_grid_a = base.clone().with_grid_id(Some("grid-a".to_owned()));
+        let for_grid_b = base.with_grid_id(Some("grid-b".to_owned()));
+
+        let bytes_a = for_grid_a.signable_bytes().unwrap_or_else(|_| std::process::abort());
+        let bytes_b = for_grid_b.signable_bytes().unwrap_or_else(|_| std::process::abort());
+
+        assert_ne!(
+            bytes_a, bytes_b,
+            "signable_bytes() must depend on grid_id, or a signature would be replayable across GridNetworks"
+        );
+    }
+
+    #[test]
+    fn receive_item_rejects_a_signature_computed_for_a_different_grid_id() {
+        // A signature made over a broadcast claiming grid_id="grid-a" must
+        // not verify once the broadcast is re-labeled grid_id="grid-b" --
+        // the cross-GridNetwork replay this field exists to prevent.
+        let (mut handler, _control) = StateBroadcastHandler::with_capacity("site-local".to_owned(), 8);
+        let (pkcs8_der, raw_pubkey) = generate_signing_key_and_pubkey();
+        handler
+            .trust_store_sender()
+            .send_modify(|store| drop(store.insert("site-p".to_owned(), vec![raw_pubkey])));
+
+        let signed_at_ms = Some(now_ms());
+        let for_grid_a = StateBroadcast::new("site-p".to_owned(), 1, snapshot("site-p", 1, 0.1), None)
+            .with_grid_id(Some("grid-a".to_owned()))
+            .with_signed_at(signed_at_ms);
+        let signature = crate::signing::sign_ecdsa_p256(
+            &pkcs8_der,
+            &for_grid_a.signable_bytes().unwrap_or_else(|_| std::process::abort()),
+        )
+        .unwrap_or_else(|_| std::process::abort());
+
+        // Re-label as grid-b, reusing grid-a's signature over grid-a's bytes.
+        let relabeled_as_grid_b = for_grid_a.with_grid_id(Some("grid-b".to_owned()));
+        let bytes = relabeled_as_grid_b
+            .with_signature(Some(signature))
+            .encode()
+            .unwrap_or_else(|_| std::process::abort());
+
+        let result = handler.receive_item(&bytes, None);
+
+        assert!(
+            matches!(&result, Err(StateBroadcastError::SignatureInvalid { origin_site }) if origin_site.as_str() == "site-p"),
+            "a broadcast re-labeled with a different grid_id than it was signed for must be rejected, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn too_many_pinned_keys_error_message_is_descriptive() {
+        let err = TooManyPinnedKeys {
+            origin: "site-p".to_owned(),
+            supplied: 3,
+        };
+        assert!(err.to_string().contains("site-p"), "error message must name the origin");
+        assert!(
+            err.to_string().contains('3'),
+            "error message must name the supplied count"
         );
     }
 
@@ -1171,6 +1863,135 @@ mod tests {
             "site_cert_pem from a pre-signature peer must survive decode, not be silently dropped"
         );
         assert_eq!(decoded.signature, None, "a pre-signature peer never sends a signature");
+    }
+
+    #[test]
+    fn decode_recovers_gateway_signature_and_cert_from_a_pre_timestamp_three_field_extension() {
+        // Simulates a broadcast sent by a peer running the three-field
+        // `PreTimestampBroadcastExtension` (gateway_address, site_cert_pem,
+        // signature) that predates the `signed_at_ms` field added in this
+        // fix. Same bincode non-self-describing failure mode as the
+        // pre-signature case above, one field further down the chain.
+        let signature = vec![9_u8, 8, 7, 6];
+        let bytes = encode_v1_plus_pre_timestamp_extension(
+            "site-old-peer",
+            5,
+            Some("10.0.0.4:8443".to_owned()),
+            Some("-----BEGIN CERTIFICATE-----legacy-----END CERTIFICATE-----".to_owned()),
+            Some(signature.clone()),
+        );
+
+        let decoded = StateBroadcast::decode(&bytes).unwrap_or_else(|_| std::process::abort());
+
+        assert_eq!(
+            decoded.gateway_address.as_deref(),
+            Some("10.0.0.4:8443"),
+            "gateway_address from a pre-timestamp peer must survive decode, not be silently dropped"
+        );
+        assert_eq!(
+            decoded.site_cert_pem.as_deref(),
+            Some("-----BEGIN CERTIFICATE-----legacy-----END CERTIFICATE-----"),
+            "site_cert_pem from a pre-timestamp peer must survive decode, not be silently dropped"
+        );
+        assert_eq!(
+            decoded.signature,
+            Some(signature),
+            "signature from a pre-timestamp peer must survive decode, not be silently dropped"
+        );
+        assert_eq!(
+            decoded.signed_at_ms, None,
+            "a pre-timestamp peer never sends a signing timestamp"
+        );
+        assert_eq!(decoded.grid_id, None, "a pre-timestamp peer never sends a grid_id");
+    }
+
+    #[test]
+    fn signed_at_ms_round_trips_through_encode_and_decode() {
+        let broadcast = StateBroadcast::new("site-p".to_owned(), 1, snapshot("site-p", 1, 0.1), None)
+            .with_signed_at(Some(1_700_000_000_000));
+        let bytes = broadcast.encode().unwrap_or_else(|_| std::process::abort());
+
+        let decoded = StateBroadcast::decode(&bytes).unwrap_or_else(|_| std::process::abort());
+
+        assert_eq!(
+            decoded.signed_at_ms,
+            Some(1_700_000_000_000),
+            "signed_at_ms must round-trip"
+        );
+    }
+
+    #[test]
+    fn grid_id_round_trips_through_encode_and_decode() {
+        let broadcast = StateBroadcast::new("site-p".to_owned(), 1, snapshot("site-p", 1, 0.1), None)
+            .with_grid_id(Some("grid-a".to_owned()));
+        let bytes = broadcast.encode().unwrap_or_else(|_| std::process::abort());
+
+        let decoded = StateBroadcast::decode(&bytes).unwrap_or_else(|_| std::process::abort());
+
+        assert_eq!(decoded.grid_id.as_deref(), Some("grid-a"), "grid_id must round-trip");
+    }
+
+    #[test]
+    fn decode_recovers_gateway_from_the_original_bare_string_extension() {
+        // The oldest wire format, predating even the two-field
+        // `PreSignatureBroadcastExtension`: a bare bincode-encoded `String`
+        // for `gateway_address`, with no `site_cert_pem` or `signature`.
+        // `decode_extension` falls all the way through to this tier only
+        // after both newer struct shapes fail to decode, so it must stay
+        // covered whenever that fallback chain is touched.
+        let v1 = StateBroadcastV1 {
+            version: STATE_BROADCAST_VERSION,
+            origin_site: "site-ancient-peer".to_owned(),
+            revision: 2,
+            snapshot: snapshot("site-ancient-peer", 2, 0.2),
+        };
+        let mut bytes =
+            bincode::serde::encode_to_vec(&v1, bincode::config::standard()).unwrap_or_else(|_| std::process::abort());
+        let gw_bytes = bincode::serde::encode_to_vec("10.0.0.5:8443".to_owned(), bincode::config::standard())
+            .unwrap_or_else(|_| std::process::abort());
+        bytes.extend_from_slice(&gw_bytes);
+
+        let decoded = StateBroadcast::decode(&bytes).unwrap_or_else(|_| std::process::abort());
+
+        assert_eq!(
+            decoded.gateway_address.as_deref(),
+            Some("10.0.0.5:8443"),
+            "gateway_address from the original bare-String wire format must survive decode"
+        );
+        assert_eq!(
+            decoded.site_cert_pem, None,
+            "the bare-String format never carries a cert"
+        );
+        assert_eq!(
+            decoded.signature, None,
+            "the bare-String format never carries a signature"
+        );
+    }
+
+    #[test]
+    fn decode_extension_returns_no_extension_fields_for_undecodable_trailing_bytes() {
+        // Bytes that match none of the three known extension shapes -- the
+        // final fallback in `decode_extension`'s chain must degrade to no
+        // extension data rather than propagating a decode error, since the
+        // trailing bytes might belong to a future format this peer doesn't
+        // understand yet.
+        let v1 = StateBroadcastV1 {
+            version: STATE_BROADCAST_VERSION,
+            origin_site: "site-p".to_owned(),
+            revision: 1,
+            snapshot: snapshot("site-p", 1, 0.1),
+        };
+        let mut bytes =
+            bincode::serde::encode_to_vec(&v1, bincode::config::standard()).unwrap_or_else(|_| std::process::abort());
+        // A single 0xFF byte is not a valid bincode length prefix for a
+        // `String`, `PreSignatureBroadcastExtension`, or `BroadcastExtension`.
+        bytes.push(0xFF);
+
+        let decoded = StateBroadcast::decode(&bytes).unwrap_or_else(|_| std::process::abort());
+
+        assert_eq!(decoded.gateway_address, None);
+        assert_eq!(decoded.site_cert_pem, None);
+        assert_eq!(decoded.signature, None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Partial fix for #75 — implements the confident, already-agreed-on part of the
signing design (ECDSA P-256 sign/verify primitives, an additive signed wire
format, and a pinned-origin verification gate in `receive_item`) while the
signing-key-sourcing question remains an open architectural fork awaiting
maintainer consensus (see the issue thread). No CRD, controller, or
`swim_runtime.rs` wiring is included here — `trust_store_sender()` has no
caller yet, so this is inert (a documented no-op) in production today.

## What's built

1. **`swim::signing`** — `sign_ecdsa_p256`/`verify_ecdsa_p256`, deliberately
   decoupled from *where* key material comes from: callers supply raw PKCS8
   DER (signing) or a raw uncompressed EC point (verification), matching how
   a `GridSite`'s certificate key material is already produced elsewhere in
   this repo.
2. **Additive wire format** — `StateBroadcast` gains `signature:
   Option<Vec<u8>>`, following the same `#[serde(skip_serializing_if)]`
   pattern already used for `site_cert_pem`/`gateway_address`. Older
   decoders are unaffected; `signable_bytes()` returns the canonical bytes a
   signature covers (the payload with `signature` cleared).
3. **Verification gate** — `StateBroadcastHandler` gains a `TrustStore`
   (`BTreeMap<String, Vec<u8>>`, origin site → raw public key) fed by a
   `watch::Sender`/`Receiver` pair, following the exact precedent
   `SwimHandle::set_swim_key()` already uses to bridge async K8s state into
   this crate's sync `receive_item`. `verify_signature_if_pinned()` runs
   *before* `make_room_for()`/state merge, so a rejected broadcast never
   touches retained-origin state:
   - No pinned identity for the origin → pass through unchanged (deliberate:
     lets a signed-broadcast rollout proceed incrementally, one origin at a
     time, instead of requiring a synchronized flag-day cutover).
   - Pinned identity + missing/wrong-key/tampered signature → rejected, with
     a `tracing::warn!` carrying `origin_site` and a closed-set `reason` tag
     (never the broadcast body) — closing a gap this repo's own review
     thread flagged for bounded rejection observability.

## Testing (TDD RED → GREEN → REFACTOR, pyramid invariant)

- **Unit** — 14 new tests (81 → 95 in the `swim` crate): sign/verify
  round-trip, malformed-key rejection, tampered-payload rejection,
  wrong-key rejection; all four `verify_signature_if_pinned` decision
  branches (unpinned pass-through, missing-signature reject, wrong-key
  reject, correctly-signed accept) driven through the real `receive_item`
  path, not direct construction; Display-message coverage for all six new
  error variants, matching this repo's own
  `node::tests::state_broadcast_error_formats_correctly` convention.
  `cargo llvm-cov` confirms every reachable decision branch in the new code
  is exercised — the only uncovered arm (`SignableEncode`'s encode-failure
  case) has no trigger reachable through this crate's public API, the same
  class as this file's pre-existing `PoisonError::into_inner` recovery
  paths.
- **Integration / E2E** — intentionally absent, not silently skipped: there
  is no reconciler or real signing call-path yet to exercise (that's the
  pending trust-store-wiring work below). Both tiers become real
  requirements, not optional, once that wiring lands.

## Validation

- `cargo test --workspace` — 2,188/2,188 passing
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo +nightly-2026-03-28 fmt --all -- --check` — clean
- `cargo doc -p swim --no-deps` — clean
- `cargo machete` — clean
- `cargo deny check` — advisories/bans/licenses/sources all ok

## Explicit non-goals here, tracked in #75

- Signing-key sourcing (dedicated key/Secret vs. reusing `tls.key`) — open
  question posted to the issue, awaiting @nerdalert / maintainer input.
- Wiring `trust_store_sender()` from `GridSite` reconcile into the operator's
  SWIM runtime — depends on the above; precedent identified
  (`SwimHandle::set_swim_key()`) but not yet implemented against a real
  source.
- A rollout cutover mechanism (stop accepting unsigned broadcasts from
  unpinned origins once every peer signs) — currently open-ended by design
  for incremental rollout; needs explicit design once the above lands.
- A bounded Prometheus counter for rejection reasons — the `tracing::warn!`
  added here gives a structured, bounded-cardinality signal today; a real
  counter needs the `swim` crate's non-existent dependency on the operator's
  metrics pipeline, a bigger wiring decision than this slice.
- Whether "drop non-`Active`" broadcast policy extends to `tenant_spend`
  (currently `ProviderState`-only, matching existing
  `is_crdt_provider_routing_eligible` precedent) — flagged as open in the
  issue thread, no production path reports spend yet (#69).

@nerdalert — this is the confident slice from our discussion on #75; the
mechanism questions you raised should be answered as posted in the issue.
Would appreciate your review, especially on the verification-gate ordering
and the rollout pass-through behavior for unpinned origins.

