### PR TITLE
feat(tls): add opt-in fips feature for a system-openssl TLS backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -864,6 +864,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "forge"
 version = "0.1.4"
 dependencies = [
@@ -1195,6 +1210,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-openssl"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527d4d619ca2c2aafa31ec139a3d1d60bf557bf7578a1f20f743637eccd9ca19"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "linked_hash_set",
+ "once_cell",
+ "openssl",
+ "openssl-sys",
+ "parking_lot",
+ "pin-project",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1221,6 +1255,22 @@ dependencies = [
  "hyper-util",
  "pin-project-lite",
  "tokio",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
  "tower-service",
 ]
 
@@ -1590,6 +1640,7 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-openssl",
  "hyper-rustls",
  "hyper-timeout",
  "hyper-util",
@@ -1597,6 +1648,7 @@ dependencies = [
  "jsonpath-rust",
  "k8s-openapi",
  "kube-core",
+ "openssl",
  "pem 3.0.6",
  "rustls",
  "rustls-platform-verifier",
@@ -1683,6 +1735,21 @@ name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
+name = "linked_hash_set"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "984fb35d06508d1e69fc91050cceba9c0b748f983e6739fa2c7a9237154c52c8"
+dependencies = [
+ "linked-hash-map",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -1801,6 +1868,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "743fb55ba31b18fb1ecef6bdc9aa2743314978ac084044301a7eee33fb99a20d"
 
 [[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1881,10 +1965,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "openssl"
+version = "0.10.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
+dependencies = [
+ "bitflags 2.13.1",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "operator"
@@ -2062,6 +2183,12 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "polyval"
@@ -2311,9 +2438,11 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "rustls",
@@ -2323,6 +2452,7 @@ dependencies = [
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower",
@@ -3043,6 +3173,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3340,6 +3480,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,19 +33,14 @@ hyper = { version = "1", features = ["client", "http1"] }
 hyper-rustls = { version = "0.27", default-features = false, features = ["http1", "native-tokio", "ring"] }
 hyper-util = { version = "0.1", features = ["client", "client-legacy", "http1", "tokio"] }
 k8s-openapi = { version = "0.28.0", features = ["v1_32"] }
-kube = { version = "4.2.0", features = ["client", "derive", "runtime", "rustls-tls"] }
+kube = { version = "4.2.0", default-features = false, features = ["client", "derive", "runtime"] }
 prometheus = "0.14"
 rcgen = "0.14.9"
-# rustls-no-provider (not "rustls"): the plain "rustls" feature pulls in
-# aws-lc-rs as reqwest's crypto provider, which conflicts at runtime with the
-# ring provider main.rs installs process-wide for kube/hyper-rustls — see
-# rustls::crypto::CryptoProvider::install_default() in main.rs.
-reqwest = { version = "0.13.4", default-features = false, features = ["rustls-no-provider", "json", "stream"] }
+reqwest = { version = "0.13.4", default-features = false, features = ["json", "stream"] }
 ring = "0.17"
 rmcp = { version = "3.1.4", default-features = false, features = [
     "client",
     "transport-streamable-http-client-reqwest",
-    "reqwest-tls-no-provider",
 ] }
 rustls = { version = "0.23", default-features = false, features = ["logging", "std", "tls12"] }
 schemars = "1.2.2"

--- a/docs/fips.md
+++ b/docs/fips.md
@@ -1,0 +1,13 @@
+# FIPS support
+
+For a FIPS build, all crypto must route through the system openssl
+(dynamically linked libssl and libcrypto). Pure-Rust crypto (rustls, ring,
+sha2) and a statically vendored openssl fall outside the validated boundary.
+
+An opt-in `fips` feature on the operator and overlay-sync crates routes the
+TLS client stacks (reqwest, rmcp, kube) through system openssl instead of
+rustls:
+
+    cargo build -p operator --no-default-features --features fips
+
+Default builds keep rustls and are unchanged.

--- a/operator/Cargo.toml
+++ b/operator/Cargo.toml
@@ -7,6 +7,11 @@ rust-version.workspace = true
 license.workspace = true
 publish = false
 
+[features]
+default = ["tls-rustls"]
+tls-rustls = ["reqwest/rustls-no-provider", "rmcp/reqwest-tls-no-provider", "kube/rustls-tls", "kube/ring"]
+fips = ["reqwest/native-tls", "rmcp/reqwest-native-tls", "kube/openssl-tls"]
+
 [dependencies]
 axum = { workspace = true }
 bytes = { workspace = true }

--- a/operator/src/lib.rs
+++ b/operator/src/lib.rs
@@ -12,6 +12,11 @@
     reason = "operator uses short closure params, index arithmetic, and casts pervasively"
 )]
 
+#[cfg(all(feature = "tls-rustls", feature = "fips"))]
+compile_error!(
+    "features `tls-rustls` and `fips` are mutually exclusive; build a FIPS binary with --no-default-features --features fips"
+);
+
 /// Command-line interface.
 pub mod cli;
 

--- a/operator/src/resources/mcp_probe.rs
+++ b/operator/src/resources/mcp_probe.rs
@@ -639,11 +639,26 @@ async fn attach_tls_ca(
     Ok(builder.tls_certs_only([ca_cert]))
 }
 
+/// Build the probe client identity: rustls takes one concatenated PEM, native-tls (fips) takes cert and key separately.
+#[cfg(not(feature = "fips"))]
+fn build_probe_client_identity(cert_pem: &[u8], key_pem: &[u8]) -> Result<reqwest::Identity, reqwest::Error> {
+    let mut combined = Vec::with_capacity(cert_pem.len() + key_pem.len());
+    combined.extend_from_slice(cert_pem);
+    combined.extend_from_slice(key_pem);
+    reqwest::Identity::from_pem(&combined)
+}
+
+/// Build the probe client identity: rustls takes one concatenated PEM, native-tls (fips) takes cert and key separately.
+#[cfg(feature = "fips")]
+fn build_probe_client_identity(cert_pem: &[u8], key_pem: &[u8]) -> Result<reqwest::Identity, reqwest::Error> {
+    reqwest::Identity::from_pkcs8_pem(cert_pem, key_pem)
+}
+
 /// Read `client_ref`'s certificate and private key and attach them to
 /// `builder` as the mTLS client identity.
 #[expect(
     clippy::too_many_lines,
-    reason = "sequential cert+key reads, eager rustls PEM validation for each, then the reqwest Identity build"
+    reason = "sequential cert and key reads, then eager PEM validation of each"
 )]
 async fn attach_tls_client_identity(
     builder: reqwest::ClientBuilder,
@@ -652,7 +667,7 @@ async fn attach_tls_client_identity(
     provider_identity: &str,
 ) -> Result<reqwest::ClientBuilder, McpProbeOutcome> {
     let cert_ref = secret_ref_from_client_cert(client_ref);
-    let mut identity_pem = Box::pin(read_tls_material(
+    let identity_pem = Box::pin(read_tls_material(
         kube_client,
         &cert_ref,
         &client_ref.certificate_key,
@@ -680,11 +695,7 @@ async fn attach_tls_client_identity(
             ENDPOINT_TLS_IDENTITY_MISMATCH.to_owned(),
         ));
     }
-    identity_pem.extend_from_slice(&key_pem);
-    // As in `attach_tls_ca`: the strict `rustls::pki_types` validation above
-    // is the real gate; this call still has to happen to build the
-    // `Identity` reqwest will actually use.
-    let identity = reqwest::Identity::from_pem(&identity_pem).map_err(|e| {
+    let identity = build_probe_client_identity(&identity_pem, &key_pem).map_err(|e| {
         tracing::warn!(provider_identity, error = %e, "AgentToolProvider probe client identity unparseable");
         McpProbeOutcome::TlsConfigInvalid(ENDPOINT_TLS_IDENTITY_MISMATCH.to_owned())
     })?;

--- a/overlay-sync/Cargo.toml
+++ b/overlay-sync/Cargo.toml
@@ -10,6 +10,11 @@ license.workspace = true
 name = "grid-overlay-sync"
 path = "src/main.rs"
 
+[features]
+default = ["tls-rustls"]
+tls-rustls = ["kube/rustls-tls", "kube/ring"]
+fips = ["kube/openssl-tls"]
+
 [dependencies]
 axum = { workspace = true }
 clap = { workspace = true, features = ["env"] }

--- a/overlay-sync/src/main.rs
+++ b/overlay-sync/src/main.rs
@@ -14,6 +14,11 @@
     reason = "overlay-sync uses short closure params and index arithmetic pervasively"
 )]
 
+#[cfg(all(feature = "tls-rustls", feature = "fips"))]
+compile_error!(
+    "features `tls-rustls` and `fips` are mutually exclusive; build a FIPS binary with --no-default-features --features fips"
+);
+
 mod atomic_file;
 mod metrics;
 mod status;


### PR DESCRIPTION
## Summary

Add an opt-in `fips` cargo feature to the operator and overlay-sync crates that routes the TLS client stacks through the system OpenSSL instead of rustls:

- reqwest: `native-tls`
- rmcp: `reqwest-native-tls`
- kube: `openssl-tls`

The TLS backend is no longer pinned in the workspace dependencies. Each crate selects it through its default (`tls-rustls`) or `fips` feature, so default builds are unchanged. The two features are mutually exclusive; enabling both fails with a `compile_error`, so a FIPS build uses the command below.

## Motivation

A FIPS build requires all crypto to route through the system OpenSSL (dynamically linked libssl and libcrypto). Pure-Rust crypto such as rustls and ring falls outside the validated boundary. This is the first step toward a FIPS-capable build.

## What Changed

This PR covers the TLS client stacks only (reqwest, rmcp, kube). A FIPS build still links rustls and hyper-rustls, because the operator's own TLS (the probe connectors and the gossip signing) has not moved to OpenSSL yet.

The rest is split into follow-ups: a refactor that routes all operator TLS through one `tls_backend` module (#145), then a PR that implements the OpenSSL backend so a FIPS build contains no rustls. The gossip signature migration from ring to OpenSSL is tracked separately, since it needs wire-compatible signatures.

## Build

    cargo build -p operator --no-default-features --features fips

## Notes

On the `fips` path the MCP probe builds the client identity with `from_pkcs8_pem` (cert and key passed separately), since native-tls has no `from_pem`.
