### PR TITLE
ci: remove isolated GLB release check

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -119,12 +119,6 @@ jobs:
       - name: Documentation
         run: make doc
 
-      - name: Validate GLB demo configuration
-        run: >-
-          cargo run -p forge --
-          --config tests/e2e/topologies/grid-glb-demo/forge.yaml
-          config validate
-
   # ----------------------------------------------------------------------------
   # Publish immutable Grid images
   # ----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- remove the GLB-only Forge configuration check from the release publication workflow
- keep topology runtime qualifications in the pre-release validation process
- avoid treating one experimental topology as a special artifact-publication gate

## Validation

- `actionlint .github/workflows/release.yaml`
- `git diff --check`

This does not change the existing `v0.1.4` tag or its active release workflow run.