### PR TITLE
test(quota): qualify three-application distributed quotas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@ tests/env/certs/
 # Forge runtime state and generated files
 .forge/
 tests/e2e/topologies/**/.forge.resolved.yaml
+tests/e2e/topologies/**/.forge.resolved.*.yaml
+tests/e2e/topologies/**/.forge.*/
+tests/e2e/topologies/**/.grid-*.resolved.yaml
 
 # Helm chart packaging artifacts
 *.tgz

--- a/charts/praxis-gateway/README.md
+++ b/charts/praxis-gateway/README.md
@@ -64,6 +64,7 @@ AI image; these values may advance independently.
 | `commonLabels` | object | `{}` | Labels added to all resources. |
 | `podLabels` | object | `{}` | Additional pod labels. Selector labels cannot be overridden. |
 | `podAnnotations` | object | `{}` | Pod annotations. |
+| `terminationGracePeriodSeconds` | integer | `null` | Optional maximum termination grace period for gateway pods. Qualification topologies set this explicitly. |
 | `podSecurityContext` | object | `{}` | Extra pod securityContext (`runAsUser`, `runAsGroup`, `fsGroup`, `supplementalGroups`). |
 | `args` | list | `["--config", "/etc/praxis/praxis.yaml"]` | Container arguments. |
 | `config.existingConfigMap` | string | **required** | Name of an existing ConfigMap with the Praxis config. |

--- a/charts/praxis-gateway/templates/deployment.yaml
+++ b/charts/praxis-gateway/templates/deployment.yaml
@@ -23,6 +23,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      {{- with .Values.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ . }}
+      {{- end }}
       automountServiceAccountToken: false
       {{- if and .Values.overlay.enabled .Values.overlay.sidecar.enabled }}
       serviceAccountName: {{ include "praxis-gateway.fullname" . }}-overlay-sync

--- a/charts/praxis-gateway/values.schema.json
+++ b/charts/praxis-gateway/values.schema.json
@@ -4,6 +4,11 @@
   "additionalProperties": false,
   "required": ["config"],
   "properties": {
+    "terminationGracePeriodSeconds": {
+      "type": ["integer", "null"],
+      "minimum": 1,
+      "description": "Maximum termination grace period for the gateway pod."
+    },
     "replicaCount": {
       "type": "integer",
       "minimum": 1,

--- a/charts/praxis-gateway/values.yaml
+++ b/charts/praxis-gateway/values.yaml
@@ -1,6 +1,11 @@
 # -- Number of gateway replicas.
 replicaCount: 1
 
+# -- Optional maximum time Kubernetes allows a terminating pod to finish.
+# Qualification topologies set this explicitly; leaving it null preserves
+# Kubernetes' default for general chart consumers.
+terminationGracePeriodSeconds: null
+
 # -- Gateway container image settings.
 image:
   # -- Image repository.

--- a/forge/src/command/up.rs
+++ b/forge/src/command/up.rs
@@ -76,7 +76,17 @@ fn ensure_network(
         }));
     }
     let existed_before_up = networking::network_exists(ctx.runner, binary, &net_name)?;
-    networking::create_network(ctx.runner, binary, &net_name, env_name)?;
+    networking::create_network(
+        ctx.runner,
+        binary,
+        &net_name,
+        env_name,
+        ctx.config
+            .spec
+            .network
+            .as_ref()
+            .and_then(|network| network.subnet.as_deref()),
+    )?;
     let cidr = networking::inspect_network_cidr(ctx.runner, binary, &net_name)?;
     set_network_active(state, &net_name, &cidr);
     state.network_created_by_forge = !existed_before_up;

--- a/forge/src/config.rs
+++ b/forge/src/config.rs
@@ -131,6 +131,9 @@ pub struct NetworkConfig {
     /// DNS zone for exported-service discovery (default `forge.test`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub dns_zone: Option<String>,
+    /// Optional IPv4 subnet for the managed cross-cluster network.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subnet: Option<String>,
 }
 
 impl NetworkConfig {

--- a/forge/src/config/validate.rs
+++ b/forge/src/config/validate.rs
@@ -20,6 +20,7 @@ pub fn validate(config: &ForgeConfig) -> Result<(), ForgeError> {
     check_kind(config)?;
     check_metadata_name(&config.metadata.name)?;
     check_network_name(&config.metadata.name, &config.spec)?;
+    check_network_subnet(&config.spec)?;
     check_cluster_names(config)?;
     check_cluster_nodes(config)?;
     check_service_names(config)?;
@@ -36,6 +37,15 @@ pub fn validate(config: &ForgeConfig) -> Result<(), ForgeError> {
     check_cross_cluster_provider(config)?;
     check_no_templates(config)?;
     Ok(())
+}
+
+/// Validate an explicitly configured Docker network subnet.
+fn check_network_subnet(spec: &crate::config::EnvironmentSpec) -> Result<(), ForgeError> {
+    let Some(subnet) = spec.network.as_ref().and_then(|network| network.subnet.as_deref()) else {
+        return Ok(());
+    };
+    crate::networking::validate_ipv4_cidr(subnet)
+        .map_err(|error| ForgeError::Validation(format!("network subnet is invalid: {error}")))
 }
 
 /// `apiVersion` must match the current schema.
@@ -1385,10 +1395,22 @@ spec:
         config.spec.network = Some(NetworkConfig {
             cross_cluster: true,
             dns_zone: None,
+            subnet: None,
         });
         validate(&config).unwrap_or_else(|_e| {
             std::process::abort();
         });
+    }
+
+    #[test]
+    fn invalid_network_subnet_is_rejected() {
+        let mut config = base_config();
+        config.spec.network = Some(NetworkConfig {
+            cross_cluster: true,
+            dns_zone: None,
+            subnet: Some("not-a-cidr".to_owned()),
+        });
+        assert!(validate(&config).is_err(), "invalid subnet must be rejected");
     }
 
     #[test]
@@ -1397,6 +1419,7 @@ spec:
         config.spec.network = Some(NetworkConfig {
             cross_cluster: false,
             dns_zone: None,
+            subnet: None,
         });
         validate(&config).unwrap_or_else(|_e| {
             std::process::abort();
@@ -1770,6 +1793,7 @@ spec:
         config.spec.network = Some(NetworkConfig {
             cross_cluster: true,
             dns_zone: Some("forge.test".to_owned()),
+            subnet: None,
         });
         assert!(validate(&config).is_ok(), "forge.test should be a valid dns zone");
     }
@@ -1780,18 +1804,21 @@ spec:
         config.spec.network = Some(NetworkConfig {
             cross_cluster: true,
             dns_zone: Some("UPPER.case".to_owned()),
+            subnet: None,
         });
         assert!(validate(&config).is_err(), "uppercase should be rejected");
 
         config.spec.network = Some(NetworkConfig {
             cross_cluster: true,
             dns_zone: Some(".leading-dot".to_owned()),
+            subnet: None,
         });
         assert!(validate(&config).is_err(), "leading dot should be rejected");
 
         config.spec.network = Some(NetworkConfig {
             cross_cluster: true,
             dns_zone: Some("nodot".to_owned()),
+            subnet: None,
         });
         assert!(validate(&config).is_err(), "no dot should be rejected");
     }
@@ -1822,6 +1849,7 @@ spec:
         config.spec.network = Some(NetworkConfig {
             cross_cluster: true,
             dns_zone: None,
+            subnet: None,
         });
         config.spec.stacks.insert(
             "net".to_owned(),
@@ -1858,6 +1886,7 @@ spec:
             config.spec.network = Some(NetworkConfig {
                 cross_cluster: true,
                 dns_zone: None,
+                subnet: None,
             });
             config.spec.stacks.insert(
                 "net".to_owned(),
@@ -1887,6 +1916,7 @@ spec:
             config.spec.network = Some(NetworkConfig {
                 cross_cluster: true,
                 dns_zone: None,
+                subnet: None,
             });
             config.spec.stacks.insert(
                 "net".to_owned(),
@@ -1914,6 +1944,7 @@ spec:
         config.spec.network = Some(NetworkConfig {
             cross_cluster: true,
             dns_zone: None,
+            subnet: None,
         });
         let Err(err) = validate(&config) else {
             std::process::abort();
@@ -1932,6 +1963,7 @@ spec:
         config.spec.network = Some(NetworkConfig {
             cross_cluster: true,
             dns_zone: None,
+            subnet: None,
         });
         validate(&config).unwrap_or_else(|_e| {
             std::process::abort();
@@ -1944,6 +1976,7 @@ spec:
         config.spec.network = Some(NetworkConfig {
             cross_cluster: true,
             dns_zone: None,
+            subnet: None,
         });
         validate(&config).unwrap_or_else(|_e| {
             std::process::abort();

--- a/forge/src/networking.rs
+++ b/forge/src/networking.rs
@@ -56,11 +56,12 @@ pub fn create_network(
     binary: &str,
     net_name: &str,
     env_name: &str,
+    subnet: Option<&str>,
 ) -> Result<(), ForgeError> {
     if network_exists(runner, binary, net_name)? {
         return verify_ownership(runner, binary, net_name, env_name);
     }
-    let spec = create_spec(binary, net_name, env_name);
+    let spec = create_spec(binary, net_name, env_name, subnet);
     let output = runner.run(&spec)?;
     check_success(&output, "network create")
 }
@@ -173,18 +174,23 @@ fn missing_label(net_name: &str, key: &str) -> ForgeError {
 // ---------------------------------------------------------------
 
 /// Build a `<binary> network create` command spec with labels.
-fn create_spec(binary: &str, net_name: &str, env_name: &str) -> CommandSpec {
+fn create_spec(binary: &str, net_name: &str, env_name: &str, subnet: Option<&str>) -> CommandSpec {
+    let mut args = vec![
+        "network".into(),
+        "create".into(),
+        "--label".into(),
+        "forge.managed=true".into(),
+        "--label".into(),
+        format!("forge.environment={env_name}").into(),
+    ];
+    if let Some(subnet) = subnet {
+        args.push("--subnet".into());
+        args.push(subnet.into());
+    }
+    args.push(net_name.into());
     CommandSpec {
         program: binary.into(),
-        args: vec![
-            "network".into(),
-            "create".into(),
-            "--label".into(),
-            "forge.managed=true".into(),
-            "--label".into(),
-            format!("forge.environment={env_name}").into(),
-            net_name.into(),
-        ],
+        args,
         env: BTreeMap::default(),
         stdin: None,
         redact: Vec::new(),
@@ -274,7 +280,7 @@ fn parse_ipam_config(stdout: &str) -> Result<String, ForgeError> {
 }
 
 /// Validate an IPv4 CIDR without accepting host-only or IPv6 forms.
-fn validate_ipv4_cidr(cidr: &str) -> Result<(), ForgeError> {
+pub(crate) fn validate_ipv4_cidr(cidr: &str) -> Result<(), ForgeError> {
     let (address, prefix) = cidr
         .split_once('/')
         .ok_or_else(|| ForgeError::State(format!("network subnet is not CIDR: {cidr:?}")))?;
@@ -365,10 +371,24 @@ mod tests {
         runner.respond("docker network inspect test-net", not_found());
         runner.respond("docker", ok());
 
-        create_network(&runner, "docker", "test-net", "test").unwrap_or_else(|_| std::process::abort());
+        create_network(&runner, "docker", "test-net", "test", None).unwrap_or_else(|_| std::process::abort());
         assert!(runner.was_called("network create"), "should call network create");
         assert!(runner.was_called("forge.managed=true"), "should include managed label");
         assert!(runner.was_called("forge.environment=test"), "should include env label");
+    }
+
+    #[test]
+    fn create_uses_explicit_subnet() {
+        let mut runner = MockRunner::new();
+        runner.respond("docker network inspect test-net", not_found());
+        runner.respond("docker", ok());
+
+        create_network(&runner, "docker", "test-net", "test", Some("10.251.0.0/16"))
+            .unwrap_or_else(|_| std::process::abort());
+        assert!(
+            runner.was_called("--subnet 10.251.0.0/16"),
+            "should pass configured subnet"
+        );
     }
 
     #[test]
@@ -380,7 +400,7 @@ mod tests {
             owned_labels("test"),
         );
 
-        create_network(&runner, "docker", "test-net", "test").unwrap_or_else(|_| std::process::abort());
+        create_network(&runner, "docker", "test-net", "test", None).unwrap_or_else(|_| std::process::abort());
         assert!(
             !runner.was_called("network create"),
             "should not create existing network"
@@ -396,7 +416,7 @@ mod tests {
             owned_labels("other-env"),
         );
 
-        let result = create_network(&runner, "docker", "test-net", "test");
+        let result = create_network(&runner, "docker", "test-net", "test", None);
         let Err(err) = result else {
             std::process::abort();
         };
@@ -416,7 +436,7 @@ mod tests {
             foreign_labels(),
         );
 
-        let result = create_network(&runner, "docker", "test-net", "test");
+        let result = create_network(&runner, "docker", "test-net", "test", None);
         assert!(result.is_err(), "should reject unmanaged network");
     }
 
@@ -589,7 +609,7 @@ mod tests {
         runner.respond("podman network inspect test-net", not_found());
         runner.respond("podman", ok());
 
-        create_network(&runner, "podman", "test-net", "test").unwrap_or_else(|_| std::process::abort());
+        create_network(&runner, "podman", "test-net", "test", None).unwrap_or_else(|_| std::process::abort());
         assert!(runner.was_called("podman"), "should use podman binary");
     }
 }

--- a/forge/src/stack.rs
+++ b/forge/src/stack.rs
@@ -760,6 +760,7 @@ mod tests {
         config.spec.network = Some(NetworkConfig {
             cross_cluster: true,
             dns_zone: None,
+            subnet: None,
         });
         let runner = crate::command::runner::MockRunner::new();
         let ctx = ForgeContext {

--- a/tests/e2e/topologies/grid-token-rate-limit/.gitignore
+++ b/tests/e2e/topologies/grid-token-rate-limit/.gitignore
@@ -1,1 +1,3 @@
 .forge/
+.forge.*/
+.forge.resolved.*.yaml

--- a/tests/e2e/topologies/grid-token-rate-limit/README.md
+++ b/tests/e2e/topologies/grid-token-rate-limit/README.md
@@ -1,248 +1,121 @@
-# Distributed Token Quota with Grid Routing
+# Distributed per-application token quota
 
-This Forge topology qualifies a shared sliding-window token budget in front
-of Grid-managed provider selection. It is separate from the generic
-provider-traffic and llm-d examples.
+This topology qualifies three Basic Auth applications sharing one inference
+endpoint and one Grid provider pool:
 
-```mermaid
-flowchart TB
-    Client[Alice]
-    subgraph West[West site - New York]
-        A[Consumer gateway A]
-        B[Consumer gateway B]
-        V[(Private Valkey)]
-        PW[New York provider gateway]
-        BW[VCR backend]
-    end
-    subgraph Central[Central site - London]
-        PC[London provider gateway]
-        BC[VCR backend]
-    end
-    subgraph East[East site - Tokyo]
-        PE[Tokyo provider gateway]
-        BE[VCR backend]
-    end
+- `application-a`
+- `application-b`
+- `application-c`
 
-    Client --> A
-    Client --> B
-    A <-->|shared atomic quota| V
-    B <-->|shared atomic quota| V
-    A -->|admitted requests| PW
-    A -->|admitted requests| PC
-    A -->|admitted requests| PE
-    B -->|admitted requests| PW
-    B -->|admitted requests| PC
-    B -->|admitted requests| PE
-    PW --> BW
-    PC --> BC
-    PE --> BE
+Both consumer gateway deployments expose the same endpoint and authenticate all
+three applications. Praxis publishes the verified subject as typed,
+request-scoped `AuthenticatedIdentity` metadata. The AI
+`token_rate_limit` filter uses `key: authenticated_subject` to partition one
+Valkey-backed rule into an independent bucket for each application.
+
+No client-controlled identity header, identity gateway, projection filter,
+trusted quota-group filter, or per-application listener is used.
+
+## Architecture
+
+```text
+application-a/b/c
+       |
+       | Basic Auth
+       v
+consumer-gateway-a or consumer-gateway-b
+       |
+       | AuthenticatedIdentity.subject_id
+       v
+token_rate_limit (one rule, subject-keyed, shared Valkey)
+       |
+       | admitted requests only
+       v
+Grid round-robin overlay -> west / central / east providers
 ```
 
-The city names are illustrative aliases for the `west`, `central`, and `east`
-test sites; they do not assert literal geographic placement.
+The two consumer replicas use the same Valkey namespace and rule. Therefore the
+same application's budget is shared across replicas, while different verified
+subjects receive independent buckets. The subject is hashed before it is used
+as a backend key and is not exposed in metrics or logs.
 
-The New York (`west`) cluster runs two independently addressable Praxis consumer deployments:
-`consumer-gateway-a` and `consumer-gateway-b`. Basic Auth gates access before
-both consumers apply Alice's shared rule-level sliding-window budget through
-one authenticated, cluster-private Valkey service. London (`central`) and Tokyo
-(`east`) remain attributable provider sites with their own VCR-backed provider
-gateways.
+Qualification evidence names the three fixed demo principals so reviewers can
+audit cross-subject isolation. Those labels are test-fixture identifiers, not
+backend keys or production telemetry; credentials and Authorization values are
+never recorded.
 
-The qualification admits only the `alice` Basic Auth principal, so its model-matched
-limiter rule represents Alice's budget. Both gateway instances address the same Valkey
-key. The quota therefore follows Alice's requests while Grid rotates admitted
-traffic among New York, London, and Tokyo; a regional route change never creates
-fresh capacity.
+Quota admission happens before Grid routing. A denied request returns HTTP 429
+without contacting a provider; changing provider or region cannot create quota.
 
-Current upstream AI keys this state by namespace and rule rather than consuming
-the authenticated username directly. Adding more independently budgeted users
-requires the trusted principal-key contract tracked in Grid issue 101.
+## Contract
 
-## Request Flow
+The filter uses reservation-based hard admission:
 
-```mermaid
-flowchart LR
-    R[Request] --> Auth{Basic Auth valid?}
-    Auth -->|no| Unauthorized[Reject without quota or provider contact]
-    Auth -->|yes| Model[Validate JSON model]
-    Model --> Quota{Shared reservation admitted?}
-    Quota -->|no| Limited[HTTP 429 without provider contact]
-    Quota -->|yes| Route[Grid overlay snapshot]
-    Route --> Pick[Round-robin provider selection]
-    Pick --> Provider[Provider gateway and VCR backend]
-    Provider --> Settle[Reconcile reservation with reported usage]
-```
+- sliding window: 60 seconds
+- capacity: 60 reserved tokens per application
+- reservation: 15 tokens per request
+- backend namespace: `praxis:grid-token-rate-limit`
+- rule: `per-application-budget`
+- key source: `authenticated_subject`
 
-The routing contract is Grid selection groups with `noMetrics` scoring and
-`selection_policy.mode: roundRobin`. No llm-d, EPP, pressure generator, queue
-metric, or KV-cache metric is part of this topology. Grid publishes routing
-state asynchronously and is not consulted during quota admission.
+The reservation cap controls admission. Actual usage replaces the reservation
+at settlement and may exceed the reservation estimate; settled usage is
+recorded as evidence rather than treated as a second hard cap.
 
-Valkey owns shared quota state only. Provider round-robin counters remain local
-to each consumer; this topology does not claim a globally synchronized provider
-sequence, cross-cluster Valkey reachability, or Valkey high availability.
+## Qualification coverage
 
-The Valkey password and connection URL are delivered through the `valkey-auth`
-Kubernetes Secret. Consumers receive the URL through a Secret-backed environment
-variable; the Praxis configuration supports the exact `${ENV_VAR}` form for this
-backend URL. The service is ClusterIP-only and its NetworkPolicy permits access
-only from the two quota-client consumer pods.
+The first-class runner preserves the hardened release harness:
 
-Before distributed measurement, the harness must wait for both consumers to
-serve the same overlay revision. Consumer restarts are not quota resets in this
-topology because the quota state remains in Valkey.
+- run-scoped Forge, Kind, network, and probe names with collision protection;
+- exact accepted/serving overlay revision convergence on both consumers;
+- bounded commands, transport-only retry, and persistent concurrency clients;
+- trusted provider attribution and structured request evidence;
+- invalid-auth rejection without quota reservation or provider contact;
+- independent A/B/C buckets through one endpoint;
+- shared exhaustion for the same application across both consumer replicas;
+- concurrent reservation-cap enforcement;
+- natural window expiry and recovery;
+- consumer restart persistence;
+- Valkey outage fail-closed behavior and recovery;
+- NetworkPolicy positive and negative controls;
+- guarded automatic cleanup with ownership evidence.
 
-## What This Demonstrates
+## Required sources and image
 
-| Capability | Behavior |
-|---|---|
-| Alice's sliding-window quota | One 60-token rolling window with a fixed 15-token reservation. |
-| Horizontal gateway scaling | Consumers A and B enforce the same Valkey namespace and Alice rule. |
-| Concurrent admission | Valkey serializes reservations against the shared budget. |
-| Actual-usage settlement | `token_count` records provider-reported usage before the limiter settles the reservation. |
-| Hard enforcement | Exhausted capacity returns 429 before `intelligent_route` or provider contact. |
-| Regional provider selection | Admitted requests rotate across New York, London, and Tokyo. |
-| Routing-independent quota | Changing the provider region does not change Alice's quota key or capacity. |
-| Restart and window recovery | State survives consumer restarts and capacity returns as usage ages out. |
+This integration requires the small Praxis change that makes Basic Auth publish
+the existing generic `AuthenticatedIdentity` extension and the AI change that
+adds `key: authenticated_subject` to `token_rate_limit`. The identity
+contract is authentication-method agnostic; OAuth/OIDC producers can publish
+the same type later without changing TRL.
 
-The shared rule uses the schema supported by upstream Praxis AI:
-
-```yaml
-filter: token_rate_limit
-backend:
-  kind: valkey
-  url: "${TOKEN_RATE_LIMIT_VALKEY_URL}"
-  namespace: praxis:grid-token-rate-limit
-rules:
-  - name: alice-shared-budget
-    match:
-      headers:
-        x-model: Qwen/Qwen3-0.6B
-    algorithm: sliding_window
-    window: 60s
-    capacity: 60
-    reserved_tokens: 15
-    reservation_timeout: 30s
-```
-
-The single-principal Basic Auth gate runs first. `json_body_field` then derives
-`X-Model` from the validated request body before the limiter matches the rule.
-Requests that are not authenticated as Alice, malformed payloads, unrelated
-paths, and other models do not reserve from Alice's inference budget. Health and
-administration use the separate admin listener and do not traverse this chain.
-
-## Regional Example
-
-| Request | Entry gateway | Selected provider site | Alice's quota |
-|---|---|---|---|
-| 1 | New York consumer A | New York (`west`) | Shared window |
-| 2 | New York consumer B | London (`central`) | Same shared window |
-| 3 | New York consumer A | Tokyo (`east`) | Same shared window |
-| 4 | New York consumer B | New York (`west`) | Same shared window |
-
-This is the important separation: Valkey answers whether Alice may spend more
-tokens, while Grid answers which eligible regional provider should serve an
-admitted request. Neither provider identity nor region participates in the
-quota key.
-
-## Expected Behavior
-
-1. Requests with invalid credentials stop at Basic Auth.
-2. Alice's requests arriving through either consumer reserve from the same
-   Valkey-backed window.
-3. An admitted request selects a provider from the accepted in-memory Grid
-   overlay; changing providers does not create a new budget.
-4. When the shared window cannot cover another reservation, the consumer
-   returns 429 without selecting or contacting a provider.
-5. Subsequent capacity reflects settlement and normal sliding-window expiry.
-
-The validation must capture every non-2xx response and verify provider request
-counts independently. It must not infer quota admission merely from timing or
-flush Valkey to simulate recovery.
-
-## Gateway Build Features
-
-The Praxis AI gateway image must enable both experimental filters used by this
-topology:
+The gateway image must be built from compatible Praxis and AI revisions with:
 
 ```text
 token-rate-limit-filter,praxis-filter/basic-auth-filter
 ```
 
-> **Published-image limitation:** The standard
-> `ghcr.io/praxis-proxy/ai:0.3.0` image does not contain these optional
-> filters because they are experimental, so it cannot run this qualification.
-> Supply a feature-enabled Praxis AI image explicitly. Grid publishes no
-> alternate AI rollup.
+Do not use a local Cargo path patch as deployment provenance. Land and version
+Praxis first, update AI to that released dependency, then build an immutable
+feature-enabled AI image. Grid does not build or publish an AI rollup.
 
-The second entry enables Basic Auth in AI's released `praxis-filter`
-dependency. It does not require a Praxis source checkout, Cargo patch, Git
-revision, or fork pin. Build AI from its own clean source tree and committed
-lockfile. Basic Auth stores the qualification credential in configuration and
-is not the production identity mechanism proposed by Grid issue 101.
+## Run
 
-AI v0.3.0's `Containerfile` does not expose a Cargo-feature build argument.
-Prepare a temporary Containerfile outside the AI worktree that adds the exact
-feature expression to both build-stage `cargo build` commands, then label the
-result so the qualification can verify its contract before creating clusters:
+Build fresh `grid-operator`, `grid-overlay-sync`, and feature-enabled
+`praxis-ai` images with one immutable tag, then run:
 
 ```bash
-AI_REPO=/path/to/clean/praxis-proxy-ai
-BUILD_DIR="$EVIDENCE_DIR/ai-image"
-mkdir -p "$BUILD_DIR"
-sed 's/cargo build --release -p praxis-ai-proxy/cargo build --release -p praxis-ai-proxy --features token-rate-limit-filter,praxis-filter\/basic-auth-filter/' \
-  "$AI_REPO/Containerfile" > "$BUILD_DIR/Containerfile"
-
-docker build \
-  --file "$BUILD_DIR/Containerfile" \
-  --label 'org.praxis-proxy.ai.features=token-rate-limit-filter,praxis-filter/basic-auth-filter' \
-  --tag "praxis-ai:$IMAGE_TAG" \
-  "$AI_REPO"
-```
-
-The temporary file is build input, not an AI source change. Do not add a Praxis
-path dependency or compose source from another checkout. The label is an early
-provenance check; gateway configuration loading remains the authoritative check
-that both filters are registered in the binary.
-
-## Running the qualification
-
-The qualification is a first-class xtask command. It materializes the Forge
-configuration with the exact locally built images, verifies the resolved
-references match what it loads into Kind (every qualification workload uses
-`pullPolicy: Never`, so a tag mismatch is rejected), deploys the topology in
-cross-cluster dependency order, runs every scenario, writes machine-readable
-evidence, and tears the clusters down.
-
-```bash
-# IMAGE_TAG is the tag of your locally built praxis-ai / grid-operator /
-# grid-overlay-sync images (all three share one tag).
 cargo xtask env run-grid-token-rate-limit-qualification \
+  --forge-config tests/e2e/topologies/grid-token-rate-limit/forge.yaml \
   --run-id quota-a1b2c3 \
   --image-tag "$IMAGE_TAG" \
   --evidence-dir "$EVIDENCE_DIR"
 ```
 
-Pass `--keep` to leave the clusters running for debugging. Evidence is written
-to `results.json` (machine-readable) and `summary.txt` (human-readable) in the
-evidence directory; neither contains credentials, authorization values, the
-Valkey password, or kubeconfig contents.
+`--run-id` is optional and must be a lowercase DNS-safe value of at most 24
+characters. Use `--keep` only for intentional debugging. A passing release
+qualification requires every functional scenario and automatic cleanup to
+pass; manual cleanup cannot produce PASS.
 
-Each invocation uses a unique validated run identity for its Forge environment,
-Kind clusters, kubectl contexts, Docker network, resolved Forge file, and probe
-names. The run-id option is optional; use a lowercase DNS-safe value such as
-quota-a1b2c3 for CI or reproducibility. Values must be 1-24 characters,
-contain only lowercase ASCII letters, digits, and hyphens, and start and end
-with an alphanumeric character. Explicit collisions fail before cluster
-creation; omitted IDs are generated and checked for collisions.
-
-Physical names are run-scoped, while logical site names (west, central, east),
-GridNetwork identity, provider candidate IDs, attribution, and the quota
-namespace remain stable. The runner records its ownership plan and deletes only
-resources created by that invocation. Resolved Forge files are removed after
-successful teardown, and a collision or cleanup failure is never reported as a
-qualification pass.
-
-The runner creates all clusters first, applies independent base stacks to every
-site, and only then applies stacks that consume cross-cluster captures. Directly
-applying one cluster's complete stack list cannot satisfy those dependencies.
+Evidence is written as `results.json` and `summary.txt`. Credentials,
+Authorization values, the Valkey password, and kubeconfig contents must never
+appear in evidence.

--- a/tests/e2e/topologies/grid-token-rate-limit/configs/consumer/praxis-valkey-a.yaml
+++ b/tests/e2e/topologies/grid-token-rate-limit/configs/consumer/praxis-valkey-a.yaml
@@ -1,101 +1,103 @@
+---
 insecure_options:
   allow_private_endpoints: true
-
 listeners:
-  - name: proxy
-    address: "0.0.0.0:8080"
-    filter_chains:
-      - main
-
+- name: proxy
+  address: 0.0.0.0:8443
+  filter_chains:
+  - main
 filter_chains:
-  - name: main
-    filters:
-      - filter: basic_auth
-        realm: "Grid token-rate-limit qualification"
-        strip_authorization: true
-        credentials:
-          - username: alice
-            password: alice-secret
-      - filter: json_body_field
-        field: model
-        header: X-Model
-      - filter: token_rate_limit
-        backend:
-          kind: valkey
-          url: "${TOKEN_RATE_LIMIT_VALKEY_URL}"
-          namespace: praxis:grid-token-rate-limit
-        rules:
-          - name: alice-shared-budget
-            match:
-              headers:
-                x-model: Qwen/Qwen3-0.6B
-            algorithm: sliding_window
-            window: 60s
-            capacity: 60
-            reserved_tokens: 15
-            reservation_timeout: 30s
-      - filter: headers
-        response_set:
-          - name: X-Grid-Quota-Consumer-Gateway
-            value: "consumer-gateway-a"
-      - filter: intelligent_route
-        overlay_file: /etc/praxis/routing/routing-overlay.json
-        model_header: X-Model
-        provider_hop_clusters:
-          - vcr-west-provider
-          - vcr-central-provider
-          - vcr-east-provider
-        expected_overlay_scope:
-          network: grid-token-rate-limit
-          gateway: consumer-gateway-a
-          namespace: grid-system
-          local_site: "{{ cluster.name }}"
-        reload:
-          enabled: true
-          debounce_ms: 500
-        session_affinity:
-          enabled: true
-          header: X-Session-Id
-          ttl_secs: 3600
-      - filter: token_count
-        provider: openai
-      - filter: load_balancer
-        clusters:
-          - name: vcr-west-provider
-            tls:
-              ca:
-                ca_path: /etc/praxis/tls/ca.crt
-              client_cert:
-                cert_path: /etc/praxis/tls/tls.crt
-                key_path: /etc/praxis/tls/tls.key
-              sni: provider-a.grid.internal
-              verify: true
-            endpoints:
-              - "{{ captures.west.provider-gateway-ip }}:8443"
-          - name: vcr-central-provider
-            tls:
-              ca:
-                ca_path: /etc/praxis/tls/ca.crt
-              client_cert:
-                cert_path: /etc/praxis/tls/tls.crt
-                key_path: /etc/praxis/tls/tls.key
-              sni: provider-b.grid.internal
-              verify: true
-            endpoints:
-              - "{{ captures.central.provider-gateway-ip }}:8443"
-          - name: vcr-east-provider
-            tls:
-              ca:
-                ca_path: /etc/praxis/tls/ca.crt
-              client_cert:
-                cert_path: /etc/praxis/tls/tls.crt
-                key_path: /etc/praxis/tls/tls.key
-              sni: provider-c.grid.internal
-              verify: true
-            endpoints:
-              - "{{ captures.east.provider-gateway-ip }}:8443"
-
+- name: main
+  filters:
+  - filter: basic_auth
+    realm: Grid distributed quota
+    strip_authorization: true
+    credentials:
+    - username: application-a
+      password: application-a-secret
+    - username: application-b
+      password: application-b-secret
+    - username: application-c
+      password: application-c-secret
+  - filter: json_body_field
+    field: model
+    header: X-Model
+  - filter: token_rate_limit
+    backend:
+      kind: valkey
+      url: "${TOKEN_RATE_LIMIT_VALKEY_URL}"
+      namespace: praxis:grid-token-rate-limit
+    rules:
+    - name: per-application-budget
+      match:
+        headers:
+          x-model: Qwen/Qwen3-0.6B
+      algorithm: sliding_window
+      window: 60s
+      capacity: 60
+      reserved_tokens: 15
+      reservation_timeout: 30s
+    key: authenticated_subject
+  - filter: headers
+    response_set:
+    - name: X-Grid-Quota-Consumer-Gateway
+      value: consumer-gateway-a
+  - filter: intelligent_route
+    overlay_file: "/etc/praxis/routing/routing-overlay.json"
+    model_header: X-Model
+    provider_hop_clusters:
+    - vcr-west-provider
+    - vcr-central-provider
+    - vcr-east-provider
+    expected_overlay_scope:
+      network: grid-token-rate-limit
+      gateway: consumer-gateway-a
+      namespace: grid-system
+      local_site: west
+    reload:
+      enabled: true
+      debounce_ms: 500
+    session_affinity:
+      enabled: true
+      header: X-Session-Id
+      ttl_secs: 3600
+  - filter: token_count
+    provider: openai
+  - filter: load_balancer
+    clusters:
+    - name: vcr-west-provider
+      tls:
+        ca:
+          ca_path: "/etc/praxis/tls/ca.crt"
+        client_cert:
+          cert_path: "/etc/praxis/tls/tls.crt"
+          key_path: "/etc/praxis/tls/tls.key"
+        sni: provider-a.grid.internal
+        verify: true
+      endpoints:
+      - "{{ captures.west.provider-gateway-ip }}:8443"
+    - name: vcr-central-provider
+      tls:
+        ca:
+          ca_path: "/etc/praxis/tls/ca.crt"
+        client_cert:
+          cert_path: "/etc/praxis/tls/tls.crt"
+          key_path: "/etc/praxis/tls/tls.key"
+        sni: provider-b.grid.internal
+        verify: true
+      endpoints:
+      - "{{ captures.central.provider-gateway-ip }}:8443"
+    - name: vcr-east-provider
+      tls:
+        ca:
+          ca_path: "/etc/praxis/tls/ca.crt"
+        client_cert:
+          cert_path: "/etc/praxis/tls/tls.crt"
+          key_path: "/etc/praxis/tls/tls.key"
+        sni: provider-c.grid.internal
+        verify: true
+      endpoints:
+      - "{{ captures.east.provider-gateway-ip }}:8443"
 admin:
-  address: "127.0.0.1:9901"
-
+  address: 127.0.0.1:9901
 shutdown_timeout_secs: 5

--- a/tests/e2e/topologies/grid-token-rate-limit/configs/consumer/praxis-valkey-b.yaml
+++ b/tests/e2e/topologies/grid-token-rate-limit/configs/consumer/praxis-valkey-b.yaml
@@ -1,101 +1,103 @@
+---
 insecure_options:
   allow_private_endpoints: true
-
 listeners:
-  - name: proxy
-    address: "0.0.0.0:8080"
-    filter_chains:
-      - main
-
+- name: proxy
+  address: 0.0.0.0:8443
+  filter_chains:
+  - main
 filter_chains:
-  - name: main
-    filters:
-      - filter: basic_auth
-        realm: "Grid token-rate-limit qualification"
-        strip_authorization: true
-        credentials:
-          - username: alice
-            password: alice-secret
-      - filter: json_body_field
-        field: model
-        header: X-Model
-      - filter: token_rate_limit
-        backend:
-          kind: valkey
-          url: "${TOKEN_RATE_LIMIT_VALKEY_URL}"
-          namespace: praxis:grid-token-rate-limit
-        rules:
-          - name: alice-shared-budget
-            match:
-              headers:
-                x-model: Qwen/Qwen3-0.6B
-            algorithm: sliding_window
-            window: 60s
-            capacity: 60
-            reserved_tokens: 15
-            reservation_timeout: 30s
-      - filter: headers
-        response_set:
-          - name: X-Grid-Quota-Consumer-Gateway
-            value: "consumer-gateway-b"
-      - filter: intelligent_route
-        overlay_file: /etc/praxis/routing/routing-overlay.json
-        model_header: X-Model
-        provider_hop_clusters:
-          - vcr-west-provider
-          - vcr-central-provider
-          - vcr-east-provider
-        expected_overlay_scope:
-          network: grid-token-rate-limit
-          gateway: consumer-gateway-b
-          namespace: grid-system
-          local_site: "{{ cluster.name }}"
-        reload:
-          enabled: true
-          debounce_ms: 500
-        session_affinity:
-          enabled: true
-          header: X-Session-Id
-          ttl_secs: 3600
-      - filter: token_count
-        provider: openai
-      - filter: load_balancer
-        clusters:
-          - name: vcr-west-provider
-            tls:
-              ca:
-                ca_path: /etc/praxis/tls/ca.crt
-              client_cert:
-                cert_path: /etc/praxis/tls/tls.crt
-                key_path: /etc/praxis/tls/tls.key
-              sni: provider-a.grid.internal
-              verify: true
-            endpoints:
-              - "{{ captures.west.provider-gateway-ip }}:8443"
-          - name: vcr-central-provider
-            tls:
-              ca:
-                ca_path: /etc/praxis/tls/ca.crt
-              client_cert:
-                cert_path: /etc/praxis/tls/tls.crt
-                key_path: /etc/praxis/tls/tls.key
-              sni: provider-b.grid.internal
-              verify: true
-            endpoints:
-              - "{{ captures.central.provider-gateway-ip }}:8443"
-          - name: vcr-east-provider
-            tls:
-              ca:
-                ca_path: /etc/praxis/tls/ca.crt
-              client_cert:
-                cert_path: /etc/praxis/tls/tls.crt
-                key_path: /etc/praxis/tls/tls.key
-              sni: provider-c.grid.internal
-              verify: true
-            endpoints:
-              - "{{ captures.east.provider-gateway-ip }}:8443"
-
+- name: main
+  filters:
+  - filter: basic_auth
+    realm: Grid distributed quota
+    strip_authorization: true
+    credentials:
+    - username: application-a
+      password: application-a-secret
+    - username: application-b
+      password: application-b-secret
+    - username: application-c
+      password: application-c-secret
+  - filter: json_body_field
+    field: model
+    header: X-Model
+  - filter: token_rate_limit
+    backend:
+      kind: valkey
+      url: "${TOKEN_RATE_LIMIT_VALKEY_URL}"
+      namespace: praxis:grid-token-rate-limit
+    rules:
+    - name: per-application-budget
+      match:
+        headers:
+          x-model: Qwen/Qwen3-0.6B
+      algorithm: sliding_window
+      window: 60s
+      capacity: 60
+      reserved_tokens: 15
+      reservation_timeout: 30s
+    key: authenticated_subject
+  - filter: headers
+    response_set:
+    - name: X-Grid-Quota-Consumer-Gateway
+      value: consumer-gateway-b
+  - filter: intelligent_route
+    overlay_file: "/etc/praxis/routing/routing-overlay.json"
+    model_header: X-Model
+    provider_hop_clusters:
+    - vcr-west-provider
+    - vcr-central-provider
+    - vcr-east-provider
+    expected_overlay_scope:
+      network: grid-token-rate-limit
+      gateway: consumer-gateway-b
+      namespace: grid-system
+      local_site: west
+    reload:
+      enabled: true
+      debounce_ms: 500
+    session_affinity:
+      enabled: true
+      header: X-Session-Id
+      ttl_secs: 3600
+  - filter: token_count
+    provider: openai
+  - filter: load_balancer
+    clusters:
+    - name: vcr-west-provider
+      tls:
+        ca:
+          ca_path: "/etc/praxis/tls/ca.crt"
+        client_cert:
+          cert_path: "/etc/praxis/tls/tls.crt"
+          key_path: "/etc/praxis/tls/tls.key"
+        sni: provider-a.grid.internal
+        verify: true
+      endpoints:
+      - "{{ captures.west.provider-gateway-ip }}:8443"
+    - name: vcr-central-provider
+      tls:
+        ca:
+          ca_path: "/etc/praxis/tls/ca.crt"
+        client_cert:
+          cert_path: "/etc/praxis/tls/tls.crt"
+          key_path: "/etc/praxis/tls/tls.key"
+        sni: provider-b.grid.internal
+        verify: true
+      endpoints:
+      - "{{ captures.central.provider-gateway-ip }}:8443"
+    - name: vcr-east-provider
+      tls:
+        ca:
+          ca_path: "/etc/praxis/tls/ca.crt"
+        client_cert:
+          cert_path: "/etc/praxis/tls/tls.crt"
+          key_path: "/etc/praxis/tls/tls.key"
+        sni: provider-c.grid.internal
+        verify: true
+      endpoints:
+      - "{{ captures.east.provider-gateway-ip }}:8443"
 admin:
-  address: "127.0.0.1:9901"
-
+  address: 127.0.0.1:9901
 shutdown_timeout_secs: 5

--- a/tests/e2e/topologies/grid-token-rate-limit/forge.yaml
+++ b/tests/e2e/topologies/grid-token-rate-limit/forge.yaml
@@ -11,6 +11,7 @@ spec:
 
   network:
     crossCluster: true
+    subnet: 10.251.0.0/16
     dnsZone: grid-token-rate-limit.test
 
   clusters:
@@ -690,6 +691,7 @@ spec:
           namespace: grid-system
           values:
             fullnameOverride: "consumer-gateway-a"
+            terminationGracePeriodSeconds: 10
             image:
               repository: "{{ cluster.properties.gatewayImageRepo }}"
               tag: "{{ cluster.properties.gatewayImageTag }}"
@@ -708,7 +710,17 @@ spec:
                   secretKeyRef:
                     name: valkey-auth
                     key: url
-            service: { type: LoadBalancer }
+            port: { containerPort: 8443, name: http, protocol: TCP }
+            service: { type: ClusterIP, port: 8443 }
+            health:
+              readiness:
+                tcpSocket: { port: http }
+                initialDelaySeconds: 3
+                periodSeconds: 5
+              liveness:
+                tcpSocket: { port: http }
+                initialDelaySeconds: 5
+                periodSeconds: 10
             overlay:
               enabled: true
               existingConfigMap: "grid-overlay-grid-token-rate-limit-consumer-gateway-a"
@@ -755,6 +767,7 @@ spec:
           namespace: grid-system
           values:
             fullnameOverride: "consumer-gateway-b"
+            terminationGracePeriodSeconds: 10
             image:
               repository: "{{ cluster.properties.gatewayImageRepo }}"
               tag: "{{ cluster.properties.gatewayImageTag }}"
@@ -773,7 +786,17 @@ spec:
                   secretKeyRef:
                     name: valkey-auth
                     key: url
-            service: { type: LoadBalancer }
+            port: { containerPort: 8443, name: http, protocol: TCP }
+            service: { type: ClusterIP, port: 8443 }
+            health:
+              readiness:
+                tcpSocket: { port: http }
+                initialDelaySeconds: 3
+                periodSeconds: 5
+              liveness:
+                tcpSocket: { port: http }
+                initialDelaySeconds: 5
+                periodSeconds: 10
             overlay:
               enabled: true
               existingConfigMap: "grid-overlay-grid-token-rate-limit-consumer-gateway-b"

--- a/xtask/src/env/forge_config.rs
+++ b/xtask/src/env/forge_config.rs
@@ -159,74 +159,76 @@ mod tests {
         clippy::too_many_lines,
         reason = "A test fixture should fail at the exact missing quota-contract field."
     )]
-    fn quota_consumers_use_the_upstream_limiter_schema_and_shared_rule() {
+    fn quota_consumers_expose_one_subject_keyed_application_listener() {
         let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../tests/e2e/topologies/grid-token-rate-limit");
-        let configs = [
-            root.join("configs/consumer/praxis-valkey-a.yaml"),
-            root.join("configs/consumer/praxis-valkey-b.yaml"),
+        let gateways = [
+            ("configs/consumer/praxis-valkey-a.yaml", "consumer-gateway-a"),
+            ("configs/consumer/praxis-valkey-b.yaml", "consumer-gateway-b"),
         ];
-        let mut quota_contract = None;
-
-        for path in configs {
+        for (rel, gateway) in gateways {
+            let path = root.join(rel);
             let source = fs::read_to_string(&path).expect("read quota consumer config");
-            for removed in ["reservationTimeout", "token_budgets", "estimation", "identity.user_id"] {
+            for removed in [
+                "identity_projection",
+                "trusted_quota_group",
+                "x-grid-quota-group",
+                "identity.user_id",
+            ] {
                 assert!(
                     !source.contains(removed),
-                    "{} still contains legacy field {removed}",
+                    "{} still references {removed}",
+                    path.display()
+                );
+            }
+            for user in ["application-a", "application-b", "application-c"] {
+                assert!(
+                    source.contains(&format!("username: {user}")),
+                    "{} missing {user}",
                     path.display()
                 );
             }
             assert!(
-                !source.contains("username: bob"),
-                "{} must remain a single-principal qualification",
+                source.contains(gateway),
+                "{} must name its own gateway {gateway}",
                 path.display()
             );
-
             let config: serde_yaml::Value = serde_yaml::from_str(&source).expect("parse quota consumer config");
-            let filters = config["filter_chains"][0]["filters"]
-                .as_sequence()
-                .expect("filter chain must contain filters");
-            let limiter = filters
-                .iter()
-                .find(|filter| filter["filter"].as_str() == Some("token_rate_limit"))
-                .expect("token_rate_limit filter must exist");
-            let contract = (
-                limiter["backend"]["namespace"].as_str().expect("namespace").to_owned(),
-                limiter["rules"][0]["name"].as_str().expect("rule name").to_owned(),
-                limiter["rules"][0]["algorithm"].as_str().expect("algorithm").to_owned(),
-                limiter["rules"][0]["window"].as_str().expect("window").to_owned(),
-                limiter["rules"][0]["capacity"].as_u64().expect("capacity"),
-                limiter["rules"][0]["reserved_tokens"]
-                    .as_u64()
-                    .expect("reserved tokens"),
-                limiter["rules"][0]["reservation_timeout"]
-                    .as_str()
-                    .expect("reservation timeout")
-                    .to_owned(),
-            );
-            assert_eq!(
-                contract,
-                (
-                    "praxis:grid-token-rate-limit".to_owned(),
-                    "alice-shared-budget".to_owned(),
-                    "sliding_window".to_owned(),
-                    "60s".to_owned(),
-                    60,
-                    15,
-                    "30s".to_owned(),
-                )
-            );
-            assert_eq!(
-                limiter["rules"][0]["match"]["headers"]["x-model"].as_str(),
-                Some("Qwen/Qwen3-0.6B"),
-                "quota must apply only to the validated inference model"
-            );
-
-            if let Some(expected) = quota_contract.as_ref() {
-                assert_eq!(&contract, expected, "both consumers must address the same Valkey rule");
-            } else {
-                quota_contract = Some(contract);
+            assert_eq!(config["listeners"].as_sequence().map(Vec::len), Some(1));
+            let chains = config["filter_chains"].as_sequence().expect("filter chains");
+            let mut contracts = Vec::new();
+            for chain in chains {
+                let filters = chain["filters"].as_sequence().expect("chain filters");
+                let Some(limiter) = filters
+                    .iter()
+                    .find(|f| f["filter"].as_str() == Some("token_rate_limit"))
+                else {
+                    continue;
+                };
+                let rule = &limiter["rules"][0];
+                assert_eq!(rule["algorithm"].as_str(), Some("sliding_window"));
+                assert_eq!(rule["window"].as_str(), Some("60s"));
+                assert_eq!(rule["capacity"].as_u64(), Some(60));
+                assert_eq!(rule["reserved_tokens"].as_u64(), Some(15));
+                assert_eq!(rule["reservation_timeout"].as_str(), Some("30s"));
+                assert_eq!(limiter["key"].as_str(), Some("authenticated_subject"));
+                assert_eq!(
+                    rule["match"]["headers"]["x-model"].as_str(),
+                    Some("Qwen/Qwen3-0.6B"),
+                    "quota applies only to the validated inference model"
+                );
+                contracts.push((
+                    limiter["backend"]["namespace"].as_str().expect("namespace").to_owned(),
+                    rule["name"].as_str().expect("rule name").to_owned(),
+                ));
             }
+            assert_eq!(
+                contracts,
+                [(
+                    "praxis:grid-token-rate-limit".to_owned(),
+                    "per-application-budget".to_owned()
+                )],
+                "each gateway must expose one shared rule partitioned by authenticated subject"
+            );
         }
     }
 }

--- a/xtask/src/env/kubectl.rs
+++ b/xtask/src/env/kubectl.rs
@@ -4,7 +4,14 @@
 //! invocations with no cluster-state knowledge and no orchestration logic.
 //! Call sites remain responsible for error context and sequencing.
 
-use std::{io::Write as _, process::Command};
+use std::{
+    fs,
+    io::Write as _,
+    os::unix::process::ExitStatusExt as _,
+    path::Path,
+    process::Command,
+    time::{SystemTime, UNIX_EPOCH},
+};
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -114,6 +121,19 @@ pub(crate) fn wait_for_rollout_ns(
     namespace: &str,
     cluster: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    wait_for_rollout_ns_with_evidence(context, deployment, namespace, cluster, None)
+}
+
+/// Evidence-aware rollout wait used by qualifications that own an evidence
+/// directory.  Diagnostics are deliberately best-effort and cannot replace
+/// the original rollout error.
+pub(crate) fn wait_for_rollout_ns_with_evidence(
+    context: &str,
+    deployment: &str,
+    namespace: &str,
+    cluster: &str,
+    evidence_dir: Option<&Path>,
+) -> Result<(), Box<dyn std::error::Error>> {
     let resource = format!("deployment/{deployment}");
     eprintln!("  waiting for {deployment} in {cluster} (ns={namespace})...");
     let status = Command::new("kubectl")
@@ -130,9 +150,172 @@ pub(crate) fn wait_for_rollout_ns(
         ])
         .status()?;
     if !status.success() {
+        capture_rollout_timeout(context, deployment, namespace, evidence_dir);
         return Err(format!("{deployment} rollout timed out in {cluster}").into());
     }
     Ok(())
+}
+
+/// Capture bounded deployment, pod, event, and log state after a rollout timeout.
+#[expect(
+    clippy::too_many_lines,
+    reason = "all rollout timeout state belongs to one failure boundary"
+)]
+fn capture_rollout_timeout(context: &str, deployment: &str, namespace: &str, evidence_dir: Option<&Path>) {
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |duration| duration.as_millis());
+    let directory = evidence_dir.map(|root| root.join(format!("rollout-timeout-{deployment}-{stamp}")));
+    if let Some(path) = &directory {
+        drop(fs::create_dir_all(path));
+    }
+
+    let deployment_json = diagnostic_command(context, namespace, &["get", "deployment", deployment, "-o", "json"]);
+    diagnostic_record(directory.as_deref(), "deployment.json", &deployment_json);
+
+    let selector = serde_json::from_slice::<serde_json::Value>(&deployment_json.stdout)
+        .ok()
+        .and_then(|value| {
+            value
+                .get("spec")?
+                .get("selector")?
+                .get("matchLabels")?
+                .as_object()
+                .cloned()
+        })
+        .map(|labels| {
+            labels
+                .iter()
+                .filter_map(|(key, value)| Some(format!("{key}={}", value.as_str()?)))
+                .collect::<Vec<_>>()
+                .join(",")
+        })
+        .filter(|value| !value.is_empty());
+    let selector_args = selector.as_deref().map_or_else(
+        || vec!["get", "pods", "-o", "wide"],
+        |value| vec!["get", "pods", "-l", value, "-o", "wide"],
+    );
+    let pods_wide = diagnostic_command(context, namespace, &selector_args);
+    diagnostic_record(directory.as_deref(), "pods-wide.txt", &pods_wide);
+    let replicasets = selector.as_deref().map_or_else(
+        || diagnostic_command(context, namespace, &["get", "replicasets", "-o", "wide"]),
+        |value| diagnostic_command(context, namespace, &["get", "replicasets", "-l", value, "-o", "wide"]),
+    );
+    diagnostic_record(directory.as_deref(), "replicasets.txt", &replicasets);
+    let events = diagnostic_command(context, namespace, &["get", "events", "--sort-by=.lastTimestamp"]);
+    diagnostic_record(directory.as_deref(), "events.txt", &events);
+    let describe = diagnostic_command(context, namespace, &["describe", "deployment", deployment]);
+    diagnostic_record(directory.as_deref(), "deployment-describe.txt", &describe);
+
+    #[expect(
+        clippy::collapsible_if,
+        reason = "keep command-output parsing separate from pod iteration"
+    )]
+    if let Ok(pods) = serde_json::from_slice::<serde_json::Value>(
+        &diagnostic_command(
+            context,
+            namespace,
+            &selector.as_deref().map_or_else(
+                || vec!["get", "pods", "-o", "json"],
+                |value| vec!["get", "pods", "-l", value, "-o", "json"],
+            ),
+        )
+        .stdout,
+    ) {
+        if let Some(items) = pods.get("items").and_then(serde_json::Value::as_array) {
+            for pod in items {
+                let Some(name) = pod
+                    .get("metadata")
+                    .and_then(|value| value.get("name"))
+                    .and_then(serde_json::Value::as_str)
+                else {
+                    continue;
+                };
+                let pod_file = format!("pod-{name}.json");
+                let pod_json = diagnostic_command(context, namespace, &["get", "pod", name, "-o", "json"]);
+                diagnostic_record(directory.as_deref(), &pod_file, &pod_json);
+                let described = diagnostic_command(context, namespace, &["describe", "pod", name]);
+                diagnostic_record(directory.as_deref(), &format!("pod-{name}-describe.txt"), &described);
+                if let Some(containers) = pod
+                    .get("spec")
+                    .and_then(|value| value.get("containers"))
+                    .and_then(serde_json::Value::as_array)
+                {
+                    for container in containers {
+                        let Some(container_name) = container.get("name").and_then(serde_json::Value::as_str) else {
+                            continue;
+                        };
+                        let current =
+                            diagnostic_command(context, namespace, &["logs", name, "-c", container_name, "--tail=100"]);
+                        diagnostic_record(
+                            directory.as_deref(),
+                            &format!("pod-{name}-{container_name}-current.log"),
+                            &current,
+                        );
+                        let previous = diagnostic_command(
+                            context,
+                            namespace,
+                            &["logs", name, "-c", container_name, "--previous", "--tail=100"],
+                        );
+                        diagnostic_record(
+                            directory.as_deref(),
+                            &format!("pod-{name}-{container_name}-previous.log"),
+                            &previous,
+                        );
+                    }
+                }
+            }
+        }
+    }
+    eprintln!(
+        "  rollout diagnostics captured for {deployment}{}",
+        directory
+            .as_ref()
+            .map_or(String::new(), |path| format!(" at {}", path.display()))
+    );
+}
+
+/// Run one bounded, best-effort diagnostic command.
+fn diagnostic_command(context: &str, namespace: &str, args: &[&str]) -> std::process::Output {
+    Command::new("timeout")
+        .args(["15s", "kubectl", "--context", context, "-n", namespace])
+        .args(args)
+        .output()
+        .unwrap_or_else(|error| std::process::Output {
+            status: std::process::ExitStatus::from_raw(1),
+            stdout: Vec::new(),
+            stderr: error.to_string().into_bytes(),
+        })
+}
+
+/// Redact and persist one diagnostic command result, also showing a short excerpt.
+fn diagnostic_record(directory: Option<&Path>, name: &str, output: &std::process::Output) {
+    let stdout = redact_diagnostic(&String::from_utf8_lossy(&output.stdout));
+    let stderr = redact_diagnostic(&String::from_utf8_lossy(&output.stderr));
+    let text = format!("exit={}\n\nstdout:\n{}\n\nstderr:\n{}\n", output.status, stdout, stderr);
+    if let Some(path) = directory {
+        drop(fs::write(path.join(name), &text));
+    }
+    eprintln!("{}", crate::env::safe_truncate_str(&text, 1_500));
+}
+
+/// Remove common credential-bearing diagnostic lines before evidence persistence.
+fn redact_diagnostic(value: &str) -> String {
+    value
+        .lines()
+        .map(|line| {
+            let lower = line.to_ascii_lowercase();
+            if ["authorization:", "password:", "token:", "secret:", "privatekey:"]
+                .iter()
+                .any(|key| lower.trim_start().starts_with(key))
+            {
+                "[REDACTED]".to_owned()
+            } else {
+                line.to_owned()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 // ---------------------------------------------------------------------------

--- a/xtask/src/env/token_rate_limit_qualification.rs
+++ b/xtask/src/env/token_rate_limit_qualification.rs
@@ -46,8 +46,6 @@ const CONSUMER_A: &str = "consumer-gateway-a";
 const CONSUMER_B: &str = "consumer-gateway-b";
 /// West consumer gateway releases that share one Alice quota.
 const CONSUMERS: [&str; 2] = [CONSUMER_A, CONSUMER_B];
-/// Data-plane listener port on each consumer gateway.
-const CONSUMER_PORT: &str = "8080";
 /// Response header the provider gateway sets for regional attribution.
 const PROVIDER_SITE_HEADER: &str = "x-grid-provider-site";
 /// Valkey key namespace for the shared sliding-window quota.
@@ -59,24 +57,77 @@ const CURL_IMAGE: &str = "curlimages/curl:8.12.1";
 /// Rule capacity in tokens for the shared Alice budget.
 const CAPACITY_TOKENS: u32 = 60;
 /// Reserved tokens per admitted request.
+///
+/// This is the pre-admission ESTIMATE the filter holds to decide admission
+/// before actual usage is known. The enforceable contract is a reservation cap
+/// (`active reserved tokens <= capacity`); settlement later replaces the
+/// estimate with actual usage, which may exceed the reservation. Size this
+/// conservatively (toward worst-case output) when settled usage should track
+/// nominal capacity more closely.
 const RESERVED_TOKENS: u32 = 15;
 /// Sliding-window length in seconds.
 const WINDOW_SECS: u64 = 60;
 /// Additional attempts allowed only when a probe receives no HTTP response.
 const TRANSPORT_RETRIES: u32 = 3;
+/// Additional attempts allowed for a restart-sensitive probe while a gateway
+/// becomes ready again and briefly returns a transient, non-quota status.
+const RESTART_PROBE_RETRIES: u32 = 5;
+/// Spacing between restart-sensitive probe retries.
+const RESTART_PROBE_INTERVAL: Duration = Duration::from_secs(3);
 /// Cargo features that must be compiled into the Praxis AI qualification image.
 const REQUIRED_GATEWAY_FEATURES: &str = "token-rate-limit-filter,praxis-filter/basic-auth-filter";
 /// OCI label used to make the gateway image's feature contract inspectable.
 const GATEWAY_FEATURES_LABEL: &str = "org.praxis-proxy.ai.features";
-/// Alice principal username.
-const ALICE_USER: &str = "alice";
-/// Alice principal password used only by this qualification topology.
-const ALICE_PASS: &str = "alice-secret";
+/// Application-A principal used by the legacy quota scenarios.
+const ALICE_USER: &str = "application-a";
+/// Application-A password used only by this qualification topology.
+const ALICE_PASS: &str = "application-a-secret";
+/// Application-B principal.
+const BOB_USER: &str = "application-b";
+/// Application-B password used only by this qualification topology.
+const BOB_PASS: &str = "application-b-secret";
+/// Application-C principal.
+const CAROL_USER: &str = "application-c";
+/// Application-C password used only by this qualification topology.
+const CAROL_PASS: &str = "application-c-secret";
 /// Inference request body; `max_tokens` is small to keep runs fast.
 const REQUEST_BODY: &str =
     r#"{"model":"Qwen/Qwen3-0.6B","messages":[{"role":"user","content":"hello"}],"max_tokens":1}"#;
 /// Inference route on the consumer data plane.
 const INFERENCE_PATH: &str = "/v1/chat/completions";
+/// Shared inference listener used by every authenticated application.
+const CONSUMER_PORT: u16 = 8443;
+/// Shared quota rule partitioned by the authenticated subject.
+const QUOTA_RULE: &str = "per-application-budget";
+
+/// One authenticated application sharing the consumer endpoint and TRL rule.
+/// Praxis's trusted subject identity partitions the rule into independent
+/// buckets, and both gateways share those buckets through Valkey.
+#[derive(Clone, Copy)]
+struct App {
+    /// Stable application principal (application-a/-b/-c).
+    name: &'static str,
+    /// The valid Basic Auth credential for this application.
+    credential: Credential,
+}
+
+/// Application A on the shared listener.
+const APP_A: App = App {
+    name: "application-a",
+    credential: Credential::Valid,
+};
+/// Application B on the shared listener.
+const APP_B: App = App {
+    name: "application-b",
+    credential: Credential::ValidB,
+};
+/// Application C on the shared listener.
+const APP_C: App = App {
+    name: "application-c",
+    credential: Credential::ValidC,
+};
+/// All three applications, in a stable order.
+const APPS: [App; 3] = [APP_A, APP_B, APP_C];
 /// Monotonic suffix source for unique probe pod names.
 static PROBE_SEQUENCE: AtomicUsize = AtomicUsize::new(0);
 
@@ -105,6 +156,10 @@ pub(crate) struct Options {
 enum Credential {
     /// Correct Alice basic-auth credential.
     Valid,
+    /// Correct application-B basic-auth credential.
+    ValidB,
+    /// Correct application-C basic-auth credential.
+    ValidC,
     /// Correct user, wrong password.
     WrongPassword,
     /// No `Authorization` header at all.
@@ -207,6 +262,9 @@ struct Evidence {
     warmup_window_reset_seconds: u64,
     /// Whether cluster teardown ran and succeeded.
     cleanup_succeeded: Option<bool>,
+    /// The stable per-application quota identities (namespace + rule) proven
+    /// independent in this run.
+    application_quota_identities: Vec<serde_json::Value>,
 }
 
 /// Physical names for one qualification invocation. Logical Grid identities
@@ -231,7 +289,10 @@ impl RunIdentity {
     /// Derive all physical names from one validated run suffix.
     fn new(run_id: &str) -> Self {
         let forge_name = format!("{PHYSICAL_PREFIX}-{run_id}");
-        let cluster_prefix = forge_name.clone();
+        // Keep the Forge environment and Docker network descriptive, but use
+        // a shorter Kind prefix. Kind embeds the full cluster name in the
+        // node hostname and kubeadm becomes unreliable with the longer form.
+        let cluster_prefix = format!("grid-tlr-{run_id}");
         let network = format!("{forge_name}-net");
         let kind_clusters = CLUSTERS
             .iter()
@@ -607,6 +668,8 @@ where
 fn credential_args(credential: Credential) -> Vec<String> {
     match credential {
         Credential::Valid => vec!["-u".to_owned(), format!("{ALICE_USER}:{ALICE_PASS}")],
+        Credential::ValidB => vec!["-u".to_owned(), format!("{BOB_USER}:{BOB_PASS}")],
+        Credential::ValidC => vec!["-u".to_owned(), format!("{CAROL_USER}:{CAROL_PASS}")],
         Credential::WrongPassword => vec!["-u".to_owned(), format!("{ALICE_USER}:wrong")],
         Credential::Missing => Vec::new(),
         Credential::Malformed => vec!["-H".to_owned(), "Authorization: Basic not-valid-base64".to_owned()],
@@ -717,14 +780,14 @@ fn consumer_for(index: usize) -> &'static str {
     }
 }
 
-/// Consumer service URL for the inference route.
-fn consumer_url(gateway: &str) -> String {
+/// URL of the shared application listener on a specific gateway deployment.
+fn gateway_app_url(gateway: &str) -> String {
     format!("http://{gateway}.{NAMESPACE}.svc.cluster.local:{CONSUMER_PORT}{INFERENCE_PATH}")
 }
 
-/// Issue one inference probe against a consumer gateway and record it.
+/// Issue one inference probe against a gateway's shared application listener.
 fn probe(label: &str, gateway: &str, credential: Credential) -> Result<HttpResult, Box<dyn std::error::Error>> {
-    let url = consumer_url(gateway);
+    let url = gateway_app_url(gateway);
     let args = curl_args(&url, credential, REQUEST_BODY);
     let output = run_curl_pod("west", label, &args)?;
     let (status, provider_site) = parse_probe_output(&String::from_utf8_lossy(&output.stdout));
@@ -806,8 +869,11 @@ fn create_concurrency_client(index: usize) -> Result<String, Box<dyn std::error:
 
 /// Issue one request from an already-running concurrency client.
 fn exec_concurrency_probe(pod: &str, label: &str, gateway: &str) -> Result<HttpResult, Box<dyn std::error::Error>> {
-    let url = consumer_url(gateway);
-    let curl = curl_args(&url, Credential::Valid, REQUEST_BODY);
+    // Concurrency samples one application (application-a) on an explicit gateway
+    // and listener port, exercising the same authenticated path as the ordinary
+    // probes.
+    let url = gateway_app_url(gateway);
+    let curl = curl_args(&url, APP_A.credential, REQUEST_BODY);
     let mut args = vec!["exec", pod, "--"];
     args.extend(curl.iter().map(String::as_str));
     let output = kubectl("west", &args, 30)?;
@@ -856,8 +922,8 @@ fn valkey_cli(query: &str, secs: u64) -> Result<String, Box<dyn std::error::Erro
 /// set; its cardinality is the trailing-window occupancy. Counter keys
 /// (`active-count`, `reservation-seq`) and the `:keys` index are intentionally
 /// excluded so this reflects real window consumption.
-fn quota_entries() -> Result<u64, Box<dyn std::error::Error>> {
-    let keys = valkey_cli(&format!("--scan --pattern \"{QUOTA_KEY_PREFIX}*:settled\""), 30)?;
+fn quota_entries(namespace: &str) -> Result<u64, Box<dyn std::error::Error>> {
+    let keys = valkey_cli(&format!("--scan --pattern \"{namespace}*:settled\""), 30)?;
     let mut total: u64 = 0;
     for key in keys.lines().filter(|line| !line.trim().is_empty()) {
         let card = valkey_cli(&format!("zcard \"{key}\""), 20)?;
@@ -866,9 +932,10 @@ fn quota_entries() -> Result<u64, Box<dyn std::error::Error>> {
     Ok(total)
 }
 
-/// Sum actual settled charges from the encoded sorted-set members.
-fn settled_tokens() -> Result<u64, Box<dyn std::error::Error>> {
-    let keys = valkey_cli(&format!("--scan --pattern \"{QUOTA_KEY_PREFIX}*:settled\""), 30)?;
+/// Sum actual settled charges from the encoded sorted-set members of one
+/// application's namespace.
+fn settled_tokens(namespace: &str) -> Result<u64, Box<dyn std::error::Error>> {
+    let keys = valkey_cli(&format!("--scan --pattern \"{namespace}*:settled\""), 30)?;
     let mut total = 0;
     for key in keys.lines().filter(|line| !line.trim().is_empty()) {
         let members = valkey_cli(&format!("zrange \"{key}\" 0 -1"), 20)?;
@@ -885,8 +952,8 @@ fn settled_tokens() -> Result<u64, Box<dyn std::error::Error>> {
 /// Every rule reservation in this topology uses the same fixed estimate, so
 /// the reserved-token total is derived without a slower key scan. Settled
 /// entries alone cannot distinguish a refund from a request never admitted.
-fn active_reservations() -> Result<(u64, u64), Box<dyn std::error::Error>> {
-    let value = valkey_cli(&format!("get \"{QUOTA_KEY_PREFIX}:active-count\""), 20)?;
+fn active_reservations(namespace: &str) -> Result<(u64, u64), Box<dyn std::error::Error>> {
+    let value = valkey_cli(&format!("get \"{namespace}:active-count\""), 20)?;
     let count = value.trim().parse::<u64>().unwrap_or(0);
     let tokens = count.saturating_mul(u64::from(RESERVED_TOKENS));
     Ok((count, tokens))
@@ -1072,15 +1139,21 @@ fn deploy(session: &Session) -> Result<(), Box<dyn std::error::Error>> {
     deploy_sites_and_trust(session)?;
     note("phase: valkey + consumers");
     deploy_consumers(session)?;
-    wait_for_consumers()?;
+    wait_for_consumers(session)?;
     Ok(())
 }
 
 /// Wait for both consumer gateway deployments to become available.
-fn wait_for_consumers() -> Result<(), Box<dyn std::error::Error>> {
+fn wait_for_consumers(session: &Session) -> Result<(), Box<dyn std::error::Error>> {
     let context = context_for("west");
     for gateway in CONSUMERS {
-        crate::env::kubectl::wait_for_rollout_ns(&context, gateway, NAMESPACE, "deployment")?;
+        crate::env::kubectl::wait_for_rollout_ns_with_evidence(
+            &context,
+            gateway,
+            NAMESPACE,
+            "deployment",
+            Some(&session.evidence),
+        )?;
     }
     Ok(())
 }
@@ -1202,10 +1275,14 @@ fn latest_log_field(logs: &str, field: &str) -> Option<String> {
 }
 
 /// Read a consumer gateway's Praxis-reported `(accepted, serving)` revisions.
+#[expect(
+    clippy::too_many_lines,
+    reason = "current and previous log fallback stays one diagnostic operation"
+)]
 fn consumer_praxis_revisions(gateway: &str) -> (Option<String>, Option<String>) {
     let context = context_for("west");
     let deployment = format!("deployment/{gateway}");
-    let args = [
+    let base_args = [
         "--context",
         &context,
         "-n",
@@ -1216,14 +1293,35 @@ fn consumer_praxis_revisions(gateway: &str) -> (Option<String>, Option<String>) 
         "praxis",
         "--tail=400",
     ];
-    let logs = match spawn_timed("kubectl", &args, 30) {
-        Ok(output) if output.status.success() => strip_csi_sgr(&String::from_utf8_lossy(&output.stdout)),
-        _ => return (None, None),
+    let read = |previous: bool| {
+        let mut args = base_args.to_vec();
+        if previous {
+            args.push("--previous");
+        }
+        spawn_timed("kubectl", &args, 30)
+            .ok()
+            .filter(|output| output.status.success())
+            .map(|output| strip_csi_sgr(&String::from_utf8_lossy(&output.stdout)))
     };
-    (
-        latest_log_field(&logs, "accepted_revision"),
-        latest_log_field(&logs, "serving_revision"),
-    )
+    let current = read(false);
+    let previous = read(true);
+    let accepted = current
+        .as_deref()
+        .and_then(|logs| latest_log_field(logs, "accepted_revision"))
+        .or_else(|| {
+            previous
+                .as_deref()
+                .and_then(|logs| latest_log_field(logs, "accepted_revision"))
+        });
+    let serving = current
+        .as_deref()
+        .and_then(|logs| latest_log_field(logs, "serving_revision"))
+        .or_else(|| {
+            previous
+                .as_deref()
+                .and_then(|logs| latest_log_field(logs, "serving_revision"))
+        });
+    (accepted, serving)
 }
 
 /// Observe one consumer: its accepted overlay plus Praxis accepted/serving revisions.
@@ -1251,7 +1349,7 @@ fn short_rev(value: &str) -> &str {
 ///
 /// Returns the validated overlays and the shared revision only when, for both
 /// consumers: the overlay is valid, the Grid revision is nonempty, and Praxis's
-/// accepted and serving revisions both equal it — and both consumers share one
+/// accepted and serving revisions both equal it - and both consumers share one
 /// current revision.
 fn convergence_ready(observations: &[ConsumerObservation]) -> Option<(Overlays, String)> {
     if observations.len() != CONSUMERS.len() {
@@ -1375,24 +1473,94 @@ fn probe_with_transport_retry(
     Err("transport retry loop ended without a result".into())
 }
 
+/// Probe through a gateway that may be mid-restart.
+///
+/// A gateway that has completed its rollout but is not yet serving briefly
+/// returns an unexpected non-quota status (classified [`Outcome::Other`]) or no
+/// response. This retries only those transient infrastructure outcomes and
+/// returns as soon as a definitive quota decision is observed. Real quota
+/// (`429`), fail-closed (`503`), and auth (`401`) outcomes are never retried
+/// away, and a persistent transient still fails once the bound is reached.
+fn probe_after_restart(
+    results: &mut Vec<HttpResult>,
+    label: &str,
+    gateway: &str,
+    credential: Credential,
+) -> Result<HttpResult, Box<dyn std::error::Error>> {
+    let mut result = probe_with_transport_retry(results, label, gateway, credential)?;
+    for attempt in 0..RESTART_PROBE_RETRIES {
+        if classify(result.status) != Outcome::Other {
+            return Ok(result);
+        }
+        results.push(result);
+        std::thread::park_timeout(RESTART_PROBE_INTERVAL);
+        result = probe_with_transport_retry(
+            results,
+            &format!("{label}-restart-retry-{attempt}"),
+            gateway,
+            credential,
+        )?;
+    }
+    Ok(result)
+}
+
 /// Scenario: valid Alice auth is admitted on both gateways with attribution.
-fn scenario_valid_auth(results: &mut Vec<HttpResult>) -> Result<ScenarioResult, Box<dyn std::error::Error>> {
+/// Return whether attribution covers every and only configured provider site.
+fn covers_all_provider_sites(distribution: &BTreeMap<String, u32>) -> bool {
+    CLUSTERS
+        .iter()
+        .all(|site| distribution.get(*site).is_some_and(|count| *count > 0))
+        && distribution.keys().all(|site| CLUSTERS.contains(&site.as_str()))
+}
+
+/// Probe one authenticated application and record its trusted attribution.
+fn record_valid_auth_probe(
+    results: &mut Vec<HttpResult>,
+    distribution: &mut BTreeMap<String, u32>,
+    facts: &mut BTreeMap<String, serde_json::Value>,
+    app: App,
+    gateway: &str,
+) -> Result<bool, Box<dyn std::error::Error>> {
+    let result = probe_with_transport_retry(
+        results,
+        &format!("valid-{}-{gateway}", app.name),
+        gateway,
+        app.credential,
+    )?;
+    let site = result.provider_site.clone();
+    if let Some(observed) = &site {
+        *distribution.entry(observed.clone()).or_insert(0) += 1;
+    }
+    let admitted = record(results, result) == Outcome::Admitted;
+    facts.insert(
+        format!("{}-{gateway}", app.name),
+        serde_json::json!({ "admitted": admitted, "site": site }),
+    );
+    Ok(admitted && site.is_some())
+}
+
+/// Verify every application on both shared consumer endpoints.
+fn scenario_valid_auth(
+    results: &mut Vec<HttpResult>,
+    distribution: &mut BTreeMap<String, u32>,
+) -> Result<ScenarioResult, Box<dyn std::error::Error>> {
     let mut facts = BTreeMap::new();
     let mut ok = true;
-    for gateway in CONSUMERS {
-        let result = probe_with_transport_retry(results, &format!("valid-{gateway}"), gateway, Credential::Valid)?;
-        let site = result.provider_site.clone();
-        let admitted = record(results, result) == Outcome::Admitted;
-        facts.insert(
-            gateway.to_owned(),
-            serde_json::json!({ "admitted": admitted, "site": site }),
-        );
-        ok = ok && admitted && site.is_some();
+    for app in APPS {
+        for gateway in CONSUMERS {
+            ok = record_valid_auth_probe(results, distribution, &mut facts, app, gateway)? && ok;
+        }
     }
+    let all_provider_sites_observed = covers_all_provider_sites(distribution);
+    facts.insert(
+        "all_provider_sites_observed".to_owned(),
+        serde_json::json!(all_provider_sites_observed),
+    );
     Ok(scenario(
         "valid_auth",
-        ok,
-        "Alice admitted with regional attribution".to_owned(),
+        ok && all_provider_sites_observed,
+        "each application is admitted on the shared endpoint on both gateways, with trusted attribution spanning west, central, and east"
+            .to_owned(),
         facts,
     ))
 }
@@ -1410,13 +1578,13 @@ fn probe_and_record(
 
 /// Scenario: missing and malformed auth are rejected before any reservation.
 fn scenario_auth_rejection(results: &mut Vec<HttpResult>) -> Result<ScenarioResult, Box<dyn std::error::Error>> {
-    let before = quota_entries()?;
+    let before = quota_entries(QUOTA_KEY_PREFIX)?;
     let outcomes = [
         probe_and_record(results, "missing-auth", CONSUMER_A, Credential::Missing)?,
         probe_and_record(results, "malformed-auth", CONSUMER_A, Credential::Malformed)?,
         probe_and_record(results, "wrong-password", CONSUMER_A, Credential::WrongPassword)?,
     ];
-    let after = quota_entries()?;
+    let after = quota_entries(QUOTA_KEY_PREFIX)?;
     let all_401 = outcomes.iter().all(|outcome| *outcome == Outcome::Unauthorized);
     let statuses = outcomes
         .iter()
@@ -1435,9 +1603,9 @@ fn scenario_auth_rejection(results: &mut Vec<HttpResult>) -> Result<ScenarioResu
 
 /// Scenario: readiness/probe traffic does not consume the inference quota.
 fn scenario_probe_no_quota() -> Result<ScenarioResult, Box<dyn std::error::Error>> {
-    let before = quota_entries()?;
+    let before = quota_entries(QUOTA_KEY_PREFIX)?;
     std::thread::park_timeout(Duration::from_secs(15));
-    let after = quota_entries()?;
+    let after = quota_entries(QUOTA_KEY_PREFIX)?;
     let spec = kubectl(
         "west",
         &[
@@ -1465,12 +1633,21 @@ fn scenario_probe_no_quota() -> Result<ScenarioResult, Box<dyn std::error::Error
 
 /// Exhaust the shared budget from one gateway; return admitted provider sites.
 fn exhaust_budget(results: &mut Vec<HttpResult>) -> Result<ExhaustOutcome, Box<dyn std::error::Error>> {
+    exhaust_budget_for(results, Credential::Valid, "a")
+}
+
+/// Exhaust one application's independent typed quota rule.
+fn exhaust_budget_for(
+    results: &mut Vec<HttpResult>,
+    credential: Credential,
+    principal: &str,
+) -> Result<ExhaustOutcome, Box<dyn std::error::Error>> {
     let attempts = (CAPACITY_TOKENS / RESERVED_TOKENS).saturating_add(4);
     let mut sites = Vec::new();
     let mut saw_denied = false;
     for index in 0..attempts {
         let gateway = consumer_for(index as usize);
-        let result = probe_with_transport_retry(results, &format!("exhaust-{index}"), gateway, Credential::Valid)?;
+        let result = probe_with_transport_retry(results, &format!("exhaust-{principal}-{index}"), gateway, credential)?;
         if let Some(site) = result.provider_site.clone() {
             sites.push(site);
         }
@@ -1481,31 +1658,66 @@ fn exhaust_budget(results: &mut Vec<HttpResult>) -> Result<ExhaustOutcome, Box<d
     Ok((sites, saw_denied))
 }
 
-/// Scenario: both gateways share one Alice budget and route across all sites.
-fn scenario_shared_budget(
+/// Scenario: all three independently mapped applications have isolated rules.
+#[expect(
+    clippy::too_many_lines,
+    reason = "three explicit application assertions are intentionally visible"
+)]
+fn scenario_three_application_independence(
     results: &mut Vec<HttpResult>,
-    distribution: &mut BTreeMap<String, u32>,
 ) -> Result<ScenarioResult, Box<dyn std::error::Error>> {
-    reset_window();
-    let (sites, saw_denied) = exhaust_budget(results)?;
-    for site in &sites {
-        *distribution.entry(site.clone()).or_insert(0) += 1;
+    let mut facts = BTreeMap::new();
+    let mut passed = true;
+    for app in APPS {
+        reset_window();
+        // Exhaust this application's budget across BOTH gateways (rotating).
+        let (_, denied_during_exhaust) = exhaust_budget_for(results, app.credential, app.name)?;
+        // The exhausted application is denied on BOTH gateway deployments: the
+        // same application on a different gateway sees the same namespace/rule
+        // ledger (shared exhaustion).
+        let mut denied_on_both = true;
+        for gateway in CONSUMERS {
+            let result = probe_with_transport_retry(
+                results,
+                &format!("indep-{}-denied-{gateway}", app.name),
+                gateway,
+                app.credential,
+            )?;
+            denied_on_both = denied_on_both && record(results, result) == Outcome::QuotaDenied;
+        }
+        // The other two authenticated subjects remain admitted even though all
+        // three share the same endpoint, namespace, and rule.
+        let mut others_admitted = true;
+        for other in APPS {
+            if other.name == app.name {
+                continue;
+            }
+            let result = probe_with_transport_retry(
+                results,
+                &format!("indep-{}-peer-{}", app.name, other.name),
+                CONSUMER_A,
+                other.credential,
+            )?;
+            others_admitted = others_admitted && record(results, result) == Outcome::Admitted;
+        }
+        let ok = denied_during_exhaust && denied_on_both && others_admitted;
+        passed &= ok;
+        facts.insert(
+            app.name.to_owned(),
+            serde_json::json!({
+                "namespace": QUOTA_KEY_PREFIX,
+                "rule": QUOTA_RULE,
+                "denied_on_both_gateways": denied_on_both,
+                "other_applications_admitted": others_admitted,
+                "authenticated_subject": app.name,
+            }),
+        );
     }
-    let denied_b =
-        classify(probe_with_transport_retry(results, "shared-b-after-exhaust", CONSUMER_B, Credential::Valid)?.status);
-    let all_sites = CLUSTERS.iter().all(|site| distribution.contains_key(*site));
-    let facts = BTreeMap::from([
-        ("distribution".to_owned(), serde_json::json!(distribution)),
-        (
-            "second_gateway_denied".to_owned(),
-            serde_json::json!(denied_b == Outcome::QuotaDenied),
-        ),
-    ]);
-    let passed = saw_denied && all_sites && denied_b == Outcome::QuotaDenied;
     Ok(scenario(
-        "shared_budget_and_distribution",
+        "three_application_independent_quota_isolation",
         passed,
-        "shared budget; routed across sites".to_owned(),
+        "one shared rule is partitioned by authenticated subject; exhausting one application denies it on both gateways while the others stay admitted"
+            .to_owned(),
         facts,
     ))
 }
@@ -1547,7 +1759,7 @@ fn concurrent_admitted(count: usize) -> Result<ConcurrentEvidence, Box<dyn std::
     let mut max_active = 0;
     let mut max_active_tokens = 0;
     while completed.load(Ordering::Relaxed) < count {
-        let (active, tokens) = active_reservations()?;
+        let (active, tokens) = active_reservations(QUOTA_KEY_PREFIX)?;
         max_active = max_active.max(active);
         max_active_tokens = max_active_tokens.max(tokens);
         if start.elapsed() >= Duration::from_secs(90) {
@@ -1582,15 +1794,34 @@ fn concurrent_admitted(count: usize) -> Result<ConcurrentEvidence, Box<dyn std::
 /// 60/15 arithmetic assumption. Completed requests may reconcile below their
 /// reservation and refund capacity, so five successful responses alone do not
 /// prove over-admission.
+#[expect(
+    clippy::too_many_lines,
+    reason = "the reservation-cap assertions and their evidence are kept explicit"
+)]
 fn scenario_concurrency(results: &mut Vec<HttpResult>) -> Result<ScenarioResult, Box<dyn std::error::Error>> {
     reset_window();
     let burst = 8;
     let concurrent = concurrent_admitted(burst)?;
+    // Denied requests must never have reached a provider: a reservation refused
+    // at admission carries no provider-site attribution.
+    let denied_reached_provider = concurrent
+        .results
+        .iter()
+        .any(|result| classify(result.status) != Outcome::Admitted && result.provider_site.is_some());
     results.extend(concurrent.results);
-    let settled = settled_tokens()?;
+    let settled = settled_tokens(QUOTA_KEY_PREFIX)?;
+    // Settlement replaces each reservation estimate with actual usage. When a
+    // request consumes more than its reservation, settled tokens legitimately
+    // exceed capacity. This is an accounting observation, not over-admission,
+    // and must not gate the result.
+    let settled_exceeds_reservation = settled > concurrent.max_active_tokens;
     let facts = BTreeMap::from([
         ("concurrent_burst".to_owned(), serde_json::json!(burst)),
         ("concurrent_admitted".to_owned(), serde_json::json!(concurrent.admitted)),
+        (
+            "expected_reserved_admissions".to_owned(),
+            serde_json::json!(CAPACITY_TOKENS / RESERVED_TOKENS),
+        ),
         (
             "max_active_reservations".to_owned(),
             serde_json::json!(concurrent.max_active),
@@ -1600,13 +1831,25 @@ fn scenario_concurrency(results: &mut Vec<HttpResult>) -> Result<ScenarioResult,
             serde_json::json!(concurrent.max_active_tokens),
         ),
         ("settled_actual_tokens".to_owned(), serde_json::json!(settled)),
+        (
+            "settled_exceeds_reservation".to_owned(),
+            serde_json::json!(settled_exceeds_reservation),
+        ),
+        (
+            "denied_reached_provider".to_owned(),
+            serde_json::json!(denied_reached_provider),
+        ),
     ]);
+    // The enforceable contract is a reservation cap: active reserved tokens
+    // never exceed capacity, admission is partial under an over-burst, and no
+    // denied request reaches a provider. Settled actual usage is recorded as
+    // evidence but is not a hard bound.
     let passed = concurrent.admitted >= 1
         && concurrent.admitted < burst
         && concurrent.max_active >= 2
         && concurrent.max_active_tokens > u64::from(RESERVED_TOKENS)
         && concurrent.max_active_tokens <= u64::from(CAPACITY_TOKENS)
-        && settled <= u64::from(CAPACITY_TOKENS);
+        && !denied_reached_provider;
     Ok(scenario(
         "concurrency_no_over_admission",
         passed,
@@ -1643,19 +1886,22 @@ fn scenario_window_expiry(results: &mut Vec<HttpResult>) -> Result<ScenarioResul
 }
 
 /// Scenario: restarting a consumer preserves Valkey-backed quota state.
-fn scenario_restart_persistence(results: &mut Vec<HttpResult>) -> Result<ScenarioResult, Box<dyn std::error::Error>> {
+fn scenario_restart_persistence(
+    session: &Session,
+    results: &mut Vec<HttpResult>,
+) -> Result<ScenarioResult, Box<dyn std::error::Error>> {
     reset_window();
     exhaust_budget(results)?;
-    let before = quota_entries()?;
-    let peer_before = probe("peer-before-restart", CONSUMER_B, Credential::Valid)?;
+    let before = quota_entries(QUOTA_KEY_PREFIX)?;
+    let peer_before = probe_with_transport_retry(results, "peer-before-restart", CONSUMER_B, Credential::Valid)?;
     let peer_before_outcome = classify(peer_before.status);
     record(results, peer_before);
-    restart_consumer(CONSUMER_A)?;
-    let after = quota_entries()?;
-    let peer_after = probe("peer-after-restart", CONSUMER_B, Credential::Valid)?;
+    restart_consumer(CONSUMER_A, session)?;
+    let after = quota_entries(QUOTA_KEY_PREFIX)?;
+    let peer_after = probe_after_restart(results, "peer-after-restart", CONSUMER_B, Credential::Valid)?;
     let peer_after_outcome = classify(peer_after.status);
     record(results, peer_after);
-    let post_restart = probe("restarted-consumer", CONSUMER_A, Credential::Valid)?;
+    let post_restart = probe_after_restart(results, "restarted-consumer", CONSUMER_A, Credential::Valid)?;
     let post_restart_status = post_restart.status;
     let post_restart_outcome = classify(post_restart.status);
     record(results, post_restart);
@@ -1676,10 +1922,17 @@ fn scenario_restart_persistence(results: &mut Vec<HttpResult>) -> Result<Scenari
 }
 
 /// Restart one west consumer and wait for the namespace-scoped rollout.
-fn restart_consumer(consumer: &str) -> Result<(), Box<dyn std::error::Error>> {
+fn restart_consumer(consumer: &str, session: &Session) -> Result<(), Box<dyn std::error::Error>> {
     let context = context_for("west");
     kubectl("west", &["rollout", "restart", &format!("deployment/{consumer}")], 60)?;
-    crate::env::kubectl::wait_for_rollout_ns(&context, consumer, NAMESPACE, "deployment")
+    crate::env::kubectl::wait_for_rollout_ns_with_evidence(
+        &context,
+        consumer,
+        NAMESPACE,
+        "deployment",
+        Some(&session.evidence),
+    )?;
+    Ok(())
 }
 
 /// Scale the Valkey deployment to a replica count and wait for rollout.
@@ -1939,6 +2192,11 @@ fn materialize(
         .ok_or("--image-tag is required for a Never-pull run")?;
     let content = fs::read_to_string(&options.forge_config)?;
     let mut config: serde_yaml::Value = serde_yaml::from_str(&content)?;
+    // The consumer configs are complete static three-listener policies checked
+    // into the topology (one application-scoped listener per app). They are used
+    // as-is; nothing is regenerated from a fixture, so deployed configuration is
+    // exactly what is reviewed in the repository.
+    let _ = state_dir;
     apply_run_identity(&mut config, names);
     rewrite_context_references(&mut config, names);
     rewrite_exec_state_references(&mut config, state_dir);
@@ -2030,6 +2288,30 @@ fn apply_run_identity(config: &mut serde_yaml::Value, names: &RunIdentity) {
             serde_yaml::Value::String(names.cluster_prefix.clone()),
         );
     }
+    if let Some(network) = config
+        .get_mut("spec")
+        .and_then(serde_yaml::Value::as_mapping_mut)
+        .and_then(|spec| spec.get_mut("network"))
+        .and_then(serde_yaml::Value::as_mapping_mut)
+    {
+        network.insert(
+            serde_yaml::Value::String("subnet".to_owned()),
+            serde_yaml::Value::String(qualification_subnet(&names.run_id)),
+        );
+    }
+}
+
+/// Choose a deterministic private /24 for one run so Docker's default pool
+/// allocation cannot collide with other qualification networks or stale IPAM
+/// reservations. The run ID remains the source of uniqueness.
+fn qualification_subnet(run_id: &str) -> String {
+    let mut hash = 0x811C_9DC5_u32;
+    for byte in run_id.bytes() {
+        hash ^= u32::from(byte);
+        hash = hash.wrapping_mul(0x0100_0193);
+    }
+    let third_octet = 20 + (hash % 200);
+    format!("10.240.{third_octet}.0/24")
 }
 
 /// Rewrite only the topology's known fixed kubectl context tokens. Logical
@@ -2150,18 +2432,22 @@ fn verify_resolved_names(resolved: &Path, names: &RunIdentity) -> Result<(), Box
 /// A scenario that hits an operational error is recorded as a failed scenario
 /// (with the error in its detail) rather than aborting the run, so evidence is
 /// always written and no failure is hidden.
-fn run_scenarios(results: &mut Vec<HttpResult>, distribution: &mut BTreeMap<String, u32>) -> Vec<ScenarioResult> {
+fn run_scenarios(
+    session: &Session,
+    results: &mut Vec<HttpResult>,
+    distribution: &mut BTreeMap<String, u32>,
+) -> Vec<ScenarioResult> {
     vec![
         guarded("probe_no_quota", scenario_probe_no_quota()),
-        guarded("valid_auth", scenario_valid_auth(results)),
+        guarded("valid_auth", scenario_valid_auth(results, distribution)),
         guarded("auth_rejection", scenario_auth_rejection(results)),
         guarded(
-            "shared_budget_and_distribution",
-            scenario_shared_budget(results, distribution),
+            "three_application_independent_quota_isolation",
+            scenario_three_application_independence(results),
         ),
         guarded("concurrency_no_over_admission", scenario_concurrency(results)),
         guarded("window_expiry_recovery", scenario_window_expiry(results)),
-        guarded("restart_persistence", scenario_restart_persistence(results)),
+        guarded("restart_persistence", scenario_restart_persistence(session, results)),
         guarded("valkey_outage_fail_closed", scenario_valkey_outage(results)),
         guarded("network_policy_denies_unauthorized", scenario_network_policy()),
     ]
@@ -2191,11 +2477,27 @@ fn logged(result: ScenarioResult) -> ScenarioResult {
 }
 
 /// Assemble and persist the evidence document plus a human summary.
+#[expect(
+    clippy::too_many_lines,
+    reason = "the evidence document is assembled field-by-field for auditability"
+)]
 fn persist_evidence(
     session: &Session,
     collected: Collected,
     cleanup_succeeded: Option<bool>,
 ) -> Result<bool, Box<dyn std::error::Error>> {
+    let application_quota_identities = APPS
+        .iter()
+        .map(|app| {
+            serde_json::json!({
+                "application": app.name,
+                "listener_port": CONSUMER_PORT,
+                "authenticated_subject": app.name,
+                "valkey_namespace": QUOTA_KEY_PREFIX,
+                "rule": QUOTA_RULE,
+            })
+        })
+        .collect::<Vec<_>>();
     let all_passed = collected.scenarios.iter().all(|scenario| scenario.passed);
     let summary = summarize(&collected.scenarios, &collected.distribution);
     let evidence = Evidence {
@@ -2213,6 +2515,7 @@ fn persist_evidence(
         scenarios: collected.scenarios,
         warmup_window_reset_seconds: collected.warmup_window_reset_seconds,
         cleanup_succeeded,
+        application_quota_identities,
     };
     write_json(&session.evidence.join("results.json"), &evidence)?;
     fs::write(session.evidence.join("summary.txt"), summary)?;
@@ -2318,7 +2621,7 @@ fn qualify(session: &Session) -> Result<Collected, Box<dyn std::error::Error>> {
         "warmup quota reset completed after {warmup_window_reset_seconds}s of natural window aging"
     ));
     let mut distribution = BTreeMap::new();
-    let scenarios = run_scenarios(&mut results, &mut distribution);
+    let scenarios = run_scenarios(session, &mut results, &mut distribution);
     Ok(Collected {
         overlays,
         results,
@@ -2334,10 +2637,15 @@ fn qualify(session: &Session) -> Result<Collected, Box<dyn std::error::Error>> {
 /// hidden or treated as normal). This readiness gate is distinct from overlay
 /// convergence; the overlay existing does not mean routing is live.
 fn await_data_plane_ready(results: &mut Vec<HttpResult>) -> Result<(), Box<dyn std::error::Error>> {
-    for gateway in CONSUMERS {
+    for (index, gateway) in CONSUMERS.iter().enumerate() {
+        let credential = if index == 0 {
+            Credential::Valid
+        } else {
+            Credential::ValidB
+        };
         let start = Instant::now();
         loop {
-            let result = probe("warmup", gateway, Credential::Valid)?;
+            let result = probe("warmup", gateway, credential)?;
             let ready = classify(result.status) == Outcome::Admitted && result.provider_site.is_some();
             note(&format!(
                 "warmup {gateway}: status={} site={:?}",
@@ -2418,7 +2726,7 @@ mod tests {
         assert!(credential_args(Credential::Missing).is_empty());
         assert_eq!(
             credential_args(Credential::Valid),
-            vec!["-u".to_owned(), "alice:alice-secret".to_owned()]
+            vec!["-u".to_owned(), "application-a:application-a-secret".to_owned()]
         );
         assert!(credential_args(Credential::Malformed).contains(&"Authorization: Basic not-valid-base64".to_owned()));
     }
@@ -2624,8 +2932,8 @@ mod tests {
     #[test]
     fn run_identity_separates_physical_names_from_logical_sites() {
         let names = RunIdentity::new("quota-a1b2c3");
-        assert_eq!(names.kind_cluster("west"), "grid-token-rate-limit-quota-a1b2c3-west");
-        assert_eq!(names.context("west"), "kind-grid-token-rate-limit-quota-a1b2c3-west");
+        assert_eq!(names.kind_cluster("west"), "grid-tlr-quota-a1b2c3-west");
+        assert_eq!(names.context("west"), "kind-grid-tlr-quota-a1b2c3-west");
         assert_eq!(names.network, "grid-token-rate-limit-quota-a1b2c3-net");
         assert_eq!(CLUSTERS, ["west", "central", "east"]);
         assert!(names.kind_clusters.values().all(|value| value.len() <= 63));
@@ -2642,9 +2950,18 @@ mod tests {
     }
 
     #[test]
+    fn qualification_subnets_are_private_bounded_and_run_derived() {
+        let first = qualification_subnet("threeapp-one");
+        let second = qualification_subnet("threeapp-two");
+        assert_ne!(first, second);
+        assert!(first.starts_with("10.240."));
+        assert!(first.ends_with(".0/24"));
+    }
+
+    #[test]
     fn materialized_config_contains_run_identity_and_preserves_logical_resources() {
         let mut config: serde_yaml::Value = serde_yaml::from_str(
-            "apiVersion: forge.praxis.dev/v1alpha1\nkind: Environment\nmetadata:\n  name: grid-token-rate-limit\nspec:\n  runtime:\n    provider: docker\n    clusterPrefix: grid-token-rate-limit\n  clusters: []\n",
+            "apiVersion: forge.praxis.dev/v1alpha1\nkind: Environment\nmetadata:\n  name: grid-token-rate-limit\nspec:\n  runtime:\n    provider: docker\n    clusterPrefix: grid-token-rate-limit\n  network:\n    crossCluster: true\n  clusters: []\n",
         )
         .unwrap();
         let names = RunIdentity::new("quota-a1b2c3");
@@ -2655,18 +2972,16 @@ mod tests {
         rewrite_context_references(&mut config, &names);
         let rendered = serde_yaml::to_string(&config).unwrap();
         assert!(rendered.contains("name: grid-token-rate-limit-quota-a1b2c3"));
-        assert!(rendered.contains("clusterPrefix: grid-token-rate-limit-quota-a1b2c3"));
+        assert!(rendered.contains("clusterPrefix: grid-tlr-quota-a1b2c3"));
+        assert!(rendered.contains("subnet: 10.240."));
         assert!(!rendered.contains("clusterPrefix: grid-token-rate-limit\n"));
         assert_eq!(
             context.as_str(),
-            Some("kubectl --context kind-grid-token-rate-limit-quota-a1b2c3-west get pods")
+            Some("kubectl --context kind-grid-tlr-quota-a1b2c3-west get pods")
         );
         let mut template = serde_yaml::Value::String("kind-grid-token-rate-limit-{{ cluster.name }}".to_owned());
         rewrite_context_references(&mut template, &names);
-        assert_eq!(
-            template.as_str(),
-            Some("kind-grid-token-rate-limit-quota-a1b2c3-{{ cluster.name }}")
-        );
+        assert_eq!(template.as_str(), Some("kind-grid-tlr-quota-a1b2c3-{{ cluster.name }}"));
     }
 
     #[test]
@@ -2679,5 +2994,57 @@ mod tests {
         let rendered = serde_yaml::to_string(&config).unwrap();
         assert!(rendered.contains("target: .forge/runtime/west/provider/praxis.yaml"));
         assert!(rendered.contains("cat topology/.forge.quota-a1b2c3/runtime/west/provider/praxis.yaml"));
+    }
+
+    #[test]
+    fn restart_probe_retries_only_transient_non_quota_outcomes() {
+        // Definitive quota, fail-closed, and auth decisions must never be
+        // retried away by probe_after_restart (its gate is `!= Outcome::Other`).
+        for status in [200_u16, 429, 503, 401] {
+            assert_ne!(
+                classify(status),
+                Outcome::Other,
+                "status {status} must be a definitive outcome"
+            );
+        }
+        // A gateway that is not yet serving (or gave no response) classifies as
+        // Other and is retried within the bound.
+        for status in [0_u16, 500, 502, 504] {
+            assert_eq!(
+                classify(status),
+                Outcome::Other,
+                "status {status} should be treated as transient"
+            );
+        }
+    }
+
+    #[test]
+    fn applications_share_the_endpoint_and_rule_but_not_subject_identity() {
+        let names = APPS
+            .iter()
+            .map(|app| app.name)
+            .collect::<std::collections::BTreeSet<_>>();
+        assert_eq!(names.len(), 3);
+        assert_eq!(QUOTA_KEY_PREFIX, "praxis:grid-token-rate-limit");
+        assert_eq!(QUOTA_RULE, "per-application-budget");
+        assert_eq!(CONSUMER_PORT, 8443);
+    }
+
+    #[test]
+    fn provider_coverage_requires_every_and_only_expected_site() {
+        let complete = BTreeMap::from([
+            ("west".to_owned(), 2),
+            ("central".to_owned(), 2),
+            ("east".to_owned(), 2),
+        ]);
+        assert!(covers_all_provider_sites(&complete));
+
+        let mut missing = complete.clone();
+        missing.remove("east");
+        assert!(!covers_all_provider_sites(&missing));
+
+        let mut unknown = complete;
+        unknown.insert("unknown".to_owned(), 1);
+        assert!(!covers_all_provider_sites(&unknown));
     }
 }


### PR DESCRIPTION
## Summary

Extends the distributed token-quota topology and first-class qualification to prove three independent application quotas through one shared consumer endpoint.

`application-a`, `application-b`, and `application-c` authenticate with Basic Auth on the same listener. Praxis publishes the verified subject privately; Praxis AI uses that subject as the quota key; Grid routes admitted requests across the shared west, central, and east provider overlay.

This keeps three responsibilities separate:

- Praxis establishes the authenticated subject.
- Praxis AI admits or denies against that subject's distributed token budget.
- Grid selects an eligible provider only after admission.

## What the qualification proves

- Three credentials use one endpoint and one quota rule configuration.
- Each authenticated subject receives an independent quota.
- The same subject shares one Valkey-backed budget across both consumer gateways, so scaling replicas does not multiply capacity.
- Exhausting one subject denies it on both gateways while the other subjects remain admitted.
- Missing, invalid, and cross-subject credentials are rejected before provider contact.
- Denied quota requests do not reach a provider.
- Admitted traffic covers all three attributable Grid provider sites.
- Concurrent reservations do not exceed configured reservation capacity.
- Natural window expiry restores admission.
- Quota state survives consumer restart.
- Valkey outage fails closed and recovery restores service.
- NetworkPolicy positive and negative controls hold.
- Accepted and serving overlay revisions converge before traffic.
- Run-owned clusters, networks, and generated Forge state are cleaned automatically.

## Topology changes

- Keeps two consumer gateways with identical quota configuration and one shared listener.
- Removes the temporary public identity gateway, projected identity headers, trusted-group filter, and private identity hop.
- Uses `key: authenticated_subject` with one common rule and Valkey namespace; the verified subject partitions the ledger securely.
- Retains the three provider sites and Grid round-robin overlay.
- Adds run-scoped Forge state and generated-config ignore rules.

## Quota contract

Admission is reservation-based because actual response usage is unknown before routing. The enforced invariant is:

```text
active reserved tokens <= capacity
```

Settlement records actual usage after the response. Actual settled usage may exceed the reservation estimate without indicating over-admission. Provider distribution is sampled independently from tight quota boundaries.

## Cross-repository dependencies

This PR is the Grid qualification and reference topology for a contract implemented across repositories:

1. praxis-proxy/praxis#1108 publishes a successfully verified Basic Auth username as private request-local `AuthenticatedIdentity`.
2. praxis-proxy/ai#980 adds `key: authenticated_subject`, consumes that trusted identity, and hashes it into an opaque quota key.
3. This PR proves three independent subject quotas across gateway replicas and Grid providers.
4. The companion Demos PR packages the same topology for users.

The identity type is authentication-method-neutral. Basic Auth enables this demo now, while JWT/OIDC/OAuth-backed authentication can publish the same identity for reuse by the AI quota filter.

Related to #101 and praxis-proxy/ai#121.
Depends on praxis-proxy/praxis#1108 and praxis-proxy/ai#980.

## Validation

Two fresh Kind qualifications passed all 9 scenarios with automatic teardown. Static validation included xtask tests, workspace Clippy, formatting, `make test`, `make doc`, `make lint`, Forge validation, and `git diff --check`.

Evidence and generated `.forge.resolved.*.yaml` files are excluded from the commit.

## Landing order

Keep this PR open until Praxis #1108 is released and AI #980 consumes that release. Then rebuild the feature-enabled AI image from committed dependencies and rerun the qualification before merge.

Companion demo: praxis-proxy/demos#20.
