### PR TITLE
feat(operator): add administrative provider drain

### DIFF
--- a/charts/grid-operator/crds/inferenceprovider.yaml
+++ b/charts/grid-operator/crds/inferenceprovider.yaml
@@ -119,6 +119,16 @@ spec:
                 endpoint:
                   description: HTTP endpoint URL.
                   type: string
+                gatewayRef:
+                  description: |-
+                    Stable provider-gateway identity used by administrative operations.
+
+                    Providers with the same value are drained together by the gateway-wide
+                    operation. It is an explicit control-plane relationship; the operator
+                    never infers it from endpoint URLs.
+                  minLength: 1
+                  nullable: true
+                  type: string
                 gridNetworkRef:
                   description: |-
                     Name of the [`GridNetwork`] this provider belongs to.
@@ -517,6 +527,15 @@ spec:
                       default: {}
                       description: Label key-value pairs that must match.
                       type: object
+                  type: object
+                trafficPolicy:
+                  description: Optional administrative traffic policy.
+                  nullable: true
+                  properties:
+                    drain:
+                      default: false
+                      description: Stop new sessions while preserving existing affinity sessions.
+                      type: boolean
                   type: object
               required:
                 - backendKind

--- a/charts/grid-site/templates/inferenceprovider.yaml
+++ b/charts/grid-site/templates/inferenceprovider.yaml
@@ -42,4 +42,11 @@ spec:
   metricsConfig:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- with .gatewayRef }}
+  gatewayRef: {{ . | quote }}
+  {{- end }}
+  {{- with .trafficPolicy }}
+  trafficPolicy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/charts/grid-site/values.schema.json
+++ b/charts/grid-site/values.schema.json
@@ -163,7 +163,13 @@
           "providerKind": { "type": "string", "minLength": 1 },
           "backendKind": { "type": "string", "minLength": 1 },
           "endpoint": { "type": "string", "minLength": 1 },
-          "routingClusterRef": { "type": "string" }
+          "routingClusterRef": { "type": "string" },
+          "gatewayRef": { "type": "string", "minLength": 1 },
+          "trafficPolicy": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": { "drain": { "type": "boolean", "default": false } }
+          }
         }
       }
     },

--- a/deploy/crds/inferenceprovider.yaml
+++ b/deploy/crds/inferenceprovider.yaml
@@ -119,6 +119,16 @@ spec:
                 endpoint:
                   description: HTTP endpoint URL.
                   type: string
+                gatewayRef:
+                  description: |-
+                    Stable provider-gateway identity used by administrative operations.
+
+                    Providers with the same value are drained together by the gateway-wide
+                    operation. It is an explicit control-plane relationship; the operator
+                    never infers it from endpoint URLs.
+                  minLength: 1
+                  nullable: true
+                  type: string
                 gridNetworkRef:
                   description: |-
                     Name of the [`GridNetwork`] this provider belongs to.
@@ -517,6 +527,15 @@ spec:
                       default: {}
                       description: Label key-value pairs that must match.
                       type: object
+                  type: object
+                trafficPolicy:
+                  description: Optional administrative traffic policy.
+                  nullable: true
+                  properties:
+                    drain:
+                      default: false
+                      description: Stop new sessions while preserving existing affinity sessions.
+                      type: boolean
                   type: object
               required:
                 - backendKind

--- a/docs/README.md
+++ b/docs/README.md
@@ -55,6 +55,8 @@
 - [Single-cluster Multi-gateway Qualification](../tests/e2e/topologies/grid-single-cluster-multi-gateway/README.md) -
   proves shared overlay delivery and independent consumer/provider gateway
   behavior within one Kind cluster and one GridSite.
+- [Provider draining](architecture/provider-draining.md) - documents graceful
+  provider maintenance, gateway-wide selection, and reversible drain state.
 
 These integration tests create their environments through Forge and execute
 through first-class Rust `xtask` commands. Their topology READMEs document

--- a/docs/architecture/provider-draining.md
+++ b/docs/architecture/provider-draining.md
@@ -1,0 +1,76 @@
+# Administrative provider draining
+
+Grid supports graceful maintenance of inference providers through the
+optional `InferenceProvider.spec.trafficPolicy.drain` field. The omitted or
+false value preserves the existing health and metrics behavior. When true,
+the operator keeps an otherwise healthy candidate in the routing overlay but
+publishes `admission_state: existing_only`, so new sessions avoid it while
+existing affinity sessions may continue.
+
+Hard failures always win. Invalid, unavailable, stale, untrusted, or
+explicitly excluded providers remain excluded; administrative drain never
+makes an unusable provider routable. Clearing drain re-evaluates current
+health and metrics. It does not blindly promote the provider. The stable
+candidate ID, selection group, and rank are preserved while only effective
+admission changes affect the semantic overlay revision.
+
+Provider membership for administrative operations is explicit through
+`spec.gatewayRef`. It is not inferred from endpoint strings. A gateway-wide
+operation selects every provider with the requested reference, prints the
+sorted selection, supports `--dry-run`, applies the change idempotently, and
+waits for the requested state to be observed. Grid remains entirely outside
+the request-time path.
+
+The basic operational sequence is:
+
+```console
+# Preview the exact selection
+cargo xtask env provider-drain --context kind-example --provider provider-one --dry-run
+
+# Drain provider-one
+cargo xtask env provider-drain --context kind-example --provider provider-one
+
+# Restore provider-one's health/metrics-derived admission state
+cargo xtask env provider-drain --context kind-example --provider provider-one --undrain
+```
+
+The command requires exactly one of `--provider` or `--gateway`. Gateway-wide
+selection uses the explicit `spec.gatewayRef` field; it never guesses from an
+endpoint URL.
+
+`gatewayRef` is administrative grouping metadata; the operator does not
+interpret it. The xtask selects and patches matching providers client-side.
+Gateway-wide mutation is a bounded fan-out and is not transactional: partial
+failures are reported and best-effort restoration is attempted. When
+convergence targets are provided, command completion requires consumer
+serving-revision convergence, not merely API writeback. Interrupted operations
+may require inspection unless signal cleanup is explicitly implemented and
+verified.
+
+For a gateway-wide operation, use the same gateway selector to restore the
+providers:
+
+```console
+cargo xtask env provider-drain --context kind-example --gateway provider-a
+cargo xtask env provider-drain --context kind-example --gateway provider-a --undrain
+```
+
+Without `--network` and `--consumer`, the command is a patch-only primitive and
+reports that it has stored the requested state. To verify convergence, provide
+the target network and every consumer, for example:
+
+```console
+cargo xtask env provider-drain --context kind-example \
+  --gateway provider-a --network production \
+  --consumer consumer-a --consumer consumer-b
+```
+
+With those targets, completion requires the provider's `spec.trafficPolicy.drain`,
+the consumer overlay admission state, and each consumer's accepted and serving
+revision to agree across two observations. The overlay is the authoritative
+observation that new-session admission has changed.
+
+Confirm completion from the
+consumer overlay: the provider must be present with `existing_only`, and the
+consumer must be serving the resulting accepted revision. An unavailable
+provider must recover health before undrain can make it eligible again.

--- a/operator/src/controller/grid_network.rs
+++ b/operator/src/controller/grid_network.rs
@@ -346,7 +346,10 @@ pub async fn reconcile(network: Arc<GridNetwork>, ctx: Arc<OperatorCtx>) -> Resu
             } else {
                 provider_admission::Observation::NotConfigured
             };
-            let state = memory.evaluate(&memory_key, observation, admission_policy, now);
+            let state = crate::resources::geography::apply_administrative_drain(
+                memory.evaluate(&memory_key, observation, admission_policy, now),
+                provider.spec.traffic_policy.as_ref().is_some_and(|p| p.drain),
+            );
             admission_keys.push(memory_key);
             admission_states.insert(identity, state);
         }

--- a/operator/src/controller/inference_provider.rs
+++ b/operator/src/controller/inference_provider.rs
@@ -2545,6 +2545,7 @@ mod tests {
             access_policy: crate::crd::auth::AccessPolicy::default(),
             auth: None,
             backend_kind: "local".to_owned(),
+            gateway_ref: None,
             cost: None,
             endpoint: endpoint.to_owned(),
             health_check,
@@ -2556,6 +2557,7 @@ mod tests {
             provider_kind: "self_hosted".to_owned(),
             routing_cluster_ref: None,
             metrics_config: None,
+            traffic_policy: None,
             site_selector: crate::crd::auth::SelectorConfig::default(),
         }
     }

--- a/operator/src/crd/inference_provider.rs
+++ b/operator/src/crd/inference_provider.rs
@@ -47,6 +47,15 @@ pub struct InferenceProviderSpec {
     /// Backend deployment category.
     pub backend_kind: String,
 
+    /// Stable provider-gateway identity used by administrative operations.
+    ///
+    /// Providers with the same value are drained together by the gateway-wide
+    /// operation. It is an explicit control-plane relationship; the operator
+    /// never infers it from endpoint URLs.
+    #[schemars(length(min = 1))]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gateway_ref: Option<String>,
+
     /// Cost information.
     pub cost: Option<CostConfig>,
 
@@ -92,6 +101,20 @@ pub struct InferenceProviderSpec {
     ///
     /// [`GridNetwork`]: crate::crd::grid_network::GridNetwork
     pub metrics_config: Option<MetricsConfig>,
+
+    /// Optional administrative traffic policy.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub traffic_policy: Option<TrafficPolicy>,
+}
+
+/// Administrative policy for provider traffic.
+#[derive(Clone, Debug, Default, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+#[serde(rename_all = "camelCase")]
+pub struct TrafficPolicy {
+    /// Stop new sessions while preserving existing affinity sessions.
+    #[serde(default)]
+    pub drain: bool,
 }
 
 /// Prometheus metrics scraping configuration for an `InferenceProvider`.
@@ -486,6 +509,38 @@ mod tests {
         let spec: InferenceProviderSpec = serde_json::from_value(json).unwrap_or_else(|_| std::process::abort());
         assert_eq!(spec.provider_kind, "anthropic", "provider kind");
         assert_eq!(spec.models.len(), 1, "model count");
+    }
+
+    #[test]
+    fn administrative_policy_round_trips_and_is_omitted_by_default() {
+        let base = serde_json::json!({
+            "gridNetworkRef": "production", "providerKind": "self_hosted",
+            "backendKind": "local", "endpoint": "http://backend:8080"
+        });
+        let spec: InferenceProviderSpec = serde_json::from_value(base).unwrap_or_else(|_| std::process::abort());
+        let serialized = serde_json::to_value(&spec).unwrap_or_else(|_| std::process::abort());
+        assert!(serialized.get("gatewayRef").is_none());
+        assert!(serialized.get("trafficPolicy").is_none());
+
+        let drained: InferenceProviderSpec = serde_json::from_value(serde_json::json!({
+            "gridNetworkRef": "production", "providerKind": "self_hosted",
+            "backendKind": "local", "endpoint": "http://backend:8080",
+            "gatewayRef": "provider-gateway-a", "trafficPolicy": {"drain": true}
+        }))
+        .unwrap_or_else(|_| std::process::abort());
+        assert_eq!(drained.gateway_ref.as_deref(), Some("provider-gateway-a"));
+        assert!(drained.traffic_policy.as_ref().is_some_and(|p| p.drain));
+    }
+
+    #[test]
+    fn crd_contains_administrative_provider_fields() {
+        let crd = crd_json();
+        let properties = crd
+            .pointer("/spec/versions/0/schema/openAPIV3Schema/properties/spec/properties")
+            .and_then(serde_json::Value::as_object)
+            .unwrap_or_else(|| std::process::abort());
+        assert!(properties.contains_key("gatewayRef"));
+        assert!(properties.contains_key("trafficPolicy"));
     }
 
     #[test]

--- a/operator/src/resources/geography.rs
+++ b/operator/src/resources/geography.rs
@@ -140,6 +140,19 @@ pub(crate) fn derive_admission_state(metrics: Option<&scoring::BackendMetrics>) 
     AdmissionState::NewAndExisting
 }
 
+/// Apply administrative drain without overriding a hard exclusion.
+///
+/// This is deliberately pure: health, staleness, trust, and exclusion are
+/// resolved before this cap is applied. Clearing drain returns the supplied
+/// health/metrics-derived state unchanged.
+pub(crate) fn apply_administrative_drain(state: AdmissionState, drain: bool) -> AdmissionState {
+    if drain && state == AdmissionState::NewAndExisting {
+        AdmissionState::ExistingOnly
+    } else {
+        state
+    }
+}
+
 /// Deterministic stable ID for a routing candidate.
 ///
 /// Computed as `fnv1a_hex8("{kind}/{name}/{site}/{cluster}")`.
@@ -325,6 +338,38 @@ mod tests {
             derive_admission_state(Some(&m)),
             AdmissionState::Excluded,
             "unhealthy must be Excluded"
+        );
+    }
+
+    #[test]
+    fn administrative_drain_caps_only_eligible_providers() {
+        assert_eq!(
+            apply_administrative_drain(AdmissionState::NewAndExisting, true),
+            AdmissionState::ExistingOnly
+        );
+        assert_eq!(
+            apply_administrative_drain(AdmissionState::ExistingOnly, true),
+            AdmissionState::ExistingOnly
+        );
+        assert_eq!(
+            apply_administrative_drain(AdmissionState::Excluded, true),
+            AdmissionState::Excluded
+        );
+    }
+
+    #[test]
+    fn clearing_administrative_drain_preserves_derived_state() {
+        assert_eq!(
+            apply_administrative_drain(AdmissionState::NewAndExisting, false),
+            AdmissionState::NewAndExisting
+        );
+        assert_eq!(
+            apply_administrative_drain(AdmissionState::ExistingOnly, false),
+            AdmissionState::ExistingOnly
+        );
+        assert_eq!(
+            apply_administrative_drain(AdmissionState::Excluded, false),
+            AdmissionState::Excluded
         );
     }
 

--- a/tests/e2e/topologies/grid-single-cluster-multi-gateway/forge.yaml
+++ b/tests/e2e/topologies/grid-single-cluster-multi-gateway/forge.yaml
@@ -182,6 +182,7 @@ spec:
             inferenceProviders:
               - name: vcr-provider-a-provider
                 gridNetworkRef: grid-single-cluster-multi-gateway
+                gatewayRef: provider-gateway-a
                 providerKind: vllm-vcr
                 backendKind: local
                 endpoint: "http://vcr-inference-provider-a.grid-system.svc.cluster.local:8000"
@@ -206,6 +207,7 @@ spec:
                   timeout: "5s"
               - name: vcr-provider-b-provider
                 gridNetworkRef: grid-single-cluster-multi-gateway
+                gatewayRef: provider-gateway-a
                 providerKind: vllm-vcr
                 backendKind: local
                 endpoint: "http://vcr-inference-provider-b.grid-system.svc.cluster.local:8000"
@@ -225,6 +227,7 @@ spec:
                   timeout: "5s"
               - name: vcr-provider-c-provider
                 gridNetworkRef: grid-single-cluster-multi-gateway
+                gatewayRef: provider-gateway-b
                 providerKind: vllm-vcr
                 backendKind: local
                 endpoint: "http://vcr-inference-provider-c.grid-system.svc.cluster.local:8000"

--- a/xtask/src/env.rs
+++ b/xtask/src/env.rs
@@ -17,6 +17,7 @@ pub(crate) mod kubectl;
 pub(crate) mod llmd_pool_metrics_demo;
 pub(crate) mod operator;
 pub(crate) mod operator_overlay;
+pub(crate) mod provider_drain;
 pub(crate) mod provider_traffic_qualification;
 pub(crate) mod providers;
 pub(crate) mod single_cluster_multi_gateway_qualification;
@@ -200,6 +201,33 @@ pub(crate) fn demo_root(forge_config: &Path) -> PathBuf {
 /// Actions for the `env` subcommand.
 #[derive(Debug, Subcommand)]
 pub(crate) enum Action {
+    /// Drain or restore all providers explicitly assigned to a gateway.
+    ProviderDrain {
+        /// Kubernetes context containing the provider resources.
+        #[arg(long)]
+        context: String,
+        /// Explicit provider-gateway identity from `spec.gatewayRef`.
+        #[arg(long, conflicts_with = "provider")]
+        gateway: Option<String>,
+        /// Drain or restore one named `InferenceProvider`.
+        #[arg(long, conflicts_with = "gateway")]
+        provider: Option<String>,
+        /// Preview the exact selected providers without changing resources.
+        #[arg(long)]
+        dry_run: bool,
+        /// Restore providers instead of draining them.
+        #[arg(long)]
+        undrain: bool,
+        /// `GridNetwork` used to verify projected overlay convergence.
+        #[arg(long, requires = "consumer")]
+        network: Option<String>,
+        /// Consumer gateway Deployment(s) whose revisions must converge.
+        #[arg(long = "consumer", requires = "network")]
+        consumers: Vec<String>,
+        /// Maximum time to wait for observed status, in seconds.
+        #[arg(long, default_value_t = 120)]
+        timeout_seconds: u64,
+    },
     /// Materialize a Forge config with `GRID_XTASK_*` image overrides.
     MaterializeForgeConfig {
         /// Source Forge environment config.
@@ -1112,6 +1140,25 @@ mod llmd_pool_metrics_demo_cli_tests {
 )]
 pub(crate) fn run(action: &Action) -> Result<(), Box<dyn std::error::Error>> {
     match action {
+        Action::ProviderDrain {
+            context,
+            gateway,
+            provider,
+            dry_run,
+            undrain,
+            network,
+            consumers,
+            timeout_seconds,
+        } => provider_drain::run(
+            context,
+            gateway.as_deref(),
+            provider.as_deref(),
+            *dry_run,
+            *undrain,
+            Duration::from_secs(*timeout_seconds),
+            network.as_deref(),
+            consumers,
+        ),
         Action::MaterializeForgeConfig { forge_config, output } => {
             let resolved = forge_config::materialize(forge_config, output.as_deref())?;
             eprintln!("materialized Forge config: {}", resolved.display());

--- a/xtask/src/env/provider_drain.rs
+++ b/xtask/src/env/provider_drain.rs
@@ -1,0 +1,481 @@
+//! Administrative provider drain operations.
+//!
+//! Selection is based only on the explicit `spec.gatewayRef` relationship.
+//! This command changes desired Kubernetes state; Grid still performs the
+//! asynchronous overlay reconciliation and never participates in requests.
+
+#![allow(
+    clippy::missing_docs_in_private_items,
+    reason = "the private JSON response model is documented by the command contract"
+)]
+
+use std::{
+    collections::BTreeMap,
+    process::Command,
+    time::{Duration, Instant},
+};
+
+use serde::Deserialize;
+
+const RESOURCE: &str = "inferenceproviders";
+type CandidateStates = BTreeMap<String, String>;
+type RevisionPair = (Option<String>, Option<String>);
+
+#[derive(Debug, Deserialize)]
+struct ProviderList {
+    items: Vec<Provider>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Provider {
+    metadata: Metadata,
+    spec: Spec,
+}
+
+#[derive(Debug, Deserialize)]
+struct Metadata {
+    name: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Spec {
+    gateway_ref: Option<String>,
+}
+
+/// Drain or restore all providers assigned to one explicit gateway identity.
+#[expect(
+    clippy::too_many_arguments,
+    clippy::too_many_lines,
+    reason = "CLI dispatch keeps the selector and bounded operation controls explicit"
+)]
+pub(crate) fn run(
+    context: &str,
+    gateway: Option<&str>,
+    provider: Option<&str>,
+    dry_run: bool,
+    undrain: bool,
+    timeout: Duration,
+    network: Option<&str>,
+    consumers: &[String],
+) -> Result<(), Box<dyn std::error::Error>> {
+    validate_selector(gateway, provider)?;
+    let selector = gateway.map_or_else(
+        || format!("provider={:?}", provider.unwrap_or_default()),
+        |value| format!("gatewayRef={value:?}"),
+    );
+    let selected = if let Some(name) = provider {
+        select_provider(context, name)?
+    } else {
+        select(context, gateway.unwrap_or_default())?
+    };
+    if selected.is_empty() {
+        return Err(format!("no InferenceProvider objects match {selector}").into());
+    }
+    println!("selected providers for {selector}:");
+    for name in &selected {
+        println!("  {name}");
+    }
+    if dry_run {
+        println!("dry-run: no provider resources changed");
+        return Ok(());
+    }
+    if network.is_some() == consumers.is_empty() {
+        return Err("--network and --consumer must be supplied together".into());
+    }
+    let original = selected
+        .iter()
+        .map(|name| read_drain_state(context, name).map(|drain| (name.clone(), drain)))
+        .collect::<Result<BTreeMap<_, _>, _>>()?;
+    let requested_drain = !undrain;
+    let mut changed = Vec::<String>::new();
+    for name in &selected {
+        if let Err(error) = patch_drain_state(context, name, requested_drain, timeout) {
+            let restoration_errors = changed
+                .iter()
+                .filter_map(|changed_name| {
+                    let drain = original.get(changed_name)?;
+                    patch_drain_state(context, changed_name, *drain, timeout)
+                        .err()
+                        .map(|restore_error| format!("{changed_name}: {restore_error}"))
+                })
+                .collect::<Vec<_>>();
+            return Err(format!(
+                "failed to update {name}: {error}; partial-update restoration errors: {restoration_errors:?}"
+            )
+            .into());
+        }
+        changed.push(name.clone());
+    }
+    if let Some(network) = network {
+        wait_for_convergence(context, &selected, !undrain, network, consumers, timeout)
+    } else {
+        println!("requested drain state stored; overlay convergence was not requested");
+        Ok(())
+    }
+}
+
+/// Store one provider's desired administrative drain state.
+fn patch_drain_state(
+    context: &str,
+    name: &str,
+    drain: bool,
+    timeout: Duration,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let patch = format!(r#"{{"spec":{{"trafficPolicy":{{"drain":{drain}}}}}}}"#);
+    kubectl(
+        context,
+        ["patch", RESOURCE, name, "--type", "merge", "-p", &patch],
+        timeout,
+    )?;
+    Ok(())
+}
+
+/// Validate the mutually exclusive administrative selector.
+fn validate_selector(gateway: Option<&str>, provider: Option<&str>) -> Result<(), Box<dyn std::error::Error>> {
+    if gateway.is_none() == provider.is_none() {
+        return Err("exactly one of --gateway or --provider is required".into());
+    }
+    if gateway.is_some_and(|value| value.trim().is_empty()) || provider.is_some_and(|value| value.trim().is_empty()) {
+        return Err("--gateway and --provider must not be empty".into());
+    }
+    Ok(())
+}
+
+fn select(context: &str, gateway: &str) -> Result<Vec<String>, Box<dyn std::error::Error>> {
+    let output = kubectl(context, ["get", RESOURCE, "-o", "json"], Duration::from_secs(30))?;
+    let list: ProviderList = serde_json::from_slice(&output)?;
+    let mut names: Vec<_> = list
+        .items
+        .into_iter()
+        .filter(|p| p.spec.gateway_ref.as_deref() == Some(gateway))
+        .filter_map(|p| p.metadata.name)
+        .collect();
+    names.sort();
+    names.dedup();
+    Ok(names)
+}
+
+/// Select one explicitly named provider, failing safely when it is absent.
+fn select_provider(context: &str, name: &str) -> Result<Vec<String>, Box<dyn std::error::Error>> {
+    let output = kubectl(context, ["get", RESOURCE, name, "-o", "json"], Duration::from_secs(30))?;
+    let provider: Provider = serde_json::from_slice(&output)?;
+    Ok(provider.metadata.name.into_iter().collect())
+}
+
+/// Read the desired administrative drain state before a qualification mutates it.
+pub(crate) fn read_drain_state(context: &str, name: &str) -> Result<bool, Box<dyn std::error::Error>> {
+    let output = kubectl(context, ["get", RESOURCE, name, "-o", "json"], Duration::from_secs(30))?;
+    let provider: serde_json::Value = serde_json::from_slice(&output)?;
+    Ok(provider
+        .pointer("/spec/trafficPolicy/drain")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false))
+}
+
+/// Execute kubectl with dynamically assembled arguments and a hard timeout.
+fn kubectl_owned(context: &str, args: &[String], timeout: Duration) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+    let output = Command::new("timeout")
+        .arg(format!("{}s", timeout.as_secs().max(1)))
+        .arg("kubectl")
+        .arg("--context")
+        .arg(context)
+        .args(args)
+        .output()?;
+    if !output.status.success() {
+        return Err(format!(
+            "kubectl {} failed or timed out: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr).trim()
+        )
+        .into());
+    }
+    Ok(output.stdout)
+}
+
+#[expect(
+    clippy::too_many_arguments,
+    clippy::too_many_lines,
+    reason = "the convergence gate keeps all target and diagnostic state explicit"
+)]
+fn wait_for_convergence(
+    context: &str,
+    names: &[String],
+    draining: bool,
+    network: &str,
+    consumers: &[String],
+    timeout: Duration,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let deadline = Instant::now() + timeout;
+    let command_timeout = Duration::from_secs(30).min(timeout.max(Duration::from_secs(1)));
+    let expected_state = if draining { "existing_only" } else { "new_and_existing" };
+    let mut stable_observations = 0;
+    let mut previous = String::new();
+    let mut last = String::from("no observation");
+    while Instant::now() < deadline {
+        let mut observation = BTreeMap::new();
+        let mut valid = true;
+        for consumer in consumers {
+            match read_overlay(context, network, consumer, command_timeout) {
+                Ok((revision, states)) => match read_revisions(context, consumer, command_timeout) {
+                    Ok((accepted, serving)) => {
+                        let states_match = names
+                            .iter()
+                            .all(|name| states.get(name).is_some_and(|state| state == expected_state));
+                        let revision_match = !revision.is_empty()
+                            && accepted.as_deref() == Some(revision.as_str())
+                            && serving.as_deref() == Some(revision.as_str());
+                        valid &= states_match && revision_match;
+                        observation.insert(
+                            consumer.clone(),
+                            format!(
+                                "grid={revision} accepted={accepted:?} serving={serving:?} states_match={states_match} states={states:?} expected={expected_state}"
+                            ),
+                        );
+                    },
+                    Err(error) => {
+                        valid = false;
+                        observation.insert(consumer.clone(), format!("revision_error={error}"));
+                    },
+                },
+                Err(error) => {
+                    valid = false;
+                    observation.insert(consumer.clone(), format!("overlay_error={error}"));
+                },
+            }
+        }
+        last = observation.values().cloned().collect::<Vec<_>>().join("; ");
+        let fingerprint = last.clone();
+        if valid && fingerprint == previous {
+            stable_observations += 1;
+        } else if valid {
+            stable_observations = 1;
+        } else {
+            stable_observations = 0;
+        }
+        previous = fingerprint;
+        if stable_observations >= 2 {
+            println!("converged: {last}");
+            return Ok(());
+        }
+        std::thread::park_timeout(Duration::from_secs(1));
+    }
+    Err(format!(
+        "timed out waiting for {} convergence; last observed: {last}",
+        if draining { "drain" } else { "undrain" }
+    )
+    .into())
+}
+
+/// Read the projected overlay revision and candidate admission states.
+#[expect(
+    clippy::too_many_lines,
+    reason = "the overlay parser validates the complete projected resource in one place"
+)]
+fn read_overlay(
+    context: &str,
+    network: &str,
+    consumer: &str,
+    timeout: Duration,
+) -> Result<(String, CandidateStates), Box<dyn std::error::Error>> {
+    let raw = kubectl(
+        context,
+        ["-n", "grid-system", "get", "configmaps", "-o", "json"],
+        timeout,
+    )?;
+    let value: serde_json::Value = serde_json::from_slice(&raw)?;
+    let item = value
+        .get("items")
+        .and_then(serde_json::Value::as_array)
+        .and_then(|items| {
+            items.iter().find(|item| {
+                item.get("metadata")
+                    .and_then(|metadata| metadata.get("name"))
+                    .and_then(serde_json::Value::as_str)
+                    .is_some_and(|name| name.contains(consumer))
+                    && item
+                        .get("data")
+                        .and_then(|data| data.get("routing-overlay.json"))
+                        .is_some()
+            })
+        })
+        .ok_or_else(|| format!("overlay ConfigMap for network={network} consumer={consumer} not found"))?;
+    let raw_overlay = item
+        .get("data")
+        .and_then(|data| data.get("routing-overlay.json"))
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| format!("overlay ConfigMap for {consumer} has no routing-overlay.json"))?;
+    let envelope: serde_json::Value = serde_json::from_str(raw_overlay)?;
+    let revision = envelope
+        .get("revision")
+        .and_then(|revision| revision.get("value"))
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_default()
+        .to_owned();
+    let mut states = BTreeMap::new();
+    if let Some(candidates) = envelope
+        .get("overlay")
+        .and_then(|overlay| overlay.get("candidates"))
+        .and_then(serde_json::Value::as_array)
+    {
+        for candidate in candidates {
+            if let (Some(cluster), Some(state)) = (
+                candidate.get("cluster").and_then(serde_json::Value::as_str),
+                candidate.get("admission_state").and_then(serde_json::Value::as_str),
+            ) {
+                states.insert(cluster.to_owned(), state.to_owned());
+            }
+        }
+    }
+    Ok((revision, states))
+}
+
+/// Read exact accepted and serving revision fields from Praxis logs.
+fn read_revisions(
+    context: &str,
+    consumer: &str,
+    timeout: Duration,
+) -> Result<RevisionPair, Box<dyn std::error::Error>> {
+    let deployment = format!("deployment/{consumer}");
+    let output = kubectl_owned(
+        context,
+        &[
+            "-n".to_owned(),
+            "grid-system".to_owned(),
+            "logs".to_owned(),
+            deployment,
+            "-c".to_owned(),
+            "praxis".to_owned(),
+        ],
+        timeout,
+    )?;
+    let logs = strip_ansi(&String::from_utf8_lossy(&output));
+    Ok((
+        latest_field(&logs, "accepted_revision"),
+        latest_field(&logs, "serving_revision"),
+    ))
+}
+
+fn latest_field(logs: &str, field: &str) -> Option<String> {
+    logs.lines().rev().find_map(|line| {
+        line.split_whitespace().find_map(|part| {
+            part.strip_prefix(&format!("{field}="))
+                .map(|value| value.trim_matches('"').trim_matches(',').to_owned())
+        })
+    })
+}
+
+fn strip_ansi(input: &str) -> String {
+    let mut output = String::with_capacity(input.len());
+    let mut in_escape = false;
+    for character in input.chars() {
+        if in_escape {
+            if character.is_ascii_alphabetic() {
+                in_escape = false;
+            }
+        } else if character == '\x1b' {
+            in_escape = true;
+        } else {
+            output.push(character);
+        }
+    }
+    output
+}
+
+fn kubectl<const N: usize>(
+    context: &str,
+    args: [&str; N],
+    timeout: Duration,
+) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+    let output = Command::new("timeout")
+        .arg(format!("{}s", timeout.as_secs().max(1)))
+        .arg("kubectl")
+        .arg("--context")
+        .arg(context)
+        .args(args)
+        .output()?;
+    if !output.status.success() {
+        return Err(format!(
+            "kubectl {} failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr).trim()
+        )
+        .into());
+    }
+    Ok(output.stdout)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn provider_selection_uses_explicit_gateway_ref() {
+        let list: ProviderList = serde_json::from_value(serde_json::json!({"items":[
+            {"metadata":{"name":"b"},"spec":{"gatewayRef":"gw"}},
+            {"metadata":{"name":"a"},"spec":{"gatewayRef":"gw"}},
+            {"metadata":{"name":"other"},"spec":{"gatewayRef":"other"}}
+        ]}))
+        .unwrap_or_else(|_| std::process::abort());
+        let mut names: Vec<_> = list
+            .items
+            .into_iter()
+            .filter(|p| p.spec.gateway_ref.as_deref() == Some("gw"))
+            .filter_map(|p| p.metadata.name)
+            .collect();
+        names.sort();
+        assert_eq!(names, ["a", "b"]);
+    }
+
+    #[test]
+    fn omitted_gateway_ref_does_not_match() {
+        let provider: Provider = serde_json::from_value(serde_json::json!({"metadata":{"name":"p"},"spec":{}}))
+            .unwrap_or_else(|_| std::process::abort());
+        assert_ne!(provider.spec.gateway_ref.as_deref(), Some("gw"));
+    }
+
+    #[test]
+    fn revision_parser_uses_exact_fields_and_strips_ansi() {
+        let logs = "previous_serving_revision=old \x1b[32maccepted_revision=next\x1b[0m serving_revision=\"next\"";
+        let clean = strip_ansi(logs);
+        assert_eq!(latest_field(&clean, "accepted_revision").as_deref(), Some("next"));
+        assert_eq!(latest_field(&clean, "serving_revision").as_deref(), Some("next"));
+        assert_eq!(
+            latest_field(&clean, "previous_serving_revision").as_deref(),
+            Some("old")
+        );
+    }
+
+    #[test]
+    fn revision_parser_does_not_match_similarly_named_fields() {
+        let logs = "previous_serving_revision=old retained_serving_revision=retained";
+        assert_eq!(latest_field(logs, "accepted_revision"), None);
+        assert_eq!(latest_field(logs, "serving_revision"), None);
+    }
+
+    #[test]
+    fn gateway_membership_requires_an_exact_reference() {
+        let list: ProviderList = serde_json::from_value(serde_json::json!({"items":[
+            {"metadata":{"name":"prefix"},"spec":{"gatewayRef":"gateway-a-extra"}},
+            {"metadata":{"name":"match"},"spec":{"gatewayRef":"gateway-a"}},
+            {"metadata":{"name":"suffix"},"spec":{"gatewayRef":"x-gateway-a"}}
+        ]}))
+        .unwrap_or_else(|_| std::process::abort());
+        let names: Vec<_> = list
+            .items
+            .into_iter()
+            .filter(|provider| provider.spec.gateway_ref.as_deref() == Some("gateway-a"))
+            .filter_map(|provider| provider.metadata.name)
+            .collect();
+        assert_eq!(names, ["match"]);
+    }
+
+    #[test]
+    fn selector_requires_one_mode() {
+        assert!(validate_selector(None, None).is_err());
+        assert!(validate_selector(Some(""), None).is_err());
+        assert!(validate_selector(Some("gw"), Some("provider")).is_err());
+        validate_selector(Some("gw"), None).unwrap_or_else(|_| std::process::abort());
+        validate_selector(None, Some("provider")).unwrap_or_else(|_| std::process::abort());
+    }
+}

--- a/xtask/src/env/provider_drain.rs
+++ b/xtask/src/env/provider_drain.rs
@@ -289,10 +289,7 @@ fn read_overlay(
         .and_then(serde_json::Value::as_array)
         .and_then(|items| {
             items.iter().find(|item| {
-                item.get("metadata")
-                    .and_then(|metadata| metadata.get("name"))
-                    .and_then(serde_json::Value::as_str)
-                    .is_some_and(|name| name.contains(consumer))
+                is_overlay_config_map(item, network, consumer)
                     && item
                         .get("data")
                         .and_then(|data| data.get("routing-overlay.json"))
@@ -328,6 +325,25 @@ fn read_overlay(
         }
     }
     Ok((revision, states))
+}
+
+/// Match an operator-produced overlay by its structured identity labels.
+///
+/// Names are length-limited and may contain a hash suffix, so the labels are
+/// the authoritative lookup key. Exact equality also prevents a gateway or
+/// network whose name is a substring of another from being selected.
+fn is_overlay_config_map(item: &serde_json::Value, network: &str, consumer: &str) -> bool {
+    let Some(labels) = item.get("metadata").and_then(|metadata| metadata.get("labels")) else {
+        return false;
+    };
+    labels
+        .get("grid.praxis-proxy.io/network")
+        .and_then(serde_json::Value::as_str)
+        == Some(network)
+        && labels
+            .get("grid.praxis-proxy.io/gateway")
+            .and_then(serde_json::Value::as_str)
+            == Some(consumer)
 }
 
 /// Read exact accepted and serving revision fields from Praxis logs.
@@ -468,6 +484,39 @@ mod tests {
             .filter_map(|provider| provider.metadata.name)
             .collect();
         assert_eq!(names, ["match"]);
+    }
+
+    #[test]
+    fn overlay_lookup_requires_exact_network_and_gateway_labels() {
+        let matching = serde_json::json!({
+            "metadata": {"labels": {
+                "grid.praxis-proxy.io/network": "network-a",
+                "grid.praxis-proxy.io/gateway": "consumer-gateway-a"
+            }}
+        });
+        let wrong_network = serde_json::json!({
+            "metadata": {"labels": {
+                "grid.praxis-proxy.io/network": "network-a-backup",
+                "grid.praxis-proxy.io/gateway": "consumer-gateway-a"
+            }}
+        });
+        let wrong_gateway = serde_json::json!({
+            "metadata": {"labels": {
+                "grid.praxis-proxy.io/network": "network-a",
+                "grid.praxis-proxy.io/gateway": "consumer-gateway-a-backup"
+            }}
+        });
+        assert!(is_overlay_config_map(&matching, "network-a", "consumer-gateway-a"));
+        assert!(!is_overlay_config_map(
+            &wrong_network,
+            "network-a",
+            "consumer-gateway-a"
+        ));
+        assert!(!is_overlay_config_map(
+            &wrong_gateway,
+            "network-a",
+            "consumer-gateway-a"
+        ));
     }
 
     #[test]

--- a/xtask/src/env/single_cluster_multi_gateway_qualification.rs
+++ b/xtask/src/env/single_cluster_multi_gateway_qualification.rs
@@ -575,13 +575,38 @@ fn client_command(args: &[&str]) -> Result<Output, String> {
 
 /// Issue one attributed request through a consumer gateway.
 fn attributed_request(consumer: &str, request_id: u32) -> Result<String, String> {
+    attributed_request_once(consumer, request_id, None)
+}
+
+/// Issue one attributed request with an explicit session-affinity key.
+fn attributed_request_with_session(consumer: &str, request_id: u32, session: &str) -> Result<String, String> {
+    attributed_request_once(consumer, request_id, Some(session))
+}
+
+fn attributed_request_once(consumer: &str, request_id: u32, session: Option<&str>) -> Result<String, String> {
+    let args = build_request_args(consumer, request_id, session)?;
+    let references: Vec<&str> = args.iter().map(String::as_str).collect();
+    let output = client_command(&references)?;
+    if !output.status.success() {
+        return Err(format!(
+            "{consumer} request failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+    Ok(String::from_utf8_lossy(&output.stderr).into_owned())
+}
+
+fn build_request_args(consumer: &str, request_id: u32, session: Option<&str>) -> Result<Vec<String>, String> {
+    if session.is_some_and(|value| value.chars().any(char::is_control)) {
+        return Err("session ID contains a control character".to_owned());
+    }
     // Consumer services expose the client-facing HTTP listener on 8080. The
     // 8443 listener is used by provider gateways for their mTLS hop.
     let service = format!("http://{consumer}.grid-system.svc.cluster.local:8080/v1/chat/completions");
     let body = format!(
         r#"{{"model":"Qwen/Qwen3-0.6B","messages":[{{"role":"user","content":"qualification-{request_id}"}}],"max_tokens":4}}"#
     );
-    let args = [
+    let mut args = vec![
         "curl",
         "--silent",
         "--show-error",
@@ -593,18 +618,208 @@ fn attributed_request(consumer: &str, request_id: u32) -> Result<String, String>
         "Content-Type: application/json",
         "--header",
         "Authorization: Bearer qualification-token",
-        "--data",
-        body.as_str(),
-        service.as_str(),
-    ];
-    let output = client_command(&args)?;
-    if !output.status.success() {
-        return Err(format!(
-            "{consumer} request failed: {}",
-            String::from_utf8_lossy(&output.stderr).trim()
-        ));
+    ]
+    .into_iter()
+    .map(str::to_owned)
+    .collect::<Vec<_>>();
+    if let Some(session) = session {
+        args.extend(["--header".to_owned(), format!("X-Session-Id: {session}")]);
     }
-    Ok(String::from_utf8_lossy(&output.stderr).into_owned())
+    args.extend(["--data".to_owned(), body, service]);
+    Ok(args)
+}
+
+#[derive(Debug)]
+struct RetriedProbe {
+    headers: String,
+    attempts: Vec<serde_json::Value>,
+}
+
+/// Retry only transport failures; a received HTTP response is final.
+#[expect(clippy::too_many_lines, reason = "the bounded retry records every probe attempt")]
+fn attributed_request_with_transport_retry(
+    consumer: &str,
+    request_id: u32,
+    session: Option<&str>,
+) -> Result<RetriedProbe, String> {
+    let mut attempts = Vec::new();
+    for attempt in 1..=3 {
+        let result = match session {
+            Some(value) => attributed_request_with_session(consumer, request_id, value),
+            None => attributed_request(consumer, request_id),
+        };
+        match result {
+            Ok(headers) => {
+                attempts.push(retry_evidence(
+                    "provider-attributed-request",
+                    attempt,
+                    true,
+                    http_status(&headers),
+                    None,
+                ));
+                return Ok(RetriedProbe { headers, attempts });
+            },
+            Err(error) => {
+                let status = http_status(&error);
+                let retry = retry_decision(false, status, attempt);
+                attempts.push(retry_evidence(
+                    "provider-attributed-request",
+                    attempt,
+                    false,
+                    status,
+                    None,
+                ));
+                if !retry {
+                    return Err(format!("{error}; attempts={attempts:?}"));
+                }
+            },
+        }
+    }
+    unreachable!("bounded retry loop always returns")
+}
+
+fn http_status(output: &str) -> Option<u16> {
+    output.lines().find_map(|line| {
+        let mut fields = line.split_whitespace();
+        matches!(
+            fields.next(),
+            Some("HTTP/1.0" | "HTTP/1.1" | "HTTP/2" | "HTTP/2.0" | "HTTP/3")
+        )
+        .then(|| fields.next()?.parse().ok())?
+    })
+}
+
+fn retry_decision(process_succeeded: bool, status: Option<u16>, attempt: u8) -> bool {
+    !process_succeeded && status.is_none() && attempt < 3
+}
+
+fn retry_reason(process_succeeded: bool, status: Option<u16>, attempt: u8) -> &'static str {
+    if process_succeeded || status.is_some() {
+        "http_response_received"
+    } else if attempt >= 3 {
+        "transport_retry_limit_reached"
+    } else {
+        "transport_without_http_response"
+    }
+}
+
+fn session_id(prefix: &str, consumer: &str, attempt: u32) -> String {
+    format!("{prefix}-{consumer}-{attempt}")
+}
+
+fn restoration_undrain(original_drain: bool) -> bool {
+    !original_drain
+}
+
+fn retry_evidence(
+    scenario: &str,
+    attempt: u8,
+    process_succeeded: bool,
+    status: Option<u16>,
+    provider: Option<&str>,
+) -> serde_json::Value {
+    let retry = retry_decision(process_succeeded, status, attempt);
+    serde_json::json!({
+        "scenario": scenario,
+        "attempt": attempt,
+        "transport": if process_succeeded { "ok" } else { "error" },
+        "http_status": status,
+        "provider": provider,
+        "retry": retry,
+        "retry_reason": retry_reason(process_succeeded, status, attempt),
+        "final": !retry,
+    })
+}
+
+/// Restore providers if a qualification phase fails after mutation.
+struct RestorationGuard {
+    context: String,
+    providers: Vec<(String, bool)>,
+    snapshot_error: Option<String>,
+    active: bool,
+}
+
+impl RestorationGuard {
+    fn new(context: &str, providers: &[&str]) -> Self {
+        let mut snapshot_error = None;
+        let providers = providers
+            .iter()
+            .filter_map(
+                |provider| match super::provider_drain::read_drain_state(context, provider) {
+                    Ok(original) => Some(((*provider).to_owned(), original)),
+                    Err(error) => {
+                        snapshot_error = Some(format!("failed to snapshot {provider} drain state: {error}"));
+                        None
+                    },
+                },
+            )
+            .collect();
+        Self {
+            context: context.to_owned(),
+            providers,
+            snapshot_error,
+            active: true,
+        }
+    }
+
+    fn ensure_snapshot(&self) -> Result<(), Box<dyn std::error::Error>> {
+        self.snapshot_error
+            .as_ref()
+            .map_or(Ok(()), |error| Err(error.clone().into()))
+    }
+
+    fn restore(&mut self, network: &str, consumers: &[String]) -> Result<(), Box<dyn std::error::Error>> {
+        for (provider, original) in &self.providers {
+            super::provider_drain::run(
+                &self.context,
+                None,
+                Some(provider),
+                false,
+                restoration_undrain(*original),
+                Duration::from_secs(120),
+                Some(network),
+                consumers,
+            )?;
+        }
+        self.active = false;
+        Ok(())
+    }
+
+    fn finish<T>(
+        &mut self,
+        result: Result<T, Box<dyn std::error::Error>>,
+        network: &str,
+        consumers: &[String],
+    ) -> Result<T, Box<dyn std::error::Error>> {
+        let restoration = self.restore(network, consumers);
+        match (result, restoration) {
+            (Ok(value), Ok(())) => Ok(value),
+            (Err(error), Ok(())) => Err(error),
+            (Ok(_), Err(error)) => Err(format!("scenario passed but restoration failed: {error}").into()),
+            (Err(error), Err(restore_error)) => {
+                Err(format!("{error}; restoration also failed: {restore_error}").into())
+            },
+        }
+    }
+}
+
+impl Drop for RestorationGuard {
+    fn drop(&mut self) {
+        if self.active {
+            for (provider, original) in &self.providers {
+                drop(super::provider_drain::run(
+                    &self.context,
+                    None,
+                    Some(provider),
+                    false,
+                    restoration_undrain(*original),
+                    Duration::from_secs(120),
+                    None,
+                    &[],
+                ));
+            }
+        }
+    }
 }
 
 /// Extract the selected provider from the trusted response header.
@@ -616,6 +831,43 @@ fn selected_provider(headers: &str) -> Result<String, String> {
         .filter(|value| !value.is_empty())
         .map(str::to_owned)
         .ok_or_else(|| format!("response did not contain trusted provider attribution: {headers}"))
+}
+
+/// Find a stable session currently attributed to the requested provider.
+fn session_for_provider(consumer: &str, provider: &str, prefix: &str) -> Result<String, String> {
+    for attempt in 0..12 {
+        let session = session_id(prefix, consumer, attempt);
+        let headers = attributed_request_with_session(consumer, 450 + attempt, &session)?;
+        if selected_provider(&headers)? == provider {
+            return Ok(session);
+        }
+    }
+    Err(format!(
+        "could not establish affinity session for {consumer} -> {provider}"
+    ))
+}
+
+/// Return the admission state for a candidate in both consumer overlays.
+fn candidate_admission_states(state: &serde_json::Value, candidate: &str) -> Result<Vec<String>, String> {
+    ["consumer-gateway-a", "consumer-gateway-b"]
+        .into_iter()
+        .map(|consumer| {
+            let overlay = consumer_overlay(state, consumer)?;
+            overlay
+                .get("overlay")
+                .and_then(|value| value.get("candidates"))
+                .and_then(serde_json::Value::as_array)
+                .and_then(|candidates| {
+                    candidates
+                        .iter()
+                        .find(|item| item.get("cluster").and_then(serde_json::Value::as_str) == Some(candidate))
+                })
+                .and_then(|item| item.get("admission_state"))
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_owned)
+                .ok_or_else(|| format!("{consumer} overlay has no candidate {candidate}"))
+        })
+        .collect()
 }
 
 /// Parse the routing overlay for one consumer from captured `ConfigMaps`.
@@ -885,6 +1137,18 @@ fn wait_deployment(name: &str) -> Result<(), String> {
     }
 }
 
+/// Restart the operator while a drain is active; the CR remains the source of truth.
+fn restart_operator() -> Result<(), String> {
+    let output = kubectl(&["-n", NAMESPACE, "rollout", "restart", "deployment/grid-operator"])?;
+    if !output.status.success() {
+        return Err(format!(
+            "operator restart failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+    wait_deployment("grid-operator")
+}
+
 fn scenario(name: &str, result: &str, detail: impl Into<String>) -> Scenario {
     Scenario {
         name: name.to_owned(),
@@ -1138,6 +1402,212 @@ pub(crate) fn run(forge_config: &Path, options: &Options) -> Result<(), Box<dyn 
                     format!("{request_failures} requests failed or provider rotation/attribution was invalid"),
                 )
             });
+            let drain_context = cluster_identity().kubectl_context;
+            let drain_consumers = ["consumer-gateway-a".to_owned(), "consumer-gateway-b".to_owned()];
+            let individual_drain = {
+                let mut restore = RestorationGuard::new(&drain_context, &["vcr-provider-a-provider"]);
+                let mut existing_session = String::new();
+                let result = restore
+                    .ensure_snapshot()
+                    .and_then(|()| {
+                        session_for_provider("consumer-gateway-a", "provider-a", "existing-individual")
+                            .map_err(Into::into)
+                    })
+                    .map(|session| existing_session = session)
+                    .and_then(|_| {
+                        super::provider_drain::run(
+                            &drain_context,
+                            None,
+                            Some("vcr-provider-a-provider"),
+                            false,
+                            false,
+                            Duration::from_secs(120),
+                            Some("grid-single-cluster-multi-gateway"),
+                            &drain_consumers,
+                        )
+                    })
+                    .and_then(|()| Ok(wait_for_candidate_set(&all_candidates)?))
+                    .and_then(|state| {
+                        let states = candidate_admission_states(&state, "vcr-provider-a-provider")?;
+                        observations.insert("individual_drain_overlay".to_owned(), state);
+                        if states.iter().all(|value| value == "existing_only") {
+                            Ok(())
+                        } else {
+                            Err(format!("individual drain did not produce existing_only: {states:?}").into())
+                        }
+                    })
+                    .and_then(|()| {
+                        let mut new_session_results = Vec::new();
+                        for request_id in 0..4 {
+                            for consumer in ["consumer-gateway-a", "consumer-gateway-b"] {
+                            let session = format!("new-drain-{consumer}-{request_id}");
+                            let RetriedProbe { headers, attempts } =
+                                attributed_request_with_transport_retry(consumer, 500 + request_id, Some(&session))?;
+                                let provider = selected_provider(&headers)?;
+                                if provider == "provider-a" {
+                                    return Err("new session selected individually drained provider-a".into());
+                                }
+                                new_session_results.push(serde_json::json!({
+                                    "consumer": consumer,
+                                "session": format!("new-drain-{consumer}-{request_id}"),
+                                "provider": provider,
+                                "attempts": attempts,
+                                }));
+                            }
+                        }
+                        observations.insert(
+                            "individual_drain_new_sessions".to_owned(),
+                            serde_json::Value::Array(new_session_results),
+                        );
+                        Ok(())
+                    })
+                    .and_then(|()| {
+                    let RetriedProbe { headers, attempts } = attributed_request_with_transport_retry(
+                        "consumer-gateway-a",
+                        550,
+                        Some(&existing_session),
+                    )?;
+                        let provider = selected_provider(&headers)?;
+                        observations.insert(
+                            "individual_drain_existing_session".to_owned(),
+                        serde_json::json!({"session": existing_session, "provider": provider, "headers": headers, "attempts": attempts}),
+                        );
+                        if provider == "provider-a" {
+                            Ok(())
+                        } else {
+                            Err("existing affinity session did not remain on provider-a".into())
+                        }
+                    });
+                restore.finish(result, "grid-single-cluster-multi-gateway", &drain_consumers)
+            };
+            scenarios.push(match individual_drain {
+                Ok(()) => scenario(
+                    "individual-provider-drain",
+                    "PASS",
+                    "one provider was capped at existing_only in both consumer overlays and restored",
+                ),
+                Err(error) => scenario("individual-provider-drain", "FAIL", error.to_string()),
+            });
+            let gateway_drain = {
+                let mut restore =
+                    RestorationGuard::new(&drain_context, &["vcr-provider-a-provider", "vcr-provider-b-provider"]);
+                let mut existing_a = String::new();
+                let mut existing_b = String::new();
+                let result = restore
+                    .ensure_snapshot()
+                    .and_then(|()| {
+                        session_for_provider("consumer-gateway-a", "provider-a", "existing-gateway-a")
+                            .map_err(Into::into)
+                    })
+                    .map(|session| existing_a = session)
+                    .and_then(|_| {
+                        session_for_provider("consumer-gateway-a", "provider-b", "existing-gateway-b")
+                            .map(|session| existing_b = session)
+                            .map_err(Into::into)
+                    })
+                    .and_then(|_| {
+                        super::provider_drain::run(
+                            &drain_context,
+                            Some("provider-gateway-a"),
+                            None,
+                            false,
+                            false,
+                            Duration::from_secs(120),
+                            Some("grid-single-cluster-multi-gateway"),
+                            &drain_consumers,
+                        )
+                    })
+                    .and_then(|()| Ok(wait_for_candidate_set(&all_candidates)?))
+                    .and_then(|state| {
+                        let a = candidate_admission_states(&state, "vcr-provider-a-provider")?;
+                        let b = candidate_admission_states(&state, "vcr-provider-b-provider")?;
+                        observations.insert("gateway_drain_overlay".to_owned(), state);
+                        if a.iter().all(|value| value == "existing_only")
+                            && b.iter().all(|value| value == "existing_only")
+                        {
+                            Ok(())
+                        } else {
+                            Err(format!("gateway drain states were not existing_only: a={a:?}, b={b:?}").into())
+                        }
+                    })
+                    .and_then(|()| restart_operator().map_err(Into::into))
+                    .and_then(|()| {
+                        let state = wait_for_candidate_set(&all_candidates)?;
+                        let a = candidate_admission_states(&state, "vcr-provider-a-provider")?;
+                        let b = candidate_admission_states(&state, "vcr-provider-b-provider")?;
+                        if a.iter().all(|value| value == "existing_only")
+                            && b.iter().all(|value| value == "existing_only")
+                        {
+                            observations.insert("gateway_drain_after_operator_restart".to_owned(), state);
+                            Ok(())
+                        } else {
+                            Err(format!("drain was not preserved across operator restart: a={a:?}, b={b:?}").into())
+                        }
+                    })
+                    .and_then(|()| {
+                        for (session, expected) in [(&existing_a, "provider-a"), (&existing_b, "provider-b")] {
+                            let RetriedProbe { headers, attempts } =
+                                attributed_request_with_transport_retry("consumer-gateway-a", 650, Some(session))?;
+                            observations.insert(
+                                format!("gateway_drain_existing_{expected}"),
+                                serde_json::json!({"session": session, "provider": expected, "attempts": attempts, "headers": headers}),
+                            );
+                            let actual = selected_provider(&headers)?;
+                            if actual != expected {
+                                return Err(
+                                    format!("existing affinity session moved from {expected} to {actual}").into()
+                                );
+                            }
+                        }
+                        for request_id in 0..4 {
+                            for consumer in ["consumer-gateway-a", "consumer-gateway-b"] {
+                            let session = format!("new-gateway-drain-{consumer}-{request_id}");
+                            let RetriedProbe { headers, attempts } =
+                                attributed_request_with_transport_retry(consumer, 600 + request_id, Some(&session))?;
+                                let provider = selected_provider(&headers)?;
+                            if provider == "provider-a" || provider == "provider-b" {
+                                return Err("new session selected a provider from drained gateway".into());
+                            }
+                            observations.insert(
+                                format!("gateway_drain_new_{consumer}_{request_id}"),
+                                serde_json::json!({"session": session, "provider": provider, "attempts": attempts, "headers": headers}),
+                            );
+                            }
+                        }
+                        Ok(())
+                    });
+                restore.finish(result, "grid-single-cluster-multi-gateway", &drain_consumers)
+            };
+            scenarios.push(match gateway_drain {
+                Ok(()) => scenario(
+                    "provider-gateway-drain",
+                    "PASS",
+                    "all explicitly assigned providers were drained together and restored",
+                ),
+                Err(error) => scenario("provider-gateway-drain", "FAIL", error.to_string()),
+            });
+            let invalid_selector = super::provider_drain::run(
+                &drain_context,
+                Some("gateway-that-does-not-exist"),
+                None,
+                false,
+                false,
+                Duration::from_secs(30),
+                None,
+                &[],
+            );
+            scenarios.push(match invalid_selector {
+                Ok(()) => scenario(
+                    "invalid-drain-selector",
+                    "FAIL",
+                    "unmatched gateway selector unexpectedly succeeded",
+                ),
+                Err(error) => scenario(
+                    "invalid-drain-selector",
+                    "PASS",
+                    format!("rejected without mutation: {error}"),
+                ),
+            });
             let withdrawal_result = scale_deployment("vcr-inference-provider-b", 0)
                 .and_then(|()| {
                     let expected = BTreeSet::from(["vcr-provider-a-provider", "vcr-provider-c-provider"]);
@@ -1182,6 +1652,54 @@ pub(crate) fn run(forge_config: &Path, options: &Options) -> Result<(), Box<dyn 
                     "provider gateway B was withdrawn, traffic continued through both consumers, and B was restored",
                 ),
                 Err(error) => scenario("withdrawal-restoration", "FAIL", error),
+            });
+            let unhealthy_drain_result = scale_deployment("vcr-inference-provider-c", 0)
+                .and_then(|()| {
+                    let expected = BTreeSet::from(["vcr-provider-a-provider", "vcr-provider-b-provider"]);
+                    wait_for_candidate_set(&expected).map(|_| ())
+                })
+                .and_then(|()| {
+                    super::provider_drain::run(
+                        &drain_context,
+                        None,
+                        Some("vcr-provider-c-provider"),
+                        false,
+                        false,
+                        Duration::from_secs(30),
+                        None,
+                        &[],
+                    )
+                    .map_err(|error| error.to_string())
+                })
+                .and_then(|()| {
+                    super::provider_drain::run(
+                        &drain_context,
+                        None,
+                        Some("vcr-provider-c-provider"),
+                        false,
+                        true,
+                        Duration::from_secs(30),
+                        None,
+                        &[],
+                    )
+                    .map_err(|error| error.to_string())
+                })
+                .and_then(|()| {
+                    let expected = BTreeSet::from(["vcr-provider-a-provider", "vcr-provider-b-provider"]);
+                    wait_for_candidate_set(&expected).map(|_| ())
+                })
+                .and_then(|()| scale_deployment("vcr-inference-provider-c", 1))
+                .and_then(|()| wait_for_candidate_set(&all_candidates).map(|_| ()))
+                .inspect_err(|_| {
+                    drop(scale_deployment("vcr-inference-provider-c", 1));
+                });
+            scenarios.push(match unhealthy_drain_result {
+                Ok(()) => scenario(
+                    "unhealthy-provider-precedence",
+                    "PASS",
+                    "drain and undrain did not promote an unhealthy provider; recovery restored it",
+                ),
+                Err(error) => scenario("unhealthy-provider-precedence", "FAIL", error),
             });
             let consumer_result = scale_deployment("consumer-gateway-a", 0)
                 .and_then(|()| attributed_request("consumer-gateway-b", 200).map(|_| ()))
@@ -1318,6 +1836,162 @@ pub(crate) fn run(forge_config: &Path, options: &Options) -> Result<(), Box<dyn 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn sessionless_and_affinity_request_arguments_are_unambiguous() {
+        let plain = build_request_args("consumer-a", 1, None).unwrap_or_else(|_| std::process::abort());
+        assert!(!plain.iter().any(|arg| arg.contains("Session-Id")));
+        assert!(!plain.iter().any(|arg| arg == "X-Session-Id"));
+        assert_eq!(plain.iter().filter(|arg| *arg == "--header").count(), 2);
+
+        let affinity =
+            build_request_args("consumer-a", 2, Some("existing-2")).unwrap_or_else(|_| std::process::abort());
+        assert_eq!(
+            affinity.iter().filter(|arg| arg.starts_with("X-Session-Id: ")).count(),
+            1
+        );
+        let header_index = affinity
+            .iter()
+            .position(|arg| arg == "X-Session-Id: existing-2")
+            .unwrap_or(usize::MAX);
+        assert!(header_index > 0 && affinity.get(header_index - 1).is_some_and(|value| value == "--header"));
+        assert_eq!(affinity.iter().filter(|arg| *arg == "--data").count(), 1);
+        assert!(
+            affinity
+                .iter()
+                .any(|arg| arg == "Authorization: Bearer qualification-token")
+        );
+        let invalid_session = build_request_args("consumer-a", 3, Some("bad\nvalue"));
+        assert!(invalid_session.is_err(), "control characters must be rejected");
+    }
+
+    #[test]
+    fn request_arguments_are_stable_except_for_request_identity() {
+        let first = build_request_args("consumer-a", 4, None).unwrap_or_else(|_| std::process::abort());
+        let second = build_request_args("consumer-a", 4, None).unwrap_or_else(|_| std::process::abort());
+        assert_eq!(first, second);
+        assert!(first.windows(2).any(|pair| pair == ["--max-time", "10"]));
+        assert!(first.last().is_some_and(|value| value.contains("/v1/chat/completions")));
+    }
+
+    #[test]
+    fn retry_decision_matrix_never_retries_http_responses_or_exceeds_three_attempts() {
+        for attempt in 1..=2 {
+            assert!(retry_decision(false, None, attempt));
+        }
+        assert!(!retry_decision(false, None, 3));
+        for status in [200, 401, 403, 429, 500, 503] {
+            assert!(!retry_decision(false, Some(status), 1));
+        }
+        assert!(!retry_decision(true, None, 1));
+        assert_eq!(http_status("pod deleted\nconnection reset"), None);
+        assert_eq!(http_status("status: 503"), None);
+        assert_eq!(http_status("HTTP/1.1 200 OK\n"), Some(200));
+    }
+
+    #[test]
+    fn retry_evidence_contains_no_credentials() {
+        let evidence = serde_json::json!({
+            "scenario": "drain",
+            "attempt": 1,
+            "transport": "error",
+            "http_status": null,
+            "retry": true,
+            "retry_reason": "transport_without_http_response",
+            "final": false,
+        });
+        let text = evidence.to_string();
+        assert!(!text.contains("Authorization"));
+        assert!(!text.contains("qualification-token"));
+        assert!(!text.contains("kubeconfig"));
+    }
+
+    #[test]
+    fn session_ids_are_reused_for_existing_and_unique_for_new_probes() {
+        let existing = session_id("existing", "consumer-a", 0);
+        assert_eq!(session_id("existing", "consumer-a", 0), existing);
+        let new_sessions = (0..4)
+            .map(|attempt| session_id("new-drain", "consumer-a", attempt))
+            .collect::<BTreeSet<_>>();
+        assert_eq!(new_sessions.len(), 4);
+    }
+
+    #[test]
+    fn retry_matrix_covers_transport_sequences_and_final_attempts() {
+        let cases = [
+            ("timeout", vec![(false, None), (true, Some(200))], 2, true),
+            ("reset", vec![(false, None), (false, None), (true, Some(200))], 3, true),
+            (
+                "three failures",
+                vec![(false, None), (false, None), (false, None)],
+                3,
+                false,
+            ),
+            ("429", vec![(false, Some(429))], 1, false),
+            ("503", vec![(false, Some(503))], 1, false),
+            ("wrong attribution", vec![(true, Some(200))], 1, true),
+        ];
+        for (name, outcomes, expected_attempts, expected_success) in cases {
+            let decisions = outcomes
+                .iter()
+                .enumerate()
+                .map(|(index, (success, status))| {
+                    retry_decision(*success, *status, u8::try_from(index).unwrap_or(0) + 1)
+                })
+                .collect::<Vec<_>>();
+            let attempts = decisions.iter().position(|retry| !retry).map_or(3, |index| index + 1);
+            assert_eq!(attempts, expected_attempts, "{name}");
+            assert_eq!(
+                decisions.last().is_some_and(|retry| !retry && expected_success),
+                expected_success,
+                "{name}"
+            );
+        }
+    }
+
+    #[test]
+    fn retry_evidence_is_ordered_structured_and_redacted() {
+        let evidence = [
+            retry_evidence("provider-drain", 1, false, None, None),
+            retry_evidence("provider-drain", 2, true, Some(200), Some("provider-a")),
+        ];
+        assert_eq!(
+            evidence.first().and_then(|item| item.get("attempt")),
+            Some(&serde_json::json!(1))
+        );
+        assert_eq!(
+            evidence.get(1).and_then(|item| item.get("attempt")),
+            Some(&serde_json::json!(2))
+        );
+        assert_eq!(
+            evidence.get(1).and_then(|item| item.get("provider")),
+            Some(&serde_json::json!("provider-a"))
+        );
+        assert_eq!(
+            evidence.get(1).and_then(|item| item.get("final")),
+            Some(&serde_json::json!(true))
+        );
+        let serialized = serde_json::to_string(&evidence).unwrap_or_else(|_| std::process::abort());
+        for secret in ["Authorization", "qualification-token", "kubeconfig", "secret-value"] {
+            assert!(!serialized.contains(secret), "serialized evidence leaked {secret}");
+        }
+    }
+
+    #[test]
+    fn restoration_and_failure_containment_decisions_are_conservative() {
+        assert!(
+            !restoration_undrain(true),
+            "a true original drain state restores with undrain=false"
+        );
+        assert!(
+            restoration_undrain(false),
+            "a false original drain state restores with undrain=true"
+        );
+        assert_eq!(scenario("session setup", "FAIL", "transport error").result, "FAIL");
+        assert_eq!(scenario("later safe scenario", "PASS", "independent").result, "PASS");
+        assert_eq!(retry_reason(false, Some(200), 1), "http_response_received");
+        assert_eq!(retry_reason(false, None, 3), "transport_retry_limit_reached");
+    }
 
     #[test]
     fn cluster_layers_use_distinct_names() {


### PR DESCRIPTION
## Summary

Adds reversible administrative draining for individual inference providers and for all providers explicitly associated with a provider gateway.

A drained provider remains in the routing overlay as `existing_only`: existing affinity sessions may continue using it, while new sessions are placed elsewhere. Health, trust, freshness, and exclusion decisions continue to take precedence, so draining or undraining cannot make an otherwise ineligible provider routable.

## Changes

- Adds `InferenceProvider.spec.trafficPolicy.drain` to the API, generated CRDs, and Helm schema/template.
- Adds optional `InferenceProvider.spec.gatewayRef` administrative grouping metadata.
- Applies administrative drain after the operator's existing health and eligibility evaluation.
- Adds `cargo xtask env provider-drain` with mutually exclusive `--provider` and `--gateway` selectors, dry-run support, bounded kubectl operations, and optional accepted/serving revision convergence checks.
- Restores providers after qualification failures and rolls back providers already changed when gateway-wide fan-out fails partway through.
- Extends the single-cluster multi-gateway qualification with individual drain, gateway-wide drain, affinity retention, new-session exclusion, operator restart persistence, unhealthy-provider precedence, invalid-selector handling, and restoration evidence.
- Documents the drain contract and operational workflow.

`gatewayRef` is grouping metadata used by the administrative command. Gateway-wide drain is an explicit client-side fan-out; it does not add request-time Grid behavior or infer membership from endpoint URLs.

## Validation

Static validation passed:

- `cargo test --workspace`: 561 passed
- `cargo clippy --workspace --all-targets -- -D warnings`
- `make test`
- `make doc`
- `make lint`
- nightly formatting check
- `git diff --check`
- Forge topology validation
- focused provider-drain tests: 23 passed

Fresh Kind validation from the final source passed twice:

- Run 2: 32/32 scenarios, automatic restoration and teardown passed
- Run 3: 32/32 scenarios, automatic restoration and teardown passed

The initial attempt used the mock-provider image for the VCR backend and failed before scenarios; its automatic cleanup passed. The two corrected runs used fresh role-appropriate images and completed successfully.

No AI or Praxis changes are included.
