### PR TITLE
feat(swim): resolve DNS endpoint hostnames

### DIFF
--- a/charts/grid-operator/README.md
+++ b/charts/grid-operator/README.md
@@ -138,7 +138,7 @@ helm upgrade grid-operator oci://ghcr.io/praxis-proxy/charts/grid-operator \
 | `swim.bindAddress` | string | `0.0.0.0:7946` | SWIM protocol bind address. |
 | `swim.advertiseAddress` | string | `""` | Externally reachable SWIM address. Defaults to Pod IP. |
 | `swim.siteName` | string | `""` | Bootstrap SWIM site name. |
-| `swim.seeds` | string | `""` | Bootstrap SWIM seeds (comma-separated). |
+| `swim.seeds` | string | `""` | Bootstrap SWIM seed endpoints (comma-separated `ip:port`, `[ipv6]:port`, or `hostname:port`). |
 | `swim.service.enabled` | bool | `false` | Create a SWIM Service. |
 | `swim.service.type` | string | `ClusterIP` | SWIM Service type. |
 | `swim.service.port` | int | `7946` | SWIM Service port. |

--- a/charts/grid-operator/crds/gridnetwork.yaml
+++ b/charts/grid-operator/crds/gridnetwork.yaml
@@ -377,7 +377,7 @@ spec:
                   type: object
                 seeds:
                   default: []
-                  description: Initial SWIM seed peer addresses.
+                  description: Initial SWIM seed peer endpoints in host:port form. Literal IPv4, bracketed IPv6, and DNS hostnames are accepted.
                   items:
                     type: string
                   type: array

--- a/charts/grid-operator/values.yaml
+++ b/charts/grid-operator/values.yaml
@@ -68,13 +68,13 @@ metrics:
 swim:
   # -- SWIM bind address (host:port).
   bindAddress: "0.0.0.0:7946"
-  # -- Externally reachable SWIM advertise address (host:port). Defaults to
+  # -- Externally reachable SWIM advertise endpoint (ip:port, [ipv6]:port, or hostname:port). Defaults to
   # Pod IP and bind port. Must be set when a LoadBalancer or NodePort Service
   # fronts the SWIM port and remote peers connect through that address.
   advertiseAddress: ""
   # -- Bootstrap SWIM site name override.
   siteName: ""
-  # -- Bootstrap SWIM seed addresses (comma-separated).
+  # -- Bootstrap SWIM seed endpoints (comma-separated ip:port, [ipv6]:port, or hostname:port).
   seeds: ""
   # -- SWIM Service (disabled by default).
   service:

--- a/deploy/crds/gridnetwork.yaml
+++ b/deploy/crds/gridnetwork.yaml
@@ -377,7 +377,7 @@ spec:
                   type: object
                 seeds:
                   default: []
-                  description: Initial SWIM seed peer addresses.
+                  description: Initial SWIM seed peer endpoints in host:port form. Literal IPv4, bracketed IPv6, and DNS hostnames are accepted.
                   items:
                     type: string
                   type: array

--- a/docs/architecture/ci-kind-e2e.md
+++ b/docs/architecture/ci-kind-e2e.md
@@ -49,6 +49,7 @@ Topology and execution details are maintained in the
 |---|---|
 | `verify-swim-membership` | Real SWIM gossip drives GridNetwork membership state. |
 | `verify-swim-state` | CRDT-over-SWIM provider state propagates across sites. |
+| `verify-swim-dns-hostnames` | Hostname-based advertise and seed endpoints resolve before SWIM startup, then membership and provider-state propagation are verified. |
 | `verify-metrics-routing` | Live normalized metrics affect overlay ordering and request routing. |
 | `verify-stale-gc-ttl` | Aged stale candidates are omitted from rendered overlays when TTL is configured. |
 | `verify-api-fallback-native` | Provider credentials are injected from mounted Secret files, not overlay or ConfigMap token bytes. |

--- a/docs/architecture/crds.md
+++ b/docs/architecture/crds.md
@@ -140,8 +140,10 @@ status:
 
 ### CRD-driven SWIM seeds
 
-`spec.seeds` is a list of socket addresses (`host:port`) used to bootstrap
-SWIM mesh formation.  Seeds are announced to the running SWIM runtime on every
+`spec.seeds` is a list of SWIM endpoints (`host:port`) used to bootstrap
+SWIM mesh formation. Each entry may be a literal IPv4 address, a bracketed IPv6
+address, or a DNS hostname. Hostnames are resolved with a bounded lookup before
+they are announced to the running SWIM runtime on every
 `GridNetwork` reconcile.  Re-announcing to an existing peer is idempotent — foca
 ignores redundant joins.
 

--- a/docs/architecture/operations.md
+++ b/docs/architecture/operations.md
@@ -284,12 +284,27 @@ and `auth.secretRef.namespace` in your CRD specs.
 The `Deployment` in `deploy/operator/deployment.yaml`
 exposes SWIM configuration through environment variables:
 
+SWIM endpoint values accept all of these forms:
+
+```text
+10.0.0.4:7946
+[2001:db8::4]:7946
+grid-swim.example.internal:7946
+```
+
+DNS names are resolved before the SWIM runtime starts. All usable seed
+addresses are retained, sorted, and deduplicated. For an advertised hostname,
+the first address in that deterministic ordering becomes the concrete address
+published to SWIM. Resolution is bounded; an invalid or unresolvable
+advertise endpoint prevents SWIM startup rather than silently advertising an
+unrelated address.
+
 | Variable | Purpose |
 |---|---|
 | `GRID_SWIM_BIND_ADDR` | UDP address to bind the SWIM listener |
-| `GRID_SWIM_ADVERTISE_ADDR` | Address advertised to peers (defaults to `$(POD_IP):7946`) |
+| `GRID_SWIM_ADVERTISE_ADDR` | Advertised SWIM endpoint; accepts `ip:port`, `[ipv6]:port`, or `hostname:port` and defaults to `$(POD_IP):7946` |
 | `GRID_SWIM_SITE_NAME` | Unique site identity for this operator instance |
-| `GRID_SWIM_SEEDS` | Comma-separated SWIM seed addresses |
+| `GRID_SWIM_SEEDS` | Comma-separated SWIM seed endpoints; accepts `ip:port`, `[ipv6]:port`, or `hostname:port` |
 | `GRID_GATEWAY_ADDRESS` | Explicit gateway address override (skips self-discovery) |
 | `GRID_GATEWAY_SERVICE_NAME` | Service name for gateway self-discovery (default: `provider-gateway`) |
 | `GRID_GATEWAY_NAMESPACE` | Namespace for gateway Service lookup (default: `grid-system`) |
@@ -349,11 +364,14 @@ The GridNetwork controller:
 ### CRD-driven seeds
 
 `spec.seeds` is **operator-consumed**: on every `GridNetwork` reconcile the
-controller parses the seed list, filters invalid addresses (logged at `warn`,
-no reconcile failure), removes the local advertise address to prevent self-
-announce noise, deduplicates, and calls `SwimHandle::announce_seeds` to deliver
-the batch to the running SWIM event loop.  Re-announcing to already-connected
-peers is idempotent — foca ignores redundant joins.
+controller parses and resolves each entry independently, logs invalid or
+temporarily unresolvable entries at `warn`, retains successful addresses,
+removes the local advertise address to prevent self-announce noise,
+deduplicates, and calls `SwimHandle::announce_seeds` to deliver the batch to
+the running SWIM event loop. Re-announcing to already-connected peers is
+idempotent — foca ignores redundant joins. If every non-empty configured seed
+fails, the controller retains the last-known-good resolved set; if none exists,
+SWIM remains active with a seedless bootstrap and a degradation warning.
 
 Startup seeds from `GRID_SWIM_SEEDS` (env var) and CRD seeds are additive.
 The env var seeds are applied once at startup; CRD seeds are applied on every
@@ -437,14 +455,17 @@ skipped for the current reconcile and retried on the next
 immediately under heavy broadcast load.
 
 **Seed format**
-Seeds must be `IP:port` socket addresses.  DNS names are not resolved.
-Example: `10.0.0.2:7946`.  Invalid addresses are skipped and logged at `warn`
-level; the reconcile does not fail.
+Seeds accept `IP:port`, `[IPv6]:port`, and `hostname:port`, for example
+`10.0.0.2:7946` or `grid-swim.example.internal:7946`. DNS is resolved during
+each reconciliation with per-endpoint and aggregate bounds; results are sorted
+and deduplicated. Invalid or failed entries are skipped with source and
+endpoint diagnostics. A partial result is announced, while a wholly failed
+non-empty list does not replace a working last-known-good set.
 
 **Troubleshooting seed changes**
 
 *New seed not joining:*
-- Verify the address is a valid `IP:port`.
+- Verify the address is a valid `IP:port`, `[IPv6]:port`, or `hostname:port`.
 - Check the operator log for `announcing CRD seeds to SWIM runtime` or
   `new CRD seeds added` — if absent, the reconcile may not have fired yet.
 - Check for `failed to queue CRD seeds for SWIM announcement` at `warn` level,
@@ -1151,6 +1172,7 @@ Available commands:
 | `cargo xtask env verify-stale-gc-ttl` | Verifies `GridNetwork.spec.staleCandidateTtlSeconds` evicts stale remote candidates from the rendered overlay |
 | `cargo xtask env verify-responses-routing` | Verifies `/v1/responses` request parsing and Grid overlay routing using `openai_responses_format` → `intelligent_route` filter chain |
 | `cargo xtask env verify-crd-schema` | Verifies required generated CRD schema fields without requiring kind clusters |
+| `cargo xtask env verify-swim-dns-hostnames` | Verifies hostname-based SWIM advertise/seeds, membership convergence, and CRDT provider-state propagation |
 | `cargo xtask env verify-operator-install-rbac` | Applies install manifests, runs positive/negative RBAC checks, proves minimal reconcile succeeds |
 | `cargo xtask env validate-all` | Runs the local validation suite and prints a Markdown result table |
 
@@ -1221,6 +1243,17 @@ state.
 ```console
 cargo xtask env verify-swim-state -c tests/env/operator-routing.toml
 ```
+
+To qualify hostname-based SWIM endpoints without relying on public DNS:
+
+```console
+GRID_SWIM_DNS_EVIDENCE_DIR=/tmp/grid-swim-dns-run-1 \
+  cargo xtask env verify-swim-dns-hostnames -c tests/env/operator-routing.toml
+```
+
+The qualification uses two distinct loopback ports with `localhost:port`
+advertise and seed endpoints, then proves membership and remote provider-state
+propagation before cleaning its resources.
 
 This command starts two SWIM-enabled operator processes,
 waits for gossip convergence, then applies a

--- a/operator/src/controller/grid_network.rs
+++ b/operator/src/controller/grid_network.rs
@@ -39,6 +39,7 @@ use crate::{
         trust_bundle::{self, CertPemStatus},
     },
     swim::{MemberStatus, MembershipSnapshot},
+    swim_endpoint::{SeedResolution, resolve_endpoint_list_partial},
     swim_runtime::SwimHandle,
 };
 
@@ -92,8 +93,8 @@ pub struct OperatorCtx {
     /// and removals.  Seeds are always announced in full (idempotent); this
     /// state is used only for diagnostics.
     ///
-    /// Uses [`std::sync::Mutex`] because [`announce_crd_seeds`] is a synchronous
-    /// function called from within the async reconcile loop.
+    /// Uses [`std::sync::Mutex`] because seed tracking is updated synchronously
+    /// after async DNS resolution and the SWIM channel announcement.
     pub(crate) last_seeds: std::sync::Mutex<HashMap<String, Vec<SocketAddr>>>,
 }
 
@@ -256,7 +257,7 @@ pub async fn reconcile(network: Arc<GridNetwork>, ctx: Arc<OperatorCtx>) -> Resu
         // without requiring the GRID_SWIM_SEEDS environment variable.
         // Re-announcing on each reconcile is idempotent (foca ignores existing members).
         // diff_seed_sets tracks additions/removals for diagnostic logging.
-        announce_crd_seeds(&network, swim, &ctx.last_seeds);
+        announce_crd_seeds(&network, swim, &ctx.last_seeds).await;
 
         // Broadcast the local site's public certificate PEM so remote peers can
         // populate GridSite.status.publicCertPem.  Only the public cert is read —
@@ -560,41 +561,6 @@ pub fn error_policy(_network: Arc<GridNetwork>, error: &OperatorError, _ctx: Arc
 // CRD-driven SWIM seeds
 // ---------------------------------------------------------------------------
 
-/// Parse and normalize SWIM seed addresses from `GridNetwork.spec.seeds`.
-///
-/// Each string is trimmed and parsed as a [`SocketAddr`].  Invalid entries
-/// are logged at `warn` level and skipped; they do not fail the reconcile.
-/// If `local_addr` is `Some`, any address equal to it is removed (self-seed).
-/// Duplicates are removed; the result is deterministically sorted.
-///
-/// Returns an empty `Vec` when `raw` is empty or all entries fail to parse.
-pub(crate) fn parse_crd_seeds(raw: &[String], local_addr: Option<SocketAddr>) -> Vec<SocketAddr> {
-    let mut seen = BTreeSet::new();
-    for s in raw {
-        let trimmed = s.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-        match trimmed.parse::<SocketAddr>() {
-            Ok(addr) => {
-                if local_addr.is_some_and(|local| addr == local) {
-                    tracing::debug!(addr = %addr, "GridNetwork spec.seeds: skipping self-address");
-                    continue;
-                }
-                seen.insert(addr);
-            },
-            Err(e) => {
-                tracing::warn!(
-                    seed = trimmed,
-                    error = %e,
-                    "GridNetwork spec.seeds contains invalid socket address, skipping"
-                );
-            },
-        }
-    }
-    seen.into_iter().collect()
-}
-
 /// Compute the difference between two seed sets.
 ///
 /// Returns `(added, removed)` as sorted `Vec<SocketAddr>` slices.
@@ -659,18 +625,14 @@ pub(crate) fn diff_seed_sets(previous: &[SocketAddr], desired: &[SocketAddr]) ->
 )]
 #[expect(
     clippy::too_many_lines,
-    reason = "linear announce sequence: parse → diff → log → announce → update tracker"
+    reason = "linear announce sequence: resolve → diff → log → announce → update tracker"
 )]
-fn announce_crd_seeds(
+async fn announce_crd_seeds(
     network: &GridNetwork,
     swim: &SwimHandle,
     last_seeds: &std::sync::Mutex<HashMap<String, Vec<SocketAddr>>>,
 ) {
-    let seeds = parse_crd_seeds(&network.spec.seeds, Some(swim.local_addr()));
     let name = network.metadata.name.as_deref().unwrap_or("?");
-
-    // Log what changed since the last reconcile using diff_seed_sets.
-    // Always announce the full set for robustness (idempotent, handles channel-full retries).
     let prev = last_seeds
         .lock()
         .unwrap_or_else(|e| {
@@ -680,6 +642,37 @@ fn announce_crd_seeds(
         .get(name)
         .cloned()
         .unwrap_or_default();
+    let resolution = resolve_endpoint_list_partial(&network.spec.seeds, "GridNetwork.spec.seeds").await;
+    for failure in &resolution.failures {
+        tracing::warn!(
+            network = name,
+            source = %failure.source,
+            endpoint = %failure.endpoint,
+            reason = %failure.reason,
+            "ignoring unusable GridNetwork seed"
+        );
+    }
+    let mut seeds = match crd_seed_decision(&resolution, &prev) {
+        CrdSeedDecision::Announce(seeds) => seeds,
+        CrdSeedDecision::Retain => {
+            tracing::warn!(
+                network = name,
+                "all configured GridNetwork seeds failed; retaining the last-known-good seed set"
+            );
+            return;
+        },
+        CrdSeedDecision::Seedless => {
+            tracing::warn!(
+                network = name,
+                "no configured GridNetwork seed resolved and no last-known-good set exists; keeping SWIM seedless"
+            );
+            return;
+        },
+    };
+    seeds.retain(|addr| *addr != swim.local_addr());
+
+    // Log what changed since the last reconcile using diff_seed_sets.
+    // Always announce the full set for robustness (idempotent, handles channel-full retries).
     let (added, removed) = diff_seed_sets(&prev, &seeds);
     if !added.is_empty() {
         let addrs: Vec<String> = added.iter().map(ToString::to_string).collect();
@@ -731,6 +724,29 @@ fn announce_crd_seeds(
             e.into_inner()
         })
         .insert(name.to_owned(), seeds);
+}
+
+/// Action for a CRD seed update after partial DNS resolution.
+enum CrdSeedDecision {
+    /// Announce the supplied resolved set.
+    Announce(Vec<SocketAddr>),
+    /// Keep the previous announced set because all current lookups failed.
+    Retain,
+    /// Keep SWIM active without seeds because no prior set exists.
+    Seedless,
+}
+
+/// Decide whether a CRD seed reconciliation may replace the announced set.
+fn crd_seed_decision(resolution: &SeedResolution, previous: &[SocketAddr]) -> CrdSeedDecision {
+    if !resolution.addresses.is_empty() {
+        CrdSeedDecision::Announce(resolution.addresses.clone())
+    } else if resolution.configured && !previous.is_empty() {
+        CrdSeedDecision::Retain
+    } else if resolution.configured {
+        CrdSeedDecision::Seedless
+    } else {
+        CrdSeedDecision::Announce(Vec::new())
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -2472,6 +2488,51 @@ fn parse_metrics_refresh_interval(value: &str) -> Result<Duration, OperatorError
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::swim_endpoint::EndpointResolutionFailure;
+
+    fn seed_addr(value: &str) -> SocketAddr {
+        value.parse().unwrap_or_else(|_| std::process::abort())
+    }
+
+    #[test]
+    fn crd_seed_resolution_retains_last_known_good_when_all_current_lookups_fail() {
+        let resolution = SeedResolution {
+            configured: true,
+            addresses: Vec::new(),
+            failures: vec![EndpointResolutionFailure {
+                source: "GridNetwork.spec.seeds".to_owned(),
+                endpoint: "missing.example:7946".to_owned(),
+                reason: "DNS resolution failed".to_owned(),
+            }],
+        };
+        assert!(matches!(
+            crd_seed_decision(&resolution, &[seed_addr("10.0.0.1:7946")]),
+            CrdSeedDecision::Retain
+        ));
+    }
+
+    #[test]
+    fn crd_seed_resolution_announces_recovered_addresses() {
+        let resolution = SeedResolution {
+            configured: true,
+            addresses: vec![seed_addr("10.0.0.2:7946")],
+            failures: Vec::new(),
+        };
+        assert!(matches!(
+            crd_seed_decision(&resolution, &[seed_addr("10.0.0.1:7946")]),
+            CrdSeedDecision::Announce(addresses) if addresses == vec![seed_addr("10.0.0.2:7946")]
+        ));
+    }
+
+    #[test]
+    fn crd_seed_resolution_without_previous_seeds_stays_seedless() {
+        let resolution = SeedResolution {
+            configured: true,
+            addresses: Vec::new(),
+            failures: Vec::new(),
+        };
+        assert!(matches!(crd_seed_decision(&resolution, &[]), CrdSeedDecision::Seedless));
+    }
     use crate::{
         crd::grid_network::{BudgetPolicyConfig, TenantBudgetConfig},
         swim::MemberRecord,
@@ -4104,103 +4165,12 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // parse_crd_seeds — pure seed normalization
+    // diff_seed_sets
     // -----------------------------------------------------------------------
 
     fn addr(s: &str) -> SocketAddr {
         s.parse().unwrap_or_else(|_| std::process::abort())
     }
-
-    #[test]
-    fn parse_crd_seeds_empty_input_returns_empty() {
-        let result = parse_crd_seeds(&[], None);
-        assert!(result.is_empty(), "empty input must produce empty output");
-    }
-
-    #[test]
-    fn parse_crd_seeds_valid_address_parsed() {
-        let raw = vec!["10.0.0.1:7946".to_owned()];
-        let result = parse_crd_seeds(&raw, None);
-        assert_eq!(result, vec![addr("10.0.0.1:7946")], "valid address must be included");
-    }
-
-    #[test]
-    fn parse_crd_seeds_invalid_address_skipped() {
-        let raw = vec!["not-an-address".to_owned()];
-        let result = parse_crd_seeds(&raw, None);
-        assert!(result.is_empty(), "invalid address must be skipped without panic");
-    }
-
-    #[test]
-    fn parse_crd_seeds_mixed_valid_and_invalid() {
-        let raw = vec![
-            "10.0.0.1:7946".to_owned(),
-            "bad-addr".to_owned(),
-            "10.0.0.2:7946".to_owned(),
-        ];
-        let result = parse_crd_seeds(&raw, None);
-        assert_eq!(result.len(), 2, "only valid addresses must appear");
-        assert!(result.contains(&addr("10.0.0.1:7946")));
-        assert!(result.contains(&addr("10.0.0.2:7946")));
-    }
-
-    #[test]
-    fn parse_crd_seeds_deduplicates() {
-        let raw = vec!["10.0.0.1:7946".to_owned(), "10.0.0.1:7946".to_owned()];
-        let result = parse_crd_seeds(&raw, None);
-        assert_eq!(result.len(), 1, "duplicates must be removed");
-    }
-
-    #[test]
-    fn parse_crd_seeds_filters_self_addr() {
-        let local = addr("10.0.0.1:7946");
-        let raw = vec!["10.0.0.1:7946".to_owned(), "10.0.0.2:7946".to_owned()];
-        let result = parse_crd_seeds(&raw, Some(local));
-        assert_eq!(result.len(), 1, "self-address must be filtered out");
-        assert_eq!(
-            result.first().copied(),
-            Some(addr("10.0.0.2:7946")),
-            "non-self address must remain"
-        );
-    }
-
-    #[test]
-    fn parse_crd_seeds_no_local_filter_when_none() {
-        let raw = vec!["10.0.0.1:7946".to_owned()];
-        let result = parse_crd_seeds(&raw, None);
-        assert_eq!(result.len(), 1, "without local filter all valid addresses are kept");
-    }
-
-    #[test]
-    fn parse_crd_seeds_whitespace_trimmed() {
-        let raw = vec!["  10.0.0.1:7946  ".to_owned()];
-        let result = parse_crd_seeds(&raw, None);
-        assert_eq!(
-            result,
-            vec![addr("10.0.0.1:7946")],
-            "leading/trailing whitespace must be trimmed"
-        );
-    }
-
-    #[test]
-    fn parse_crd_seeds_empty_string_skipped() {
-        let raw = vec![String::new(), "  ".to_owned()];
-        let result = parse_crd_seeds(&raw, None);
-        assert!(result.is_empty(), "blank strings must be skipped");
-    }
-
-    #[test]
-    fn parse_crd_seeds_result_is_sorted() {
-        let raw = vec!["10.0.0.2:7946".to_owned(), "10.0.0.1:7946".to_owned()];
-        let result = parse_crd_seeds(&raw, None);
-        let mut expected = result.clone();
-        expected.sort();
-        assert_eq!(result, expected, "result must be sorted for deterministic ordering");
-    }
-
-    // -----------------------------------------------------------------------
-    // diff_seed_sets
-    // -----------------------------------------------------------------------
 
     #[test]
     fn diff_seed_sets_empty_to_empty_is_no_op() {

--- a/operator/src/lib.rs
+++ b/operator/src/lib.rs
@@ -38,6 +38,8 @@ pub mod gateway;
 /// Pure data layer for peer discovery; the live UDP runtime is implemented in
 /// [`swim_runtime`].
 pub mod swim;
+/// SWIM endpoint parsing and bounded DNS resolution.
+pub mod swim_endpoint;
 /// Live SWIM membership runtime (foca-backed UDP event loop).
 ///
 /// Produces [`swim::MembershipSnapshot`]s consumed by the [`GridNetwork`]

--- a/operator/src/main.rs
+++ b/operator/src/main.rs
@@ -9,7 +9,9 @@
 //! Set `GRID_SWIM_BIND_ADDR` (e.g. `"0.0.0.0:7946"`) to enable the SWIM
 //! runtime. Set `GRID_SWIM_ADVERTISE_ADDR` when the bind address is not
 //! directly reachable by peers, and set `GRID_SWIM_SEEDS` to a comma-separated
-//! list of seed peer socket addresses. When `GRID_SWIM_BIND_ADDR` is absent
+//! list of `host:port` seed endpoints. Both literal IP addresses and DNS
+//! hostnames are accepted; DNS is resolved once, with a bounded timeout, before
+//! the runtime starts. When `GRID_SWIM_BIND_ADDR` is absent
 //! the operator runs in static mode (`membership = None`);
 //! `GridNetwork.status.connectedSites` and `distributedProviderCount` remain
 //! 0, and the phase stays `Pending`/`Initializing` based on TLS configuration
@@ -43,7 +45,6 @@
 
 use std::{
     collections::BTreeMap,
-    net::SocketAddr,
     sync::Arc,
     time::{SystemTime, UNIX_EPOCH},
 };
@@ -68,6 +69,7 @@ use operator::{
         inference_provider::InferenceProvider,
     },
     gateway,
+    swim_endpoint::{SwimEndpoint, resolve_endpoint, resolve_endpoint_list_partial},
     swim_runtime::{self, RevisionLease, SwimConfig},
 };
 
@@ -115,7 +117,13 @@ async fn main() {
         },
     };
 
-    let swim = maybe_start_swim(&client, &config.gateway).await;
+    let swim = match maybe_start_swim(&client, &config.gateway).await {
+        Ok(swim) => swim,
+        Err(error) => {
+            tracing::error!(%error, "SWIM startup failed");
+            std::process::exit(1);
+        },
+    };
 
     if let Some(handle) = &swim {
         tokio::spawn(gateway::run_discovery_poller(
@@ -147,8 +155,9 @@ async fn main() {
 /// Optionally start the SWIM runtime from environment variables.
 ///
 /// Returns `Some(handle)` if `GRID_SWIM_BIND_ADDR` is set and the runtime
-/// starts successfully.  Returns `None` when the variable is absent,
-/// unparseable, or the bind fails (all logged at error level).
+/// starts successfully, `None` when SWIM is not configured or a non-contract
+/// startup dependency is unavailable, and an error when an explicitly
+/// configured bind or advertise endpoint is invalid or cannot be resolved.
 ///
 /// Gateway address resolution uses [`operator::gateway::resolve`]:
 /// `GRID_GATEWAY_ADDRESS` env var wins; otherwise the operator discovers
@@ -159,17 +168,61 @@ async fn main() {
     clippy::large_stack_frames,
     reason = "sequential env-var parsing + runtime startup; splitting would obscure the startup sequence"
 )]
-async fn maybe_start_swim(client: &Client, config: &gateway::Config) -> Option<Arc<swim_runtime::SwimHandle>> {
-    let addr_str = std::env::var("GRID_SWIM_BIND_ADDR").ok()?;
+async fn maybe_start_swim(
+    client: &Client,
+    config: &gateway::Config,
+) -> Result<Option<Arc<swim_runtime::SwimHandle>>, String> {
+    let Some(addr_str) = std::env::var("GRID_SWIM_BIND_ADDR").ok() else {
+        return Ok(None);
+    };
     let bind_addr = match addr_str.parse() {
         Ok(a) => a,
         Err(e) => {
             tracing::error!(addr = %addr_str, error = %e, "GRID_SWIM_BIND_ADDR not a valid socket address");
-            return None;
+            return Err(format!("GRID_SWIM_BIND_ADDR is not a valid socket address: {e}"));
         },
     };
-    let advertise_addr = parse_optional_socket_addr_env("GRID_SWIM_ADVERTISE_ADDR");
-    let seeds = parse_socket_addr_list_env("GRID_SWIM_SEEDS");
+    let advertise_addr = match std::env::var("GRID_SWIM_ADVERTISE_ADDR") {
+        Ok(value) => {
+            let endpoint = match value.parse::<SwimEndpoint>() {
+                Ok(endpoint) => endpoint,
+                Err(error) => {
+                    tracing::error!(env = "GRID_SWIM_ADVERTISE_ADDR", value = %value, %error, "invalid SWIM endpoint");
+                    return Err(format!("GRID_SWIM_ADVERTISE_ADDR is invalid: {error}"));
+                },
+            };
+            match resolve_endpoint(&endpoint, "GRID_SWIM_ADVERTISE_ADDR").await {
+                Ok(addresses) => {
+                    let resolved = addresses.first().copied();
+                    if let Some(address) = resolved {
+                        tracing::info!(configured = %endpoint.as_text(), %address, "resolved SWIM advertise endpoint");
+                    }
+                    resolved
+                },
+                Err(error) => return Err(format!("cannot resolve GRID_SWIM_ADVERTISE_ADDR: {error}")),
+            }
+        },
+        Err(_) => None,
+    };
+    let seed_values = std::env::var("GRID_SWIM_SEEDS").unwrap_or_default();
+    let seed_values: Vec<String> = seed_values.split(',').map(str::to_owned).collect();
+    let seed_resolution = resolve_endpoint_list_partial(&seed_values, "GRID_SWIM_SEEDS").await;
+    for failure in &seed_resolution.failures {
+        tracing::warn!(
+            source = %failure.source,
+            endpoint = %failure.endpoint,
+            reason = %failure.reason,
+            "ignoring unusable SWIM seed"
+        );
+    }
+    if seed_resolution.configured && seed_resolution.addresses.is_empty() {
+        tracing::warn!(
+            source = "GRID_SWIM_SEEDS",
+            failures = seed_resolution.failures.len(),
+            "no configured SWIM seeds resolved; keeping SWIM active with a seedless bootstrap"
+        );
+    }
+    let seeds = seed_resolution.addresses;
     let site_name = std::env::var("GRID_SWIM_SITE_NAME").unwrap_or_else(|_| hostname_or_default());
     let gateway_address = match gateway::resolve(client, config).await {
         Ok(addr) => addr,
@@ -183,7 +236,7 @@ async fn maybe_start_swim(client: &Client, config: &gateway::Config) -> Option<A
         Ok(lease) => lease,
         Err(error) => {
             tracing::error!(%error, "failed to reserve SWIM revisions; running in static mode");
-            return None;
+            return Ok(None);
         },
     };
     let cfg = SwimConfig {
@@ -198,11 +251,11 @@ async fn maybe_start_swim(client: &Client, config: &gateway::Config) -> Option<A
     match swim_runtime::start(cfg).await {
         Ok(handle) => {
             tracing::info!(addr = %addr_str, "SWIM runtime started");
-            Some(handle)
+            Ok(Some(handle))
         },
         Err(e) => {
             tracing::error!(error = %e, "SWIM runtime failed to start; running in static mode");
-            None
+            Ok(None)
         },
     }
 }
@@ -408,42 +461,6 @@ fn parse_swim_key_env(name: &str) -> Option<swim::crypto::SwimKey> {
     }
     tracing::info!(env = name, "SWIM encryption key loaded from environment");
     Some(key)
-}
-
-/// Parse an optional socket address environment variable.
-fn parse_optional_socket_addr_env(name: &str) -> Option<SocketAddr> {
-    let value = std::env::var(name).ok()?;
-    match value.parse() {
-        Ok(addr) => Some(addr),
-        Err(e) => {
-            tracing::error!(env = name, value = %value, error = %e, "SWIM socket address env var is invalid");
-            None
-        },
-    }
-}
-
-/// Parse a comma-separated socket address environment variable.
-fn parse_socket_addr_list_env(name: &str) -> Vec<SocketAddr> {
-    let Ok(value) = std::env::var(name) else {
-        return Vec::new();
-    };
-
-    value
-        .split(',')
-        .filter_map(|raw| {
-            let item = raw.trim();
-            if item.is_empty() {
-                return None;
-            }
-            match item.parse() {
-                Ok(addr) => Some(addr),
-                Err(e) => {
-                    tracing::error!(env = name, value = %item, error = %e, "SWIM seed address is invalid");
-                    None
-                },
-            }
-        })
-        .collect()
 }
 
 /// Return the machine hostname or a safe fallback.

--- a/operator/src/swim_endpoint.rs
+++ b/operator/src/swim_endpoint.rs
@@ -1,0 +1,580 @@
+//! Parsing and startup resolution for SWIM endpoints.
+
+use std::{
+    collections::BTreeSet,
+    io,
+    net::{IpAddr, SocketAddr},
+    str::FromStr,
+    time::Duration,
+};
+
+use futures::StreamExt as _;
+
+/// Maximum time allowed for one DNS lookup.
+pub const DNS_RESOLUTION_TIMEOUT: Duration = Duration::from_secs(5);
+/// Maximum time allowed for one seed-list reconciliation.
+pub const DNS_RESOLUTION_AGGREGATE_TIMEOUT: Duration = Duration::from_secs(10);
+/// Maximum number of DNS lookups running concurrently.
+const DNS_RESOLUTION_CONCURRENCY: usize = 32;
+
+/// One endpoint-resolution failure that can be reported without discarding
+/// successful entries from the same configuration list.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EndpointResolutionFailure {
+    /// Configuration source, such as `GRID_SWIM_SEEDS`.
+    pub source: String,
+    /// The configured endpoint that failed.
+    pub endpoint: String,
+    /// Bounded, actionable failure detail.
+    pub reason: String,
+}
+
+/// Result of resolving a configured seed list.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SeedResolution {
+    /// Whether at least one non-empty endpoint was configured.
+    pub configured: bool,
+    /// All usable addresses, sorted and deduplicated.
+    pub addresses: Vec<SocketAddr>,
+    /// Invalid or unresolved entries, in configuration order.
+    pub failures: Vec<EndpointResolutionFailure>,
+}
+
+impl SeedResolution {
+    /// Return whether a non-empty configuration produced no usable address.
+    pub fn is_degraded(&self) -> bool {
+        self.configured && (!self.failures.is_empty() || self.addresses.is_empty())
+    }
+}
+
+/// A SWIM endpoint before DNS resolution.
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub enum SwimEndpoint {
+    /// A literal IPv4 or bracketed IPv6 socket address.
+    Literal(SocketAddr),
+    /// A DNS hostname and its UDP port.
+    Hostname {
+        /// DNS name to resolve.
+        host: String,
+        /// UDP port.
+        port: u16,
+    },
+}
+
+impl SwimEndpoint {
+    /// Return the configured endpoint text in a stable display form.
+    pub fn as_text(&self) -> String {
+        match self {
+            Self::Literal(addr) => addr.to_string(),
+            Self::Hostname { host, port } => format!("{host}:{port}"),
+        }
+    }
+
+    /// Return the DNS lookup input, if this endpoint is a hostname.
+    fn host_port(&self) -> Option<(&str, u16)> {
+        match self {
+            Self::Literal(_) => None,
+            Self::Hostname { host, port } => Some((host, *port)),
+        }
+    }
+}
+
+impl FromStr for SwimEndpoint {
+    type Err = String;
+
+    #[expect(
+        clippy::too_many_lines,
+        reason = "endpoint parsing keeps all accepted and rejected forms together"
+    )]
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        if value.is_empty() || value.chars().any(char::is_whitespace) {
+            return Err("endpoint must be non-empty and contain no whitespace".to_owned());
+        }
+        if value.contains("://") || value.contains('/') {
+            return Err("endpoint must be host:port, not a URL or path".to_owned());
+        }
+
+        if let Ok(addr) = value.parse::<SocketAddr>() {
+            return nonzero_port(addr.port()).map(|()| Self::Literal(addr));
+        }
+
+        let (host, port_text) = if let Some(rest) = value.strip_prefix('[') {
+            let Some((host, suffix)) = rest.split_once(']') else {
+                return Err("bracketed IPv6 endpoint is missing ]".to_owned());
+            };
+            let Some(port_text) = suffix.strip_prefix(':') else {
+                return Err("bracketed host must be followed by :port".to_owned());
+            };
+            if host.is_empty() || port_text.is_empty() || port_text.contains(':') {
+                return Err("invalid bracketed host:port endpoint".to_owned());
+            }
+            if !matches!(host.parse::<IpAddr>(), Ok(IpAddr::V6(_))) {
+                return Err("only IPv6 literals may use brackets".to_owned());
+            }
+            (host, port_text)
+        } else {
+            if value.matches(':').count() != 1 {
+                return Err("IPv6 addresses must be bracketed and hostnames require one :port".to_owned());
+            }
+            let Some((host, port_text)) = value.split_once(':') else {
+                return Err("endpoint must be host:port".to_owned());
+            };
+            (host, port_text)
+        };
+
+        if host.is_empty() || host.contains('[') || host.contains(']') {
+            return Err("endpoint host is empty or malformed".to_owned());
+        }
+        if host.parse::<IpAddr>().is_err() {
+            validate_hostname(host)?;
+        }
+        let port = port_text
+            .parse::<u16>()
+            .map_err(|_error| "endpoint port must be an integer in 1..=65535".to_owned())?;
+        nonzero_port(port)?;
+        Ok(Self::Hostname {
+            host: host.to_owned(),
+            port,
+        })
+    }
+}
+
+/// Validate the DNS label syntax accepted by the endpoint parser.
+fn validate_hostname(host: &str) -> Result<(), String> {
+    for label in host.trim_end_matches('.').split('.') {
+        if label.is_empty()
+            || label.starts_with('-')
+            || label.ends_with('-')
+            || !label.chars().all(|ch| ch.is_ascii_alphanumeric() || ch == '-')
+        {
+            return Err("endpoint hostname contains an invalid DNS label".to_owned());
+        }
+    }
+    Ok(())
+}
+
+/// Reject the zero port, which is not a usable SWIM endpoint port.
+fn nonzero_port(port: u16) -> Result<(), String> {
+    if port == 0 {
+        Err("endpoint port must be nonzero".to_owned())
+    } else {
+        Ok(())
+    }
+}
+
+/// Resolve one endpoint with the production Tokio resolver.
+///
+/// # Errors
+///
+/// Returns an actionable error if parsing or bounded DNS resolution fails.
+pub async fn resolve_endpoint(endpoint: &SwimEndpoint, source: &str) -> Result<Vec<SocketAddr>, String> {
+    resolve_endpoint_with(endpoint, source, DNS_RESOLUTION_TIMEOUT, |host, port| {
+        let host = host.to_owned();
+        async move { Ok(tokio::net::lookup_host((host, port)).await?.collect()) }
+    })
+    .await
+}
+
+/// Resolve a configured list, retaining every usable address deterministically.
+///
+/// # Errors
+///
+/// Returns an actionable error identifying the configuration source and endpoint
+/// when parsing or bounded DNS resolution fails.
+pub async fn resolve_endpoint_list(raw: &[String], source: &str) -> Result<Vec<SocketAddr>, String> {
+    let result = resolve_endpoint_list_partial(raw, source).await;
+    if let Some(failure) = result.failures.first() {
+        return Err(format!(
+            "{} endpoint {:?}: {}",
+            failure.source, failure.endpoint, failure.reason
+        ));
+    }
+    Ok(result.addresses)
+}
+
+/// Resolve a configured list while retaining successful entries when others fail.
+pub async fn resolve_endpoint_list_partial(raw: &[String], source: &str) -> SeedResolution {
+    resolve_endpoint_list_partial_with(
+        raw,
+        source,
+        DNS_RESOLUTION_TIMEOUT,
+        DNS_RESOLUTION_AGGREGATE_TIMEOUT,
+        |host, port| {
+            let host = host.to_owned();
+            async move { Ok(tokio::net::lookup_host((host, port)).await?.collect()) }
+        },
+    )
+    .await
+}
+
+/// Injectable implementation of the partial seed resolver.
+#[expect(
+    clippy::too_many_lines,
+    reason = "partial resolution keeps parse, bounded concurrency, diagnostics, and deterministic finalization together"
+)]
+pub async fn resolve_endpoint_list_partial_with<F, Fut>(
+    raw: &[String],
+    source: &str,
+    timeout: Duration,
+    aggregate_timeout: Duration,
+    resolver: F,
+) -> SeedResolution
+where
+    F: Fn(&str, u16) -> Fut + Copy + Send + Sync + 'static,
+    Fut: Future<Output = io::Result<Vec<SocketAddr>>> + Send + 'static,
+{
+    let mut failures = Vec::new();
+    let mut pending = Vec::new();
+    for item in raw.iter().map(String::as_str).map(str::trim).filter(|s| !s.is_empty()) {
+        match item.parse::<SwimEndpoint>() {
+            Ok(endpoint) => pending.push((item.to_owned(), endpoint)),
+            Err(reason) => failures.push(EndpointResolutionFailure {
+                source: source.to_owned(),
+                endpoint: item.to_owned(),
+                reason: format!("invalid endpoint: {reason}"),
+            }),
+        }
+    }
+    let configured = !pending.is_empty() || !failures.is_empty();
+    let mut unresolved: BTreeSet<String> = pending.iter().map(|(item, _)| item.clone()).collect();
+    let jobs = futures::stream::iter(pending.into_iter().map(|(item, endpoint)| async move {
+        let result = resolve_endpoint_with(&endpoint, source, timeout, resolver).await;
+        (item, result)
+    }))
+    .buffer_unordered(DNS_RESOLUTION_CONCURRENCY);
+    tokio::pin!(jobs);
+    let deadline = tokio::time::sleep(aggregate_timeout);
+    tokio::pin!(deadline);
+    let mut addresses = Vec::new();
+    loop {
+        tokio::select! {
+            item = jobs.next() => {
+                let Some((endpoint, result)) = item else { break };
+                unresolved.remove(&endpoint);
+                match result {
+                    Ok(mut endpoint_addresses) => addresses.append(&mut endpoint_addresses),
+                    Err(reason) => failures.push(EndpointResolutionFailure {
+                        source: source.to_owned(), endpoint, reason,
+                    }),
+                }
+            }
+            () = &mut deadline => {
+                for endpoint in unresolved {
+                    failures.push(EndpointResolutionFailure {
+                        source: source.to_owned(),
+                        endpoint,
+                        reason: format!("DNS resolution exceeded aggregate timeout of {aggregate_timeout:?}"),
+                    });
+                }
+                break;
+            }
+        }
+    }
+    addresses.sort_unstable();
+    addresses.dedup();
+    SeedResolution {
+        configured,
+        addresses,
+        failures,
+    }
+}
+
+/// Resolve a configured list with an injectable resolver.
+///
+/// # Errors
+///
+/// Returns the first invalid or unresolved endpoint as an actionable error.
+pub async fn resolve_endpoint_list_with<F, Fut>(
+    raw: &[String],
+    source: &str,
+    timeout: Duration,
+    resolver: F,
+) -> Result<Vec<SocketAddr>, String>
+where
+    F: Fn(&str, u16) -> Fut + Copy + Send + Sync + 'static,
+    Fut: Future<Output = io::Result<Vec<SocketAddr>>> + Send + 'static,
+{
+    let result = resolve_endpoint_list_partial_with(raw, source, timeout, timeout, resolver).await;
+    if let Some(failure) = result.failures.first() {
+        return Err(format!(
+            "{} endpoint {:?}: {}",
+            failure.source, failure.endpoint, failure.reason
+        ));
+    }
+    Ok(result.addresses)
+}
+
+
+/// Resolve an endpoint with an injectable resolver for deterministic tests.
+///
+/// # Errors
+///
+/// Returns an actionable error when the injected resolver fails, times out, or
+/// returns no usable addresses.
+pub async fn resolve_endpoint_with<F, Fut>(
+    endpoint: &SwimEndpoint,
+    source: &str,
+    timeout: Duration,
+    resolver: F,
+) -> Result<Vec<SocketAddr>, String>
+where
+    F: FnOnce(&str, u16) -> Fut,
+    Fut: Future<Output = io::Result<Vec<SocketAddr>>>,
+{
+    let Some((host, port)) = endpoint.host_port() else {
+        return match endpoint {
+            SwimEndpoint::Literal(addr) => Ok(vec![*addr]),
+            SwimEndpoint::Hostname { .. } => Err(format!("{source} endpoint resolution failed")),
+        };
+    };
+    let result = tokio::time::timeout(timeout, resolver(host, port))
+        .await
+        .map_err(|_error| format!("{source} DNS resolution timed out for {host}:{port}"))?
+        .map_err(|error| format!("{source} DNS resolution failed for {host}:{port}: {error}"))?;
+    let mut addresses = result;
+    addresses.sort_unstable();
+    addresses.dedup();
+    if addresses.is_empty() {
+        return Err(format!(
+            "{source} DNS resolution returned no addresses for {host}:{port}"
+        ));
+    }
+    Ok(addresses)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn addr(value: &str) -> SocketAddr {
+        value.parse().unwrap_or_else(|_| std::process::abort())
+    }
+
+    #[test]
+    fn parses_ipv4_literal() {
+        assert_eq!(
+            "10.0.0.4:7946".parse(),
+            Ok(SwimEndpoint::Literal(addr("10.0.0.4:7946")))
+        );
+    }
+
+    #[test]
+    fn parses_bracketed_ipv6_literal() {
+        assert_eq!(
+            "[2001:db8::4]:7946".parse(),
+            Ok(SwimEndpoint::Literal(addr("[2001:db8::4]:7946")))
+        );
+    }
+
+    #[test]
+    fn parses_hostname() {
+        assert_eq!(
+            "grid-swim.example.internal:7946".parse(),
+            Ok(SwimEndpoint::Hostname {
+                host: "grid-swim.example.internal".to_owned(),
+                port: 7946,
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_endpoint_shapes() {
+        for value in [
+            "host",
+            "host:0",
+            "host:",
+            "http://host:7946",
+            "/host:7946",
+            "2001:db8::4:7946",
+        ] {
+            assert!(value.parse::<SwimEndpoint>().is_err(), "{value} must be rejected");
+        }
+    }
+
+    #[tokio::test]
+    async fn resolves_multiple_addresses_deterministically_and_deduplicates() {
+        let endpoint = "grid.example:7946"
+            .parse::<SwimEndpoint>()
+            .unwrap_or_else(|_| std::process::abort());
+        let result = resolve_endpoint_with(
+            &endpoint,
+            "GRID_SWIM_SEEDS",
+            Duration::from_secs(1),
+            |_host, _port| async {
+                Ok(vec![
+                    addr("10.0.0.2:7946"),
+                    addr("10.0.0.1:7946"),
+                    addr("10.0.0.2:7946"),
+                ])
+            },
+        )
+        .await;
+        assert_eq!(result, Ok(vec![addr("10.0.0.1:7946"), addr("10.0.0.2:7946")]));
+    }
+
+    #[tokio::test]
+    async fn literal_seed_lists_trim_blanks_and_deduplicate() {
+        let raw = vec![
+            " 10.0.0.2:7946 ".to_owned(),
+            String::new(),
+            "10.0.0.1:7946".to_owned(),
+            "10.0.0.2:7946".to_owned(),
+        ];
+        let result = resolve_endpoint_list(&raw, "GridNetwork.spec.seeds").await;
+        assert_eq!(result, Ok(vec![addr("10.0.0.1:7946"), addr("10.0.0.2:7946")]));
+    }
+
+    #[tokio::test]
+    async fn mixed_literal_and_hostname_seed_lists_resolve_deterministically() {
+        let raw = vec!["10.0.0.2:7946".to_owned(), "grid.example:7946".to_owned()];
+        let result =
+            resolve_endpoint_list_with(&raw, "GRID_SWIM_SEEDS", Duration::from_secs(1), |_host, _port| async {
+                Ok(vec![addr("10.0.0.1:7946")])
+            })
+            .await;
+        assert_eq!(result, Ok(vec![addr("10.0.0.1:7946"), addr("10.0.0.2:7946")]));
+    }
+
+    #[tokio::test]
+    async fn partial_seed_resolution_keeps_healthy_entries() {
+        let raw = vec!["missing.example:7946".to_owned(), "healthy.example:7946".to_owned()];
+        let result = resolve_endpoint_list_partial_with(
+            &raw,
+            "GRID_SWIM_SEEDS",
+            Duration::from_secs(1),
+            Duration::from_secs(1),
+            |host, _port| {
+                let host = host.to_owned();
+                async move {
+                    if host == "missing.example" {
+                        Err(io::Error::new(io::ErrorKind::NotFound, "not found"))
+                    } else {
+                        Ok(vec![addr("10.0.0.2:7946")])
+                    }
+                }
+            },
+        )
+        .await;
+        assert_eq!(result.addresses, vec![addr("10.0.0.2:7946")]);
+        assert_eq!(result.failures.len(), 1);
+        assert!(result.is_degraded());
+    }
+
+    #[tokio::test]
+    async fn partial_seed_resolution_sorts_deduplicates_and_keeps_parse_failures() {
+        let raw = vec![
+            "healthy.example:7946".to_owned(),
+            "bad".to_owned(),
+            "other.example:7946".to_owned(),
+        ];
+        let result = resolve_endpoint_list_partial_with(
+            &raw,
+            "GridNetwork.spec.seeds",
+            Duration::from_secs(1),
+            Duration::from_secs(1),
+            |host, _port| {
+                let host = host.to_owned();
+                async move {
+                    Ok(if host == "healthy.example" {
+                        vec![addr("10.0.0.2:7946"), addr("10.0.0.1:7946")]
+                    } else {
+                        vec![addr("10.0.0.1:7946")]
+                    })
+                }
+            },
+        )
+        .await;
+        assert_eq!(result.addresses, vec![addr("10.0.0.1:7946"), addr("10.0.0.2:7946")]);
+        assert_eq!(result.failures.len(), 1);
+        assert!(
+            result
+                .failures
+                .first()
+                .is_some_and(|failure| failure.reason.contains("invalid endpoint"))
+        );
+    }
+
+    #[tokio::test]
+    async fn all_failed_nonempty_seed_list_is_degraded_but_empty_is_valid() {
+        let failed = resolve_endpoint_list_partial_with(
+            &["missing.example:7946".to_owned()],
+            "GridNetwork.spec.seeds",
+            Duration::from_secs(1),
+            Duration::from_secs(1),
+            |_host, _port| async { Err(io::Error::new(io::ErrorKind::NotFound, "not found")) },
+        )
+        .await;
+        assert!(failed.configured);
+        assert!(failed.addresses.is_empty());
+        assert!(failed.is_degraded());
+
+        let empty = resolve_endpoint_list_partial(&[], "GridNetwork.spec.seeds").await;
+        assert!(!empty.configured);
+        assert!(empty.addresses.is_empty());
+        assert!(!empty.is_degraded());
+    }
+
+    #[tokio::test]
+    async fn timed_out_seed_does_not_discard_other_success() {
+        let raw = vec!["slow.example:7946".to_owned(), "fast.example:7946".to_owned()];
+        let result = resolve_endpoint_list_partial_with(
+            &raw,
+            "GRID_SWIM_SEEDS",
+            Duration::from_millis(20),
+            Duration::from_millis(100),
+            |host, _port| {
+                let host = host.to_owned();
+                async move {
+                    if host == "slow.example" {
+                        std::future::pending::<io::Result<Vec<SocketAddr>>>().await
+                    } else {
+                        Ok(vec![addr("10.0.0.3:7946")])
+                    }
+                }
+            },
+        )
+        .await;
+        assert_eq!(result.addresses, vec![addr("10.0.0.3:7946")]);
+        assert_eq!(result.failures.len(), 1);
+        assert!(
+            result
+                .failures
+                .first()
+                .is_some_and(|failure| failure.reason.contains("timed out"))
+        );
+    }
+
+    #[tokio::test]
+    async fn reports_dns_failure_with_source_and_endpoint() {
+        let endpoint = "missing.example:7946"
+            .parse::<SwimEndpoint>()
+            .unwrap_or_else(|_| std::process::abort());
+        let result = resolve_endpoint_with(
+            &endpoint,
+            "GRID_SWIM_ADVERTISE_ADDR",
+            Duration::from_secs(1),
+            |_host, _port| async { Err(io::Error::new(io::ErrorKind::NotFound, "not found")) },
+        )
+        .await;
+        let error = result.err().unwrap_or_else(|| std::process::abort());
+        assert!(error.contains("GRID_SWIM_ADVERTISE_ADDR"));
+        assert!(error.contains("missing.example:7946"));
+    }
+
+    #[tokio::test]
+    async fn reports_dns_timeout() {
+        let endpoint = "slow.example:7946"
+            .parse::<SwimEndpoint>()
+            .unwrap_or_else(|_| std::process::abort());
+        let result = resolve_endpoint_with(
+            &endpoint,
+            "GRID_SWIM_SEEDS",
+            Duration::from_millis(1),
+            |_host, _port| async { std::future::pending::<io::Result<Vec<SocketAddr>>>().await },
+        )
+        .await;
+        let error = result.err().unwrap_or_else(|| std::process::abort());
+        assert!(error.contains("GRID_SWIM_SEEDS"));
+        assert!(error.contains("timed out"));
+    }
+}

--- a/xtask/src/env.rs
+++ b/xtask/src/env.rs
@@ -451,6 +451,20 @@ pub(crate) enum Action {
         site: Option<String>,
     },
 
+    /// Prove SWIM discovery and provider-state propagation with DNS endpoints.
+    ///
+    /// Starts two operators with hostname-based advertise and seed values,
+    /// then verifies membership and real provider-state propagation.
+    VerifySwimDnsHostnames {
+        /// Path to the environment config file.
+        #[arg(short, long, default_value = "tests/env/operator-routing.toml")]
+        config: PathBuf,
+
+        /// Kind cluster context to run against (first provider site by default).
+        #[arg(long)]
+        site: Option<String>,
+    },
+
     /// Run all validations in sequence and print a Markdown summary table.
     ///
     /// Runs, in order:
@@ -1137,6 +1151,7 @@ pub(crate) fn run(action: &Action) -> Result<(), Box<dyn std::error::Error>> {
         Action::VerifySwimMembership { config, site } => env_verify_swim_membership(config, site.as_deref()),
         Action::VerifySwimState { config, site } => env_verify_swim_state(config, site.as_deref()),
         Action::VerifySwimCrdSeeds { config, site } => env_verify_swim_crd_seeds(config, site.as_deref()),
+        Action::VerifySwimDnsHostnames { config, site } => env_verify_swim_dns_hostnames(config, site.as_deref()),
         Action::ValidateAll { config, site } => env_validate_all(config, site.as_deref()),
         Action::VerifyApiFallback { config, site } => env_verify_api_fallback(config, site.as_deref()),
         Action::VerifyApiFallbackNative { config, site } => env_verify_api_fallback_native(config, site.as_deref()),
@@ -2343,9 +2358,8 @@ fn env_verify_swim_membership(config: &Path, site: Option<&str>) -> Result<(), B
 ///
 /// Both operators start with `GRID_SWIM_SEEDS=""` — no startup seeds at all.
 /// After the `GridNetwork` fixture is applied with `spec.seeds = [bind1]`,
-/// each operator reconciles the resource and calls `announce_crd_seeds`:
-/// - Primary: `parse_crd_seeds([bind1], Some(bind1)) → []` (self-filtered) → no announce
-/// - Secondary: `parse_crd_seeds([bind1], Some(bind2)) → [bind1]` → announces to primary
+/// each operator resolves the resource and calls `announce_crd_seeds`; the
+/// local address is filtered and the secondary announces to the primary.
 ///
 /// SWIM gossip then converges and `GridNetwork.status.phase` becomes `Active`.
 /// The `GRID_SWIM_SEEDS` env var is empty for both operators throughout.
@@ -2517,6 +2531,117 @@ fn env_verify_swim_state(config: &Path, site: Option<&str>) -> Result<(), Box<dy
          distributedProviderCount={distributed_count})"
     );
     Ok(())
+}
+
+/// Prove SWIM membership and provider-state propagation using DNS endpoints.
+///
+/// `localhost` is intentional: the two out-of-cluster operators bind to
+/// distinct loopback ports, so this exercises the production hostname resolver
+/// without depending on public DNS or cluster DNS from the host.
+#[expect(
+    clippy::too_many_lines,
+    reason = "one bounded qualification keeps startup, convergence, propagation, evidence, and cleanup together"
+)]
+fn env_verify_swim_dns_hostnames(config: &Path, site: Option<&str>) -> Result<(), Box<dyn std::error::Error>> {
+    use operator::{
+        SWIM_NODE_PRIMARY_NAME, SWIM_NODE_SECONDARY_NAME, SWIM_STATUS_POLL_TIMEOUT, SWIM_TEST_NETWORK,
+        SWIM_TEST_PROVIDER, SWIM_TEST_PROVIDER_MODEL,
+    };
+
+    let cfg = EnvConfig::from_file(config)?;
+    let context = resolve_operator_context(&cfg, site)?;
+    eprintln!("verify-swim-dns-hostnames: context={context}");
+    operator::install_grid_crds(&context)?;
+    operator::cleanup_swim_test_resources(&context)?;
+
+    let (bind1, bind2) = reserve_swim_bind_addrs()?;
+    let advertise1 = hostname_for_swim_addr(&bind1)?;
+    let advertise2 = hostname_for_swim_addr(&bind2)?;
+    let rejected_seed = "missing.grid-swim.invalid:7946";
+    let seeds1 = format!("{rejected_seed},{advertise2}");
+    let seeds2 = format!("{rejected_seed},{advertise1}");
+
+    let evidence_dir = std::env::var("GRID_SWIM_DNS_EVIDENCE_DIR")
+        .map_or_else(|_| PathBuf::from("/tmp/grid-swim-dns-hostnames"), PathBuf::from);
+    std::fs::create_dir_all(&evidence_dir)?;
+    std::fs::write(
+        evidence_dir.join("summary.txt"),
+        format!(
+            "context={context}\nconfigured_advertise={advertise1},{advertise2}\n\
+             configured_seeds={seeds1};{seeds2}\nrejected_seed={rejected_seed}\n\
+             resolved_advertise={bind1},{bind2}\nresolution=bounded concurrent startup DNS; successful seed addresses retained, sorted, and deduplicated\n"
+        ),
+    )?;
+    std::fs::write(
+        evidence_dir.join("summary.json"),
+        serde_json::to_vec_pretty(&serde_json::json!({
+            "context": context,
+            "configured_advertise": [advertise1, advertise2],
+            "configured_seeds": [seeds1, seeds2],
+            "intentionally_rejected_seed": rejected_seed,
+            "resolved_advertise": [bind1, bind2],
+            "seed_resolution": {
+                "mode": "partial_success_is_retained",
+                "aggregate_timeout_seconds": 10,
+                "ordering": "sorted_and_deduplicated",
+            },
+        }))?,
+    )?;
+
+    let op1 = operator::spawn_operator_with_swim_for_context(
+        &context,
+        &bind1,
+        &advertise1,
+        SWIM_NODE_PRIMARY_NAME,
+        &seeds1,
+        None,
+    )?;
+    let op1_guard = ProcGuard(Some(op1), "dns-operator-primary");
+    let op2 = operator::spawn_operator_with_swim_for_context(
+        &context,
+        &bind2,
+        &advertise2,
+        SWIM_NODE_SECONDARY_NAME,
+        &seeds2,
+        None,
+    )?;
+    let op2_guard = ProcGuard(Some(op2), "dns-operator-secondary");
+
+    let result = (|| -> Result<(), Box<dyn std::error::Error>> {
+        operator::apply_swim_test_network(&context)?;
+        operator::apply_swim_test_provider(&context)?;
+        let connected = operator::wait_for_gridnetwork_active(&context, SWIM_TEST_NETWORK, SWIM_STATUS_POLL_TIMEOUT)?;
+        let distributed =
+            operator::wait_for_gridnetwork_distributed_state(&context, SWIM_TEST_NETWORK, SWIM_STATUS_POLL_TIMEOUT)?;
+        operator::verify_swim_status("Active", connected)?;
+        operator::verify_distributed_state_received(distributed)?;
+        eprintln!(
+            "verify-swim-dns-hostnames: PASS (configured DNS endpoints {advertise1}, {advertise2}; \
+             resolved {bind1}, {bind2}; provider={SWIM_TEST_PROVIDER}; model={SWIM_TEST_PROVIDER_MODEL}; \
+             connectedSites={connected}; distributedProviderCount={distributed})"
+        );
+        Ok(())
+    })();
+
+    drop(op2_guard);
+    drop(op1_guard);
+    for (site_name, log_name) in [
+        (SWIM_NODE_PRIMARY_NAME, "operator-primary.log"),
+        (SWIM_NODE_SECONDARY_NAME, "operator-secondary.log"),
+    ] {
+        let source = format!("/tmp/grid-operator-{site_name}.log");
+        drop(std::fs::copy(source, evidence_dir.join(log_name)));
+    }
+    operator::cleanup_swim_test_resources(&context)?;
+    result
+}
+
+/// Replace a loopback bind address with the equivalent DNS-based localhost endpoint.
+fn hostname_for_swim_addr(addr: &str) -> Result<String, Box<dyn std::error::Error>> {
+    let (_, port) = addr
+        .rsplit_once(':')
+        .ok_or_else(|| format!("SWIM bind address {addr:?} has no port"))?;
+    Ok(format!("localhost:{port}"))
 }
 
 /// Prove that SWIM transport AES-256-GCM encryption is enforced.

--- a/xtask/src/env/operator.rs
+++ b/xtask/src/env/operator.rs
@@ -1247,7 +1247,7 @@ pub(crate) fn spawn_operator(context: &str) -> Result<Child, Box<dyn std::error:
 ///
 /// `bind_addr` and `advertise_addr` are the SWIM UDP addresses.
 /// `site_name` is the stable SWIM site identity.
-/// `seeds` is a comma-separated list of seed addresses (empty = no seeds).
+/// `seeds` is a comma-separated list of seed endpoints (empty = no seeds).
 #[expect(
     clippy::too_many_lines,
     reason = "kubeconfig export + process spawn + sleep: splitting obscures the startup contract"
@@ -1729,10 +1729,9 @@ pub(crate) fn apply_swim_test_network(context: &str) -> Result<(), Box<dyn std::
 ///
 /// Both operators are started with `GRID_SWIM_SEEDS=""`.  The secondary operator
 /// has no peer at startup.  After this fixture is applied, the secondary's
-/// `GridNetwork` reconcile calls `parse_crd_seeds(spec.seeds, local_addr)`
-/// which filters out the primary address only if it matches the secondary's
-/// own `local_addr`; since it does not, the secondary announces to the primary
-/// via the SWIM runtime channel.  SWIM gossip then converges and the `GridNetwork`
+/// `GridNetwork` reconcile resolves and normalizes `spec.seeds`, filters out
+/// the local address, and announces to the primary via the SWIM runtime
+/// channel.  SWIM gossip then converges and the `GridNetwork`
 /// reaches `Active`.
 ///
 /// # Errors


### PR DESCRIPTION
## Summary

Allow SWIM advertise and seed configuration to use DNS hostnames in addition to literal IPv4 and bracketed IPv6 socket addresses.

This removes the need to resolve and pin addresses such as AWS NLB IPs before deploying Grid. Literal socket addresses retain their existing behavior and avoid DNS lookup.

Closes #133.

## Behavior

- `GRID_SWIM_ADVERTISE_ADDR`, `GRID_SWIM_SEEDS`, and `GridNetwork.spec.seeds` accept `10.0.0.4:7946`, `[2001:db8::4]:7946`, and `grid-swim.example.internal:7946`.
- Advertise hostnames resolve during startup under a five-second bound. The first address in deterministic sorted order is advertised as the concrete SWIM address.
- An explicitly configured advertise endpoint fails startup when malformed, unresolved, empty, or timed out. Grid does not silently enter static mode or substitute the bind address.
- Seed entries resolve independently and concurrently. Successful addresses are retained, sorted, and deduplicated when another seed is malformed, unavailable, or slow.
- A configured startup seed list with no usable addresses keeps SWIM active in seedless bootstrap mode and reports degradation.
- CRD seed resolution runs during reconciliation. If all configured seeds fail, the controller retains its last-known-good resolved set; a later successful lookup recovers automatically.
- Empty seed configuration remains a valid seedless bootstrap case.

DNS resolution is bounded per endpoint and across the complete seed list. This change does not add continuous advertise-address re-resolution or DNS caching.

## Implementation

- Adds a typed SWIM endpoint parser and bounded Tokio DNS resolver.
- Keeps bind/listen addresses as concrete `SocketAddr` values; DNS applies only to advertise and seed inputs.
- Replaces sequential, all-or-nothing seed parsing with bounded concurrent partial resolution.
- Adds explicit CRD decisions for announcing resolved addresses, retaining last-known-good state, and initial seedless operation.
- Updates Helm values, generated CRDs, operations documentation, and the qualification catalog.
- Adds `cargo xtask env verify-swim-dns-hostnames`, which starts two real SWIM operators using hostname endpoints and proves membership plus remote provider-state propagation.

## Tests

Focused coverage includes IPv4 and bracketed IPv6 literals, hostname parsing, deterministic multi-address resolution, malformed endpoints, mixed IP/DNS lists, partial DNS failures and timeouts, sorting and deduplication, empty and wholly failed lists, actionable diagnostics, CRD last-known-good retention and recovery, fatal advertise failures, and unchanged IP-only behavior.

Validation completed successfully:

- workspace tests and Clippy with warnings denied;
- formatting and diff checks;
- `make test`, `make doc`, and `make lint`;
- CRD schema validation and parity;
- Forge topology validation;
- two fresh `verify-swim-dns-hostnames` Kind qualifications.

Both qualification runs proved SWIM membership and remote provider-state propagation while one seed intentionally failed and another hostname seed remained healthy. Automatic cleanup passed and unrelated Kind clusters and Docker networks were preserved.

## Qualification limitation

The deterministic qualification runs operators outside Kind and uses `localhost` DNS with distinct loopback ports. This exercises the production resolver and real SWIM/CRDT path without public DNS. It does not independently validate Kubernetes Service DNS or an external load balancer; those remain deployment-environment concerns.
