### PR TITLE
test(glb): make drain and attribution proofs strict

### DIFF
--- a/mock-providers/src/common.rs
+++ b/mock-providers/src/common.rs
@@ -11,8 +11,8 @@ use serde_json::Value;
 
 use crate::AppState;
 
-/// Header name for the demo provider site attribution.
-pub(crate) const PROVIDER_HEADER_NAME: &str = "x-grid-demo-provider";
+/// Header name for test-provider identity attribution.
+pub(crate) const PROVIDER_HEADER_NAME: &str = "x-grid-test-provider";
 
 /// Provider-owned attribution received by the backend.
 const PROVIDER_ATTRIBUTION_INPUT: &str = "x-ai-provider-attribution";

--- a/mock-providers/src/lib.rs
+++ b/mock-providers/src/lib.rs
@@ -2,8 +2,8 @@
 //!
 //! Each module exposes a `router()` function returning an
 //! [`axum::Router`] that simulates a specific provider's API.
-//! Pass an [`AppState`] to inject the `X-Grid-Demo-Provider`
-//! response header for demo attribution.
+//! Pass an [`AppState`] to inject the `X-Grid-Test-Provider`
+//! response header for test attribution.
 
 #![deny(unsafe_code)]
 
@@ -25,7 +25,7 @@ pub mod vertex;
 /// Shared application state injected into every provider router.
 #[derive(Clone, Debug)]
 pub struct AppState {
-    /// Site identity for the `X-Grid-Demo-Provider` response header.
+    /// Site identity for the `X-Grid-Test-Provider` response header.
     pub provider_site: Arc<str>,
 
     /// Normalized queue depth exported by the demo metrics endpoint.

--- a/tests/e2e/topologies/grid-glb-demo/forge.yaml
+++ b/tests/e2e/topologies/grid-glb-demo/forge.yaml
@@ -120,7 +120,7 @@ spec:
           resource: deployment/grid-operator
           namespace: grid-system
           condition: available
-          timeout: "120s"
+          timeout: "180s"
         - type: capture
           resource: svc/grid-operator-swim
           namespace: grid-system

--- a/tests/e2e/topologies/grid-provider-traffic/forge.yaml
+++ b/tests/e2e/topologies/grid-provider-traffic/forge.yaml
@@ -70,7 +70,7 @@ spec:
           resource: deployment/controller
           namespace: metallb-system
           condition: available
-          timeout: "120s"
+          timeout: "180s"
         - type: metallb-auto-pool
           name: forge-pool
 

--- a/tests/e2e/topologies/grid-token-rate-limit/configs/consumer/praxis-valkey-a.yaml
+++ b/tests/e2e/topologies/grid-token-rate-limit/configs/consumer/praxis-valkey-a.yaml
@@ -1,3 +1,6 @@
+insecure_options:
+  allow_private_endpoints: true
+
 listeners:
   - name: proxy
     address: "0.0.0.0:8080"

--- a/tests/e2e/topologies/grid-token-rate-limit/configs/consumer/praxis-valkey-b.yaml
+++ b/tests/e2e/topologies/grid-token-rate-limit/configs/consumer/praxis-valkey-b.yaml
@@ -1,3 +1,6 @@
+insecure_options:
+  allow_private_endpoints: true
+
 listeners:
   - name: proxy
     address: "0.0.0.0:8080"

--- a/tests/e2e/topologies/grid-token-rate-limit/configs/provider/praxis.yaml
+++ b/tests/e2e/topologies/grid-token-rate-limit/configs/provider/praxis.yaml
@@ -4,6 +4,9 @@
 # and authorizes the consumer gateway before AI-owned x-ai-routing-* fields can
 # influence provider-local routing.
 
+insecure_options:
+  allow_private_endpoints: true
+
 listeners:
   - name: provider
     address: "0.0.0.0:8443"

--- a/xtask/src/env/glb.rs
+++ b/xtask/src/env/glb.rs
@@ -1183,11 +1183,7 @@ fn collect_prereq_errors(forge_config: &Path) -> (Vec<String>, Option<String>) {
     }
     let forge_bin = resolve_forge_binary();
     if forge_bin.is_none() {
-        errors.push(
-            "praxis-forge binary not found on PATH or at \
-             target/debug/praxis-forge"
-                .to_owned(),
-        );
+        errors.push("praxis-forge was unavailable and its workspace build failed".to_owned());
     }
     (errors, forge_bin)
 }
@@ -1202,17 +1198,53 @@ fn tool_available(name: &str) -> bool {
         .is_ok_and(|s| s.success())
 }
 
-/// Resolve the forge binary: prefer `praxis-forge` on PATH, fall
-/// back to `target/debug/praxis-forge`.
+/// Resolve Forge from an override, `PATH`, or the workspace build.
+///
+/// A fresh checkout builds the workspace binary automatically under a hard
+/// timeout so qualifications do not require an undocumented bootstrap step.
 pub(crate) fn resolve_forge_binary() -> Option<String> {
+    if let Some(override_path) = std::env::var_os("FORGE_BIN") {
+        let path = PathBuf::from(override_path);
+        if path.is_file() {
+            return Some(path.to_string_lossy().into_owned());
+        }
+        eprintln!("FORGE_BIN does not name a file: {}", path.display());
+        return None;
+    }
     if tool_available("praxis-forge") {
         return Some("praxis-forge".to_owned());
     }
-    let local = "target/debug/praxis-forge";
-    if Path::new(local).exists() {
-        return Some(local.to_owned());
+    let workspace = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap_or_else(|| Path::new("."));
+    let local = workspace.join("target/debug/praxis-forge");
+    if local.is_file() {
+        return Some(local.to_string_lossy().into_owned());
     }
-    None
+    build_workspace_forge(workspace, &local)
+}
+
+/// Build the workspace Forge binary under a hard timeout.
+fn build_workspace_forge(workspace: &Path, local: &Path) -> Option<String> {
+    eprintln!("praxis-forge not found; building the workspace binary");
+    let manifest = workspace.join("Cargo.toml");
+    let target = workspace.join("target");
+    let output = Command::new("timeout")
+        .args(["300", "cargo", "build", "--manifest-path"])
+        .arg(manifest)
+        .args(["--target-dir"])
+        .arg(target)
+        .args(["-p", "forge", "--bin", "praxis-forge"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        eprintln!(
+            "failed to build praxis-forge: {}",
+            safe_truncate_str(String::from_utf8_lossy(&output.stderr).trim(), 2_000)
+        );
+        return None;
+    }
+    local.is_file().then(|| local.to_string_lossy().into_owned())
 }
 
 /// Detect placeholder images in Forge configuration.
@@ -1612,20 +1644,7 @@ fn run_steps(ctx: &PrereqContext, mode: DemoMode, ingress_mode: IngressMode, res
 
     // Drain routing verification — new sessions must avoid the withdrawn provider.
     proof_banner("checking drain routing");
-    let drain_proof = wait_for_data_plane_convergence("provider drain routing", || {
-        let session = format!("drain-proof-{}", unix_nanos());
-        let resp = curl_edge_request(EDGE_PORT, Some(&session))?;
-        if resp.status != 200 {
-            return Err(format!("drain routing request returned HTTP {}", resp.status).into());
-        }
-        let provider = extract_provider(&resp)?;
-        if provider == provider_a {
-            return Err(format!("new session routed to withdrawn provider {provider_a}").into());
-        }
-        Ok(format!(
-            "new session routed to {provider}, avoiding withdrawn {provider_a}"
-        ))
-    });
+    let drain_proof = verify_new_sessions_avoid_provider(EDGE_PORT, &provider_a, 6);
     let drain_restore = restore_withdrawn_provider(PRIMARY_EDGE, &drain_withdrawal);
     match (drain_proof, drain_restore) {
         (Ok(proof), Ok(restored)) => {
@@ -1703,6 +1722,57 @@ fn run_steps(ctx: &PrereqContext, mode: DemoMode, ingress_mode: IngressMode, res
     record_step("invalid overlay protection", results, || {
         check_invalid_overlay_protection(PRIMARY_EDGE)
     });
+}
+
+/// Require several distinct post-barrier sessions to avoid one exact backend.
+/// A withdrawn response is a real failure and is never retried away.
+fn verify_new_sessions_avoid_provider(
+    port: u16,
+    withdrawn: &str,
+    count: usize,
+) -> Result<String, Box<dyn std::error::Error>> {
+    let withdrawn_cluster = provider_routing_cluster(withdrawn)?;
+    let mut observations = Vec::with_capacity(count);
+    for index in 0..count {
+        let session = format!("drain-proof-{index}-{}", unix_nanos());
+        let resp = curl_edge_request(port, Some(&session))?;
+        let provider = extract_provider(&resp)?;
+        let observation = drain_observation(&session, &resp, &provider);
+        eprintln!("  drain observation: {observation}");
+        observations.push(observation);
+        if resp.status != 200 {
+            return Err(format!("post-withdrawal observations={observations:?}").into());
+        }
+        let selected = resp
+            .headers
+            .get("x-ai-inference-provider")
+            .ok_or("post-withdrawal response missing x-ai-inference-provider")?;
+        if selected == withdrawn_cluster {
+            return Err(format!(
+                "new session selected withdrawn cluster {withdrawn_cluster}; observations={observations:?}"
+            )
+            .into());
+        }
+    }
+    Ok(format!(
+        "{count} new sessions avoided withdrawn backend {withdrawn}; observations={observations:?}"
+    ))
+}
+
+/// Format the two routing identities needed to locate a stale decision.
+fn drain_observation(session: &str, resp: &verify::HttpResponse, provider: &str) -> String {
+    let gateway = resp
+        .headers
+        .get(PROVIDER_GATEWAY_RESPONSE_HEADER)
+        .map_or("missing", String::as_str);
+    let selected = resp
+        .headers
+        .get("x-ai-inference-provider")
+        .map_or("missing", String::as_str);
+    format!(
+        "session={session} status={} selected={selected} backend={provider} gateway={gateway}",
+        resp.status
+    )
 }
 
 /// Print a step progress banner.
@@ -3215,14 +3285,14 @@ fn check_edge_overlay_mounts_with_count(expected_candidates: usize) -> Result<St
 /// do not become ready before the provider-state timeout.
 pub(crate) fn wait_for_edge_overlays_ready() -> Result<String, Box<dyn std::error::Error>> {
     // Try to auto-detect the candidate count by checking the actual overlay
-    match detect_candidate_count() {
+    match edge_candidate_count() {
         Ok(count) => wait_for_edge_overlays_ready_with_count(count),
         Err(_) => wait_for_edge_overlays_ready_with_count(3), // fallback to default
     }
 }
 
 /// Detect the expected candidate count by checking the first edge's overlay
-fn detect_candidate_count() -> Result<usize, Box<dyn std::error::Error>> {
+pub(crate) fn edge_candidate_count() -> Result<usize, Box<dyn std::error::Error>> {
     let context = kubectl_context("east-edge");
     let overlay = kubectl_jsonpath(
         &context,
@@ -3287,8 +3357,8 @@ fn verify_single_edge_overlay_with_count(
         .ok_or_else(|| format!("{edge} overlay missing candidates"))?;
     if local_site != edge || candidates.len() != expected_candidates {
         return Err(format!(
-            "{edge} overlay local_site={local_site:?}, candidates={}",
-            candidates.len()
+            "{edge} overlay local_site={local_site:?}, candidates={} (expected {expected_candidates})",
+            candidates.len(),
         )
         .into());
     }
@@ -3308,7 +3378,7 @@ fn verify_single_edge_overlay_with_count(
 }
 
 /// Read the semantic revision from one edge's distributed envelope.
-fn overlay_revision(edge: &str) -> Result<String, Box<dyn std::error::Error>> {
+pub(crate) fn overlay_revision(edge: &str) -> Result<String, Box<dyn std::error::Error>> {
     let envelope_raw = kubectl_jsonpath(
         &kubectl_context(edge),
         "configmap",
@@ -4632,7 +4702,7 @@ fn extract_provider(resp: &verify::HttpResponse) -> Result<String, Box<dyn std::
     // site can host multiple candidates, so using it for withdrawal checks
     // would confuse a withdrawn backend with a still-eligible sibling.
     resp.headers
-        .get("x-grid-demo-provider")
+        .get("x-grid-test-provider")
         .or_else(|| resp.headers.get("x-ai-demo-provider-gateway"))
         .cloned()
         .ok_or_else(|| "missing provider attribution headers".into())
@@ -5444,6 +5514,24 @@ clusters:
     }
 
     #[test]
+    fn drain_observation_distinguishes_selection_from_backend() {
+        let response = verify::HttpResponse {
+            status: 200,
+            body: "{}".to_owned(),
+            headers: BTreeMap::from([
+                (
+                    "x-ai-inference-provider".to_owned(),
+                    "vcr-east-provider-secondary".to_owned(),
+                ),
+                (PROVIDER_GATEWAY_RESPONSE_HEADER.to_owned(), "east-provider".to_owned()),
+            ]),
+        };
+        let observed = drain_observation("new-session", &response, "east-provider");
+        assert!(observed.contains("selected=vcr-east-provider-secondary"));
+        assert!(observed.contains("backend=east-provider"));
+    }
+
+    #[test]
     fn parse_header_dump_empty() {
         let map = parse_header_dump("");
         assert!(map.is_empty(), "empty input should produce empty map");
@@ -5467,7 +5555,7 @@ clusters:
             body: String::new(),
             headers: BTreeMap::from([
                 ("x-ai-demo-provider-gateway".to_owned(), "east-provider".to_owned()),
-                ("x-grid-demo-provider".to_owned(), "east-provider-secondary".to_owned()),
+                ("x-grid-test-provider".to_owned(), "east-provider-secondary".to_owned()),
             ]),
         };
         assert_eq!(extract_provider(&resp).ok().as_deref(), Some("east-provider-secondary"));

--- a/xtask/src/env/glb_demo.rs
+++ b/xtask/src/env/glb_demo.rs
@@ -1043,8 +1043,10 @@ fn print_crossed_path(narrator: &mut Narrator, paths: &ObservedPaths) {
 
 /// Map a backend provider identity to its provider-site gateway.
 fn provider_gateway_for_backend(provider: &str) -> &str {
-    if provider == "east-provider-secondary" {
+    if matches!(provider, "east-provider-secondary" | "vcr-east-provider-secondary") {
         "east-provider"
+    } else if let Some(site) = provider.strip_prefix("vcr-") {
+        site
     } else {
         provider
     }
@@ -1192,11 +1194,7 @@ fn discover_workload_paths() -> Result<Vec<ObservedPathEntry>, Box<dyn std::erro
         if response.status != 200 {
             return Err(format!("workload request from {cluster} returned status {}", response.status).into());
         }
-        let provider = if response.provider.is_empty() {
-            extract_provider_from_response(&response.body)?
-        } else {
-            response.provider.clone()
-        };
+        let provider = require_workload_provider(&response)?;
         paths.push(ObservedPathEntry {
             edge: (*cluster).to_owned(),
             provider: provider.clone(),
@@ -1209,19 +1207,16 @@ fn discover_workload_paths() -> Result<Vec<ObservedPathEntry>, Box<dyn std::erro
     Ok(paths)
 }
 
-/// Extract provider identity from the workload response body.
-///
-/// Returns an error when the response is not valid JSON or lacks a
-/// `model` field — missing attribution must fail the proof rather than
-/// silently substituting a placeholder.
-fn extract_provider_from_response(body: &str) -> Result<String, Box<dyn std::error::Error>> {
-    let value: serde_json::Value =
-        serde_json::from_str(body).map_err(|e| format!("response is not valid JSON: {e}"))?;
-    value
-        .get("model")
-        .and_then(serde_json::Value::as_str)
-        .map(String::from)
-        .ok_or_else(|| "response JSON missing 'model' field for provider attribution".into())
+/// Require provider identity from the trusted workload response header.
+fn require_workload_provider(response: &workload::WorkloadResponse) -> Result<String, Box<dyn std::error::Error>> {
+    if response.provider.is_empty() {
+        return Err(format!(
+            "workload response lacked provider-owned x-ai-demo-provider-gateway attribution (HTTP {}, body={})",
+            response.status, response.body
+        )
+        .into());
+    }
+    Ok(response.provider.clone())
 }
 
 /// Maximum time to wait for overlay convergence during drain/restore.
@@ -1469,11 +1464,7 @@ fn verify_local_routing(consumer_edge: &str) -> Result<String, Box<dyn std::erro
     if verify.status != 200 {
         return Err(format!("{consumer_edge} returned status {}", verify.status).into());
     }
-    let provider = if verify.provider.is_empty() {
-        extract_provider_from_response(&verify.body)?
-    } else {
-        verify.provider
-    };
+    let provider = require_workload_provider(&verify)?;
     let region = consumer_edge.strip_suffix("-edge").unwrap_or(consumer_edge);
     if !provider.starts_with(region) {
         return Err(format!("{consumer_edge} routed to {provider}, expected local {region} provider").into());
@@ -1615,6 +1606,7 @@ fn prove_operator_restarts(
     fixtures: &[&AffinityFixture],
     request_fixture: &Path,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    let expected_candidates = glb::edge_candidate_count()?;
     narrator.narrate("");
     narrator.wrapped(
         "[RESTART] ",
@@ -1628,7 +1620,7 @@ fn prove_operator_restarts(
             GRID_CLUSTERS.len()
         ));
         restart_grid_operator(cluster)?;
-        let overlay_evidence = glb::wait_for_edge_overlays_ready()?;
+        let overlay_evidence = verify_restart_overlay_recovery(expected_candidates)?;
         let fixture = fixtures
             .get(index % fixtures.len())
             .ok_or("no affinity fixture available after Grid restart")?;
@@ -1643,6 +1635,16 @@ fn prove_operator_restarts(
         ));
     }
     Ok(())
+}
+
+/// Require both consumers to return to the complete, served overlay after a restart.
+fn verify_restart_overlay_recovery(expected_candidates: usize) -> Result<String, Box<dyn std::error::Error>> {
+    let evidence = glb::wait_for_edge_overlays_ready_with_count(expected_candidates)?;
+    for edge in CONSUMER_CLUSTERS {
+        let revision = glb::overlay_revision(edge)?;
+        glb::verify_edge_serving_revision(edge, &revision)?;
+    }
+    Ok(evidence)
 }
 
 /// Sustain inference requests for the full-mode soak window.
@@ -2490,6 +2492,27 @@ mod setup_tests {
             PathBuf::from(env!("CARGO_MANIFEST_DIR"))
                 .parent()
                 .map_or_else(|| PathBuf::from("."), Path::to_path_buf)
+        }
+
+        #[test]
+        fn workload_provider_requires_trusted_header() {
+            let response = workload::WorkloadResponse {
+                status: 200,
+                body: r#"{"model":"east-provider"}"#.to_owned(),
+                provider: String::new(),
+            };
+            let error = require_workload_provider(&response).unwrap_err();
+            assert!(error.to_string().contains("lacked provider-owned"));
+        }
+
+        #[test]
+        fn workload_provider_returns_header_identity() {
+            let response = workload::WorkloadResponse {
+                status: 200,
+                body: "{}".to_owned(),
+                provider: "east-provider".to_owned(),
+            };
+            assert_eq!(require_workload_provider(&response).unwrap(), "east-provider");
         }
 
         #[test]

--- a/xtask/src/env/gtm_emulator.rs
+++ b/xtask/src/env/gtm_emulator.rs
@@ -469,7 +469,7 @@ fn parse_provider_attribution(headers: &str) -> Result<(String, String, String),
     // vllm-vcr intentionally exposes the normal OpenAI-compatible response
     // surface, so use the authenticated provider gateway as the observable
     // final-hop identity when those mock-only headers are absent.
-    let provider = parse_header(headers, "x-grid-demo-provider")
+    let provider = parse_header(headers, "x-grid-test-provider")
         .filter(|value| matches!(*value, "east-provider" | "east-provider-secondary" | "west-provider"))
         .unwrap_or(provider_gateway);
     let expected_gateway = match provider {
@@ -520,7 +520,7 @@ mod tests {
             "HTTP/1.1 200 OK\r\n",
             "X-Grid-Demo-Edge-Gateway: west-edge\r\n",
             "X-AI-Demo-Provider-Gateway: east-provider\r\n",
-            "X-Grid-Demo-Provider: east-provider\r\n",
+            "X-Grid-Test-Provider: east-provider\r\n",
             "X-Grid-Demo-Backend-Request-Id: backend-123\r\n",
             "Content-Type: application/json\r\n\r\n{}"
         );
@@ -543,7 +543,7 @@ mod tests {
             "HTTP/1.1 200 OK\r\n",
             "X-Grid-Demo-Edge-Gateway: west-edge\r\n",
             "X-AI-Demo-Provider-Gateway: east-provider\r\n",
-            "X-Grid-Demo-Provider: east-provider-secondary\r\n",
+            "X-Grid-Test-Provider: east-provider-secondary\r\n",
             "X-Grid-Demo-Backend-Request-Id: backend-secondary\r\n\r\n{}"
         );
         let sample = parse_response(response).unwrap_or_else(|_| std::process::abort());

--- a/xtask/src/env/provider_traffic_qualification.rs
+++ b/xtask/src/env/provider_traffic_qualification.rs
@@ -2113,6 +2113,7 @@ fn deploy_setup(context: &ProviderTrafficContext) -> Result<OverlayState, Box<dy
             .args(["--non-interactive", "stack", "apply", cluster, stack])
             .status()?;
         if !stack_status.success() {
+            capture_stack_failure(cluster, stack);
             return Err(format!("Failed to apply {stack} to {cluster}").into());
         }
         Ok(())
@@ -2233,6 +2234,32 @@ fn deploy_setup(context: &ProviderTrafficContext) -> Result<OverlayState, Box<dy
         pre_swim: pre_swim_overlays,
         post_swim: post_swim_overlays,
     })
+}
+
+/// Capture bounded Kubernetes diagnostics before failed setup is torn down.
+fn capture_stack_failure(cluster: &str, stack: &str) {
+    let context = format!("kind-grid-provider-traffic-{cluster}");
+    eprintln!("  [DIAG] {stack} failed on {cluster}; capturing Kubernetes state");
+    for args in [
+        vec!["get", "pods", "-o", "wide"],
+        vec!["get", "deployments", "-o", "wide"],
+        vec!["describe", "deployment", stack],
+        vec!["get", "events", "--sort-by=.lastTimestamp"],
+        vec!["logs", "deployment/provider-gateway", "--all-containers", "--tail=100"],
+    ] {
+        let output = Command::new("kubectl")
+            .args(["--context", &context, "-n", GRID_SYSTEM_NS, "--request-timeout=10s"])
+            .args(&args)
+            .output();
+        match output {
+            Ok(output) => {
+                let stdout = safe_truncate_str(String::from_utf8_lossy(&output.stdout).trim(), 8_000);
+                let stderr = safe_truncate_str(String::from_utf8_lossy(&output.stderr).trim(), 2_000);
+                eprintln!("  [DIAG] kubectl {}\n{stdout}\n{stderr}", args.join(" "));
+            },
+            Err(error) => eprintln!("  [DIAG] kubectl {} failed: {error}", args.join(" ")),
+        }
+    }
 }
 
 // -----------------------------------------------------------------------------

--- a/xtask/src/env/token_rate_limit_qualification.rs
+++ b/xtask/src/env/token_rate_limit_qualification.rs
@@ -937,7 +937,7 @@ fn apply_stack(session: &Session, cluster: &str, stack: &str) -> Result<(), Box<
     let config = session.config.to_string_lossy().into_owned();
     let state_dir = session.state_dir.to_string_lossy().into_owned();
     let forge = session.forge.to_string_lossy().into_owned();
-    run_timed(
+    let result = run_timed(
         &forge,
         &[
             "--config",
@@ -951,8 +951,32 @@ fn apply_stack(session: &Session, cluster: &str, stack: &str) -> Result<(), Box<
             stack,
         ],
         300,
-    )?;
-    Ok(())
+    );
+    if result.is_err() {
+        capture_stack_failure(cluster, stack);
+    }
+    result.map(|_| ())
+}
+
+/// Capture bounded Kubernetes state before a failed stack is torn down.
+fn capture_stack_failure(cluster: &str, stack: &str) {
+    note(&format!("diagnostics: {stack} failed on {cluster}"));
+    for args in [
+        vec!["get", "pods", "-o", "wide"],
+        vec!["get", "deployments", "-o", "wide"],
+        vec!["describe", "deployment", stack],
+        vec!["get", "events", "--sort-by=.lastTimestamp"],
+        vec!["logs", "deployment/provider-gateway", "--all-containers", "--tail=100"],
+    ] {
+        match kubectl_unchecked(cluster, &args, 15) {
+            Ok(output) => {
+                let stdout = crate::env::safe_truncate_str(String::from_utf8_lossy(&output.stdout).trim(), 8_000);
+                let stderr = crate::env::safe_truncate_str(String::from_utf8_lossy(&output.stderr).trim(), 2_000);
+                eprintln!("[token-rate-limit] kubectl {}\n{stdout}\n{stderr}", args.join(" "));
+            },
+            Err(error) => eprintln!("[token-rate-limit] kubectl {} failed: {error}", args.join(" ")),
+        }
+    }
 }
 
 /// Apply a per-site stack (named `<site>-<suffix>`) across all clusters.

--- a/xtask/src/env/workload.rs
+++ b/xtask/src/env/workload.rs
@@ -47,7 +47,7 @@ pub(crate) struct WorkloadResponse {
     pub(crate) status: u16,
     /// Raw response body.
     pub(crate) body: String,
-    /// Provider identity from the `x-grid-demo-provider` response header.
+    /// Provider gateway identity from Praxis provider-route attribution.
     pub(crate) provider: String,
 }
 
@@ -134,8 +134,10 @@ fn build_curl_job_manifest(job_name: &str, session_id: Option<&str>) -> String {
         "--show-error".to_owned(),
         "--max-time".to_owned(),
         "15".to_owned(),
+        "--dump-header".to_owned(),
+        "-".to_owned(),
         "--write-out".to_owned(),
-        "\nSTATUS:%{http_code}\nPROVIDER:%header{x-grid-demo-provider}".to_owned(),
+        "\nSTATUS:%{http_code}\nPROVIDER:%header{x-ai-demo-provider-gateway}".to_owned(),
         "--header".to_owned(),
         "Content-Type: application/json".to_owned(),
     ];
@@ -318,8 +320,35 @@ fn parse_curl_output(output: &str) -> WorkloadResponse {
         body_end = 0;
     }
 
-    let body = trimmed.get(..body_end).unwrap_or("").trim().to_owned();
+    let response = trimmed.get(..body_end).unwrap_or("");
+    let (headers, body) = split_response_headers(response);
+    if provider.is_empty() {
+        provider = header_value(headers, "x-ai-demo-provider-gateway").unwrap_or_default();
+    }
+    let body = body.trim().to_owned();
     WorkloadResponse { status, body, provider }
+}
+
+/// Split curl's dumped HTTP headers from the response body.
+fn split_response_headers(response: &str) -> (&str, &str) {
+    response.find("\r\n\r\n").map_or_else(
+        || {
+            response
+                .find("\n\n")
+                .map_or(("", response), |end| response.split_at(end + 2))
+        },
+        |end| response.split_at(end + 4),
+    )
+}
+
+/// Read one case-insensitive response header from a dumped header block.
+fn header_value(headers: &str, expected: &str) -> Option<String> {
+    headers.lines().find_map(|line| {
+        let (name, value) = line.split_once(':')?;
+        name.trim()
+            .eq_ignore_ascii_case(expected)
+            .then(|| value.trim().to_owned())
+    })
 }
 
 /// Build the kind cluster context name.
@@ -353,11 +382,21 @@ mod tests {
 
         #[test]
         fn parse_status_trailer_extracts_code_and_body() {
-            let output = "{\"choices\":[]}\nSTATUS:200\nPROVIDER:east-provider";
+            let output = "HTTP/1.1 200 OK\r\nX-AI-Demo-Provider-Gateway: east-provider\r\n\r\n{\"choices\":[]}\nSTATUS:200\nPROVIDER:east-provider";
             let response = parse_curl_output(output);
             assert_eq!(response.status, 200);
             assert_eq!(response.body, r#"{"choices":[]}"#);
             assert_eq!(response.provider, "east-provider");
+        }
+
+        #[test]
+        fn raw_header_supplies_attribution_when_curl_trailer_is_empty() {
+            let output =
+                "HTTP/1.1 200 OK\r\nx-ai-demo-provider-gateway: west-provider\r\n\r\n{}\nSTATUS:200\nPROVIDER:";
+            let response = parse_curl_output(output);
+            assert_eq!(response.status, 200);
+            assert_eq!(response.provider, "west-provider");
+            assert_eq!(response.body, "{}");
         }
 
         #[test]


### PR DESCRIPTION
## Summary

Hardens the GLB qualification paths that failed in the clean post-release matrix, makes fresh-checkout Forge bootstrap automatic, and gives the shared mock-provider attribution header an explicitly test-only name.

- After both edge gateways serve the withdrawal revision, exercise six distinct new sessions and fail immediately if any request reaches the exact withdrawn backend.
- Record the session, HTTP status, backend identity, and provider-gateway identity for every drain observation.
- Capture raw response headers in workload/no-ingress probes so attribution does not depend solely on curl's `%header` trailer.
- Require the trusted `x-grid-test-provider` response header. The response JSON `model` field is no longer accepted as provider attribution.
- Rename `x-grid-demo-provider` to `x-grid-test-provider` consistently across the shared mock-provider fixture and all example/qualification consumers.
- Resolve Forge from `FORGE_BIN`, `PATH`, or the workspace build; if absent in a fresh checkout, build `praxis-forge` automatically under a five-minute timeout and verify the resulting binary.

## Why

The previous GLB drain loop retried a withdrawn-provider response for up to 45 seconds, which could hide intermittent stale routing after the serving-revision barrier had already passed. The no-ingress path could also lose curl's header trailer and then incorrectly treat the response model as provider identity.

The full-matrix rerun also showed that a fresh checkout fails before deployment unless Forge has been built manually. Forge is part of this workspace, so the shared resolver now performs that deterministic bootstrap instead of requiring an undocumented preparatory command.

`x-grid-demo-provider` was an arbitrary fixture header rather than a Grid or Praxis protocol header. `x-grid-test-provider` makes that scope explicit and avoids presenting it as a production contract.

These changes do not alter Grid routing, topology policy, or production gateway code.

## Validation

- `cargo +nightly-2026-03-28 fmt --all -- --check`
- `cargo test -p mock-providers` (59 passed)
- `cargo test -p xtask` (545 passed)
- `cargo clippy -p mock-providers -p xtask --all-targets -- -D warnings`
- `git diff --check`

The branch is rebased on main including #124. A full runtime matrix is running separately.
