### PR TITLE
refactor(operator): route TLS through a tls_backend module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -864,6 +864,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "forge"
 version = "0.1.4"
 dependencies = [
@@ -1195,6 +1210,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-openssl"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527d4d619ca2c2aafa31ec139a3d1d60bf557bf7578a1f20f743637eccd9ca19"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "linked_hash_set",
+ "once_cell",
+ "openssl",
+ "openssl-sys",
+ "parking_lot",
+ "pin-project",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1221,6 +1255,22 @@ dependencies = [
  "hyper-util",
  "pin-project-lite",
  "tokio",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
  "tower-service",
 ]
 
@@ -1590,6 +1640,7 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-openssl",
  "hyper-rustls",
  "hyper-timeout",
  "hyper-util",
@@ -1597,6 +1648,7 @@ dependencies = [
  "jsonpath-rust",
  "k8s-openapi",
  "kube-core",
+ "openssl",
  "pem 3.0.6",
  "rustls",
  "rustls-platform-verifier",
@@ -1683,6 +1735,21 @@ name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
+name = "linked_hash_set"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "984fb35d06508d1e69fc91050cceba9c0b748f983e6739fa2c7a9237154c52c8"
+dependencies = [
+ "linked-hash-map",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -1801,6 +1868,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "743fb55ba31b18fb1ecef6bdc9aa2743314978ac084044301a7eee33fb99a20d"
 
 [[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1881,10 +1965,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "openssl"
+version = "0.10.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
+dependencies = [
+ "bitflags 2.13.1",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "operator"
@@ -2062,6 +2183,12 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "polyval"
@@ -2311,9 +2438,11 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "rustls",
@@ -2323,6 +2452,7 @@ dependencies = [
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower",
@@ -3043,6 +3173,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3340,6 +3480,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,19 +33,14 @@ hyper = { version = "1", features = ["client", "http1"] }
 hyper-rustls = { version = "0.27", default-features = false, features = ["http1", "native-tokio", "ring"] }
 hyper-util = { version = "0.1", features = ["client", "client-legacy", "http1", "tokio"] }
 k8s-openapi = { version = "0.28.0", features = ["v1_32"] }
-kube = { version = "4.2.0", features = ["client", "derive", "runtime", "rustls-tls"] }
+kube = { version = "4.2.0", default-features = false, features = ["client", "derive", "runtime"] }
 prometheus = "0.14"
 rcgen = "0.14.9"
-# rustls-no-provider (not "rustls"): the plain "rustls" feature pulls in
-# aws-lc-rs as reqwest's crypto provider, which conflicts at runtime with the
-# ring provider main.rs installs process-wide for kube/hyper-rustls — see
-# rustls::crypto::CryptoProvider::install_default() in main.rs.
-reqwest = { version = "0.13.4", default-features = false, features = ["rustls-no-provider", "json", "stream"] }
+reqwest = { version = "0.13.4", default-features = false, features = ["json", "stream"] }
 ring = "0.17"
 rmcp = { version = "3.1.4", default-features = false, features = [
     "client",
     "transport-streamable-http-client-reqwest",
-    "reqwest-tls-no-provider",
 ] }
 rustls = { version = "0.23", default-features = false, features = ["logging", "std", "tls12"] }
 schemars = "1.2.2"

--- a/docs/fips.md
+++ b/docs/fips.md
@@ -1,0 +1,13 @@
+# FIPS support
+
+For a FIPS build, all crypto must route through the system openssl
+(dynamically linked libssl and libcrypto). Pure-Rust crypto (rustls, ring,
+sha2) and a statically vendored openssl fall outside the validated boundary.
+
+An opt-in `fips` feature on the operator and overlay-sync crates routes the
+TLS client stacks (reqwest, rmcp, kube) through system openssl instead of
+rustls:
+
+    cargo build -p operator --no-default-features --features fips
+
+Default builds keep rustls and are unchanged.

--- a/operator/Cargo.toml
+++ b/operator/Cargo.toml
@@ -7,6 +7,11 @@ rust-version.workspace = true
 license.workspace = true
 publish = false
 
+[features]
+default = ["tls-rustls"]
+tls-rustls = ["reqwest/rustls-no-provider", "rmcp/reqwest-tls-no-provider", "kube/rustls-tls", "kube/ring"]
+fips = ["reqwest/native-tls", "rmcp/reqwest-native-tls", "kube/openssl-tls"]
+
 [dependencies]
 axum = { workspace = true }
 bytes = { workspace = true }

--- a/operator/src/controller/grid_site.rs
+++ b/operator/src/controller/grid_site.rs
@@ -17,7 +17,6 @@ use kube::{
         events::{Event, EventType, Recorder, Reporter},
     },
 };
-use rustls::pki_types::ServerName;
 use tokio::time::Duration;
 use tracing::info;
 use zeroize::Zeroizing;
@@ -318,7 +317,8 @@ async fn build_probe_config_from_secrets(
         .and_then(|e| e.tls.server_name.as_deref())
         .ok_or(O::TrustMaterialMissing)?;
     validate_server_name(server_name_str).map_err(|_err| O::TrustMaterialInvalid)?;
-    let server_name = ServerName::try_from(server_name_str.to_owned()).map_err(|_err| O::TrustMaterialInvalid)?;
+    let server_name =
+        crate::resources::tls_backend::parse_server_name(server_name_str).map_err(|_err| O::TrustMaterialInvalid)?;
 
     let pins = resolve_pins(site)?;
 

--- a/operator/src/controller/inference_provider.rs
+++ b/operator/src/controller/inference_provider.rs
@@ -410,7 +410,7 @@ pub(crate) fn requeue_interval_for_provider(spec: &InferenceProviderSpec) -> Dur
 pub(crate) async fn probe_endpoint(
     url: &str,
     timeout: Duration,
-    tls_config: Option<Arc<rustls::ClientConfig>>,
+    tls_config: Option<crate::resources::tls_backend::ClientTlsConfig>,
 ) -> ProbeOutcome {
     let Ok(uri) = url.parse::<http::Uri>() else {
         return ProbeOutcome::Unavailable;
@@ -432,14 +432,14 @@ pub(crate) async fn probe_endpoint(
     }
 
     let connector = if let Some(config) = &tls_config {
-        // Custom TLS config — use the provided CA / client identity.
+        // Custom TLS config: use the provided CA / client identity.
         crate::metrics_scraper::build_custom_tls_connector(config)
     } else {
-        // No custom TLS — use native root certificates.
-        let Ok(tls_builder) = hyper_rustls::HttpsConnectorBuilder::new().with_native_roots() else {
-            return ProbeOutcome::Unavailable;
-        };
-        tls_builder.https_or_http().enable_http1().build()
+        // No custom TLS: use native root certificates.
+        match crate::metrics_scraper::build_native_connector() {
+            Ok(connector) => connector,
+            Err(_err) => return ProbeOutcome::Unavailable,
+        }
     };
 
     let client: HyperClient<_, Empty<Bytes>> = HyperClient::builder(TokioExecutor::new()).build(connector);

--- a/operator/src/lib.rs
+++ b/operator/src/lib.rs
@@ -12,6 +12,11 @@
     reason = "operator uses short closure params, index arithmetic, and casts pervasively"
 )]
 
+#[cfg(all(feature = "tls-rustls", feature = "fips"))]
+compile_error!(
+    "features `tls-rustls` and `fips` are mutually exclusive; build a FIPS binary with --no-default-features --features fips"
+);
+
 /// Command-line interface.
 pub mod cli;
 

--- a/operator/src/lib.rs
+++ b/operator/src/lib.rs
@@ -35,7 +35,7 @@ pub mod metrics_scraper;
 /// Kubernetes resource builders.
 pub mod resources;
 
-pub use resources::trust_bundle::sha256_fingerprint;
+pub use resources::{tls_backend::init_process_crypto, trust_bundle::sha256_fingerprint};
 /// Provider gateway address self-discovery.
 pub mod gateway;
 /// SWIM membership data model and status summarization.

--- a/operator/src/main.rs
+++ b/operator/src/main.rs
@@ -88,24 +88,9 @@ async fn main() {
     tracing_subscriber::fmt::init();
     tracing::info!("starting grid-operator");
 
-    // Explicit process-wide rustls crypto-provider choice.
-    //
-    // `InferenceProvider`'s probe (`inference_provider.rs`) builds a
-    // `hyper-rustls` client via `.with_native_roots()`, which relies on
-    // `rustls` auto-detecting a single process-wide `CryptoProvider`. The
-    // `AgentToolProvider` MCP probe (PR 2 of grid#41) links in `reqwest`
-    // (via `rmcp`'s reqwest-backed transport) using its `rustls-no-provider`
-    // feature specifically to avoid pulling in `aws-lc-rs` alongside `ring`
-    // (see the workspace `Cargo.toml` comment on the `reqwest`/`rmcp`
-    // entries) — but that feature means `reqwest` will no longer install a
-    // default provider on our behalf either, so `Client::builder().build()`
-    // panics with "No rustls crypto provider is configured" unless one is
-    // installed explicitly first. Installing `ring` here, once, up front,
-    // covers both `hyper-rustls` and `reqwest` for every reconciler in this
-    // binary, regardless of which one runs first.
-    if rustls::crypto::ring::default_provider().install_default().is_err() {
-        tracing::warn!("rustls default CryptoProvider already installed; continuing");
-    }
+    // Install the process-wide crypto provider the TLS stack requires, once,
+    // up front, before any reconciler builds a client.
+    operator::init_process_crypto();
 
     let config = Cli::parse();
 

--- a/operator/src/metrics_scraper.rs
+++ b/operator/src/metrics_scraper.rs
@@ -25,28 +25,20 @@
 //!
 //! [`rustls::ClientConfig`]: rustls::ClientConfig
 
-use std::{sync::Arc, time::Duration};
+use std::time::Duration;
 
 use bytes::Bytes;
 use http_body_util::{BodyExt as _, Empty, Limited};
 use hyper_util::{client::legacy::Client as HyperClient, rt::TokioExecutor};
-use rustls::pki_types::{CertificateDer, PrivateKeyDer, pem::PemObject as _};
+
+use crate::resources::tls_backend::ClientTlsConfig;
+pub(crate) use crate::resources::tls_backend::{
+    build_custom_tls_connector, build_native_connector, build_tls_client_config,
+};
 
 // ---------------------------------------------------------------------------
 // Bounded input limits
 // ---------------------------------------------------------------------------
-
-/// Maximum size for a CA PEM bundle (256 KiB).
-const MAX_CA_PEM_BYTES: usize = 256 * 1024;
-
-/// Maximum size for a client certificate PEM (64 KiB).
-const MAX_CLIENT_CERT_PEM_BYTES: usize = 64 * 1024;
-
-/// Maximum size for a client private key PEM (64 KiB).
-const MAX_CLIENT_KEY_PEM_BYTES: usize = 64 * 1024;
-
-/// Maximum number of certificates in a CA or client chain.
-const MAX_CERT_CHAIN_LENGTH: usize = 10;
 
 /// Maximum size for a metrics response body (1 MiB).
 const MAX_RESPONSE_BODY_BYTES: usize = 1024 * 1024;
@@ -119,7 +111,7 @@ pub enum MetricsScrapeError {
 pub async fn scrape_metrics(
     url: &str,
     timeout: Duration,
-    tls_config: Option<Arc<rustls::ClientConfig>>,
+    tls_config: Option<ClientTlsConfig>,
 ) -> Result<String, MetricsScrapeError> {
     let uri = url
         .parse::<http::Uri>()
@@ -180,133 +172,6 @@ pub async fn scrape_metrics(
 }
 
 // ---------------------------------------------------------------------------
-// TLS client config builder
-// ---------------------------------------------------------------------------
-
-/// Build a [`rustls::ClientConfig`] from raw PEM bytes.
-///
-/// `ca_pem` is the CA certificate chain (required).  `client_cert_pem` and
-/// `client_key_pem` are the client identity for mTLS (both required together,
-/// or both absent for one-way TLS).
-///
-/// # Security invariant
-///
-/// Private key bytes are consumed by `rustls` and never written to logs,
-/// events, status fields, or Prometheus labels.
-///
-/// # Errors
-///
-/// Returns [`MetricsScrapeError::TlsMaterial`] when PEM parsing fails or the
-/// material is structurally invalid.
-#[expect(
-    clippy::too_many_lines,
-    reason = "sequential PEM parsing for CA, client cert, and client key with validation"
-)]
-pub fn build_tls_client_config(
-    ca_pem: &[u8],
-    client_cert_pem: Option<&[u8]>,
-    client_key_pem: Option<&[u8]>,
-) -> Result<rustls::ClientConfig, MetricsScrapeError> {
-    if ca_pem.len() > MAX_CA_PEM_BYTES {
-        return Err(MetricsScrapeError::TlsMaterial(format!(
-            "CA PEM exceeds maximum size ({} bytes > {MAX_CA_PEM_BYTES})",
-            ca_pem.len()
-        )));
-    }
-
-    let mut root_store = rustls::RootCertStore::empty();
-    let ca_certs = CertificateDer::pem_slice_iter(ca_pem)
-        .collect::<Result<Vec<_>, _>>()
-        .map_err(|e| MetricsScrapeError::TlsMaterial(format!("CA PEM parse failed: {e}")))?;
-    if ca_certs.is_empty() {
-        return Err(MetricsScrapeError::TlsMaterial(
-            "CA PEM contains no certificates".to_owned(),
-        ));
-    }
-    if ca_certs.len() > MAX_CERT_CHAIN_LENGTH {
-        return Err(MetricsScrapeError::TlsMaterial(format!(
-            "CA PEM contains too many certificates ({} > {MAX_CERT_CHAIN_LENGTH})",
-            ca_certs.len()
-        )));
-    }
-    for cert in &ca_certs {
-        root_store
-            .add(cert.clone())
-            .map_err(|e| MetricsScrapeError::TlsMaterial(format!("CA certificate invalid: {e}")))?;
-    }
-
-    let builder = rustls::ClientConfig::builder().with_root_certificates(root_store);
-
-    let config = match (client_cert_pem, client_key_pem) {
-        (Some(cert_pem), Some(key_pem)) => {
-            if cert_pem.len() > MAX_CLIENT_CERT_PEM_BYTES {
-                return Err(MetricsScrapeError::TlsMaterial(format!(
-                    "client cert PEM exceeds maximum size ({} bytes > {MAX_CLIENT_CERT_PEM_BYTES})",
-                    cert_pem.len()
-                )));
-            }
-            if key_pem.len() > MAX_CLIENT_KEY_PEM_BYTES {
-                return Err(MetricsScrapeError::TlsMaterial(format!(
-                    "client key PEM exceeds maximum size ({} bytes > {MAX_CLIENT_KEY_PEM_BYTES})",
-                    key_pem.len()
-                )));
-            }
-            let certs = CertificateDer::pem_slice_iter(cert_pem)
-                .collect::<Result<Vec<_>, _>>()
-                .map_err(|e| MetricsScrapeError::TlsMaterial(format!("client cert PEM parse failed: {e}")))?;
-            if certs.is_empty() {
-                return Err(MetricsScrapeError::TlsMaterial(
-                    "client cert PEM contains no certificates".to_owned(),
-                ));
-            }
-            if certs.len() > MAX_CERT_CHAIN_LENGTH {
-                return Err(MetricsScrapeError::TlsMaterial(format!(
-                    "client cert PEM contains too many certificates ({} > {MAX_CERT_CHAIN_LENGTH})",
-                    certs.len()
-                )));
-            }
-            let key = PrivateKeyDer::from_pem_slice(key_pem)
-                .map_err(|e| MetricsScrapeError::TlsMaterial(format!("client key PEM parse failed: {e}")))?;
-            builder
-                .with_client_auth_cert(certs, key)
-                .map_err(|e| MetricsScrapeError::TlsMaterial(format!("client identity construction failed: {e}")))?
-        },
-        (None, None) => builder.with_no_client_auth(),
-        _ => {
-            return Err(MetricsScrapeError::TlsMaterial(
-                "client cert and key must both be present or both absent".to_owned(),
-            ));
-        },
-    };
-
-    Ok(config)
-}
-
-// ---------------------------------------------------------------------------
-// Connector builders
-// ---------------------------------------------------------------------------
-
-/// Build an HTTPS connector using native root certificates.
-fn build_native_connector()
--> Result<hyper_rustls::HttpsConnector<hyper_util::client::legacy::connect::HttpConnector>, MetricsScrapeError> {
-    hyper_rustls::HttpsConnectorBuilder::new()
-        .with_native_roots()
-        .map(|b| b.https_or_http().enable_http1().build())
-        .map_err(|e| MetricsScrapeError::Transport(e.into()))
-}
-
-/// Build an HTTPS-only connector using a custom [`rustls::ClientConfig`].
-pub(crate) fn build_custom_tls_connector(
-    config: &rustls::ClientConfig,
-) -> hyper_rustls::HttpsConnector<hyper_util::client::legacy::connect::HttpConnector> {
-    hyper_rustls::HttpsConnectorBuilder::new()
-        .with_tls_config(config.clone())
-        .https_only()
-        .enable_http1()
-        .build()
-}
-
-// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -314,9 +179,13 @@ pub(crate) fn build_custom_tls_connector(
 #[expect(clippy::allow_attributes, reason = "blanket test suppressions")]
 #[allow(clippy::unwrap_used, clippy::expect_used, reason = "tests")]
 mod tests {
+    use std::sync::Arc;
+
+    use rustls::pki_types::{CertificateDer, PrivateKeyDer, pem::PemObject as _};
     use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
 
     use super::*;
+    use crate::resources::tls_backend::{MAX_CA_PEM_BYTES, MAX_CLIENT_CERT_PEM_BYTES, MAX_CLIENT_KEY_PEM_BYTES};
 
     /// Start a local HTTP server on a random port and return the URL.
     async fn start_test_server(response: &'static [u8]) -> String {

--- a/operator/src/resources.rs
+++ b/operator/src/resources.rs
@@ -50,5 +50,7 @@ pub(crate) mod endpoint_tls;
 pub(crate) mod gateway_probe;
 /// Live MCP `tools/list` probe for [`AgentToolProvider`](crate::crd::agent_tool_provider::AgentToolProvider).
 pub(crate) mod mcp_probe;
+/// TLS backend abstraction: client config, connectors, handshake, PEM gates.
+pub(crate) mod tls_backend;
 /// TLS gateway probe — bounded handshake and peer certificate extraction.
 pub(crate) mod tls_probe;

--- a/operator/src/resources/endpoint_tls.rs
+++ b/operator/src/resources/endpoint_tls.rs
@@ -13,6 +13,7 @@ use std::sync::Arc;
 use crate::{
     crd::inference_provider::{ClientCertificateSecretRef, EndpointTlsConfig},
     metrics_scraper,
+    resources::tls_backend::ClientTlsConfig,
 };
 
 // ---------------------------------------------------------------------------
@@ -163,7 +164,7 @@ pub(crate) async fn resolve_tls_config(
     tls_config: Option<&EndpointTlsConfig>,
     client: Option<&kube::Client>,
     provider_identity: &str,
-) -> Result<Option<Arc<rustls::ClientConfig>>, (TlsFailureReason, String)> {
+) -> Result<Option<ClientTlsConfig>, (TlsFailureReason, String)> {
     let Some(tls) = tls_config else {
         return Ok(None);
     };

--- a/operator/src/resources/mcp_probe.rs
+++ b/operator/src/resources/mcp_probe.rs
@@ -33,13 +33,13 @@ use rmcp::{
         streamable_http_client::{StreamableHttpClientTransportConfig, StreamableHttpError},
     },
 };
-use rustls::pki_types::pem::PemObject as _;
 
 use crate::{
     crd::inference_provider::EndpointTlsConfig,
     resources::{
         credentials::BearerToken,
         endpoint_tls::{read_secret_bytes_for_tls, secret_ref_from_client_cert},
+        tls_backend::{validate_pem_certificates, validate_pem_private_key},
     },
 };
 
@@ -565,38 +565,6 @@ async fn read_tls_material(
             tracing::warn!(provider_identity, error = %msg, material_desc, "AgentToolProvider probe TLS material invalid");
             McpProbeOutcome::TlsConfigInvalid(reason.as_status_reason("Endpoint"))
         })
-}
-
-/// Structurally validate that `pem` decodes to at least one well-formed
-/// certificate.
-///
-/// `reqwest::Certificate::from_pem` is too lenient to be a validation gate
-/// by itself: it accepts empty input and PEM blocks with undecodable base64
-/// content without returning `Err` (only genuine third-party wire behavior,
-/// like a TLS handshake against real malformed material, would eventually
-/// surface a problem — far too late for a reconcile-time `status.reason`).
-/// This reuses the same strict `rustls::pki_types` parsing
-/// [`metrics_scraper::build_tls_client_config`](crate::metrics_scraper::build_tls_client_config)
-/// already relies on for `InferenceProvider`, so both TLS paths reject
-/// malformed CA material identically rather than diverging silently.
-fn validate_pem_certificates(pem: &[u8]) -> Result<(), String> {
-    let certs = rustls::pki_types::CertificateDer::pem_slice_iter(pem)
-        .collect::<Result<Vec<_>, _>>()
-        .map_err(|e| e.to_string())?;
-    if certs.is_empty() {
-        return Err("PEM contains no certificates".to_owned());
-    }
-    Ok(())
-}
-
-/// Structurally validate that `pem` decodes to a well-formed private key.
-///
-/// Same rationale as [`validate_pem_certificates`]: `reqwest::Identity::from_pem`
-/// alone is not a reliable validation gate for malformed key material.
-fn validate_pem_private_key(pem: &[u8]) -> Result<(), String> {
-    rustls::pki_types::PrivateKeyDer::from_pem_slice(pem)
-        .map(|_key| ())
-        .map_err(|e| e.to_string())
 }
 
 /// Read `tls.ca_secret_ref`'s CA certificate and add it to `builder` as a

--- a/operator/src/resources/mcp_probe.rs
+++ b/operator/src/resources/mcp_probe.rs
@@ -639,11 +639,26 @@ async fn attach_tls_ca(
     Ok(builder.tls_certs_only([ca_cert]))
 }
 
+/// Build the probe client identity: rustls takes one concatenated PEM, native-tls (fips) takes cert and key separately.
+#[cfg(not(feature = "fips"))]
+fn build_probe_client_identity(cert_pem: &[u8], key_pem: &[u8]) -> Result<reqwest::Identity, reqwest::Error> {
+    let mut combined = Vec::with_capacity(cert_pem.len() + key_pem.len());
+    combined.extend_from_slice(cert_pem);
+    combined.extend_from_slice(key_pem);
+    reqwest::Identity::from_pem(&combined)
+}
+
+/// Build the probe client identity: rustls takes one concatenated PEM, native-tls (fips) takes cert and key separately.
+#[cfg(feature = "fips")]
+fn build_probe_client_identity(cert_pem: &[u8], key_pem: &[u8]) -> Result<reqwest::Identity, reqwest::Error> {
+    reqwest::Identity::from_pkcs8_pem(cert_pem, key_pem)
+}
+
 /// Read `client_ref`'s certificate and private key and attach them to
 /// `builder` as the mTLS client identity.
 #[expect(
     clippy::too_many_lines,
-    reason = "sequential cert+key reads, eager rustls PEM validation for each, then the reqwest Identity build"
+    reason = "sequential cert and key reads, then eager PEM validation of each"
 )]
 async fn attach_tls_client_identity(
     builder: reqwest::ClientBuilder,
@@ -652,7 +667,7 @@ async fn attach_tls_client_identity(
     provider_identity: &str,
 ) -> Result<reqwest::ClientBuilder, McpProbeOutcome> {
     let cert_ref = secret_ref_from_client_cert(client_ref);
-    let mut identity_pem = Box::pin(read_tls_material(
+    let identity_pem = Box::pin(read_tls_material(
         kube_client,
         &cert_ref,
         &client_ref.certificate_key,
@@ -680,11 +695,7 @@ async fn attach_tls_client_identity(
             ENDPOINT_TLS_IDENTITY_MISMATCH.to_owned(),
         ));
     }
-    identity_pem.extend_from_slice(&key_pem);
-    // As in `attach_tls_ca`: the strict `rustls::pki_types` validation above
-    // is the real gate; this call still has to happen to build the
-    // `Identity` reqwest will actually use.
-    let identity = reqwest::Identity::from_pem(&identity_pem).map_err(|e| {
+    let identity = build_probe_client_identity(&identity_pem, &key_pem).map_err(|e| {
         tracing::warn!(provider_identity, error = %e, "AgentToolProvider probe client identity unparseable");
         McpProbeOutcome::TlsConfigInvalid(ENDPOINT_TLS_IDENTITY_MISMATCH.to_owned())
     })?;

--- a/operator/src/resources/provider_metrics.rs
+++ b/operator/src/resources/provider_metrics.rs
@@ -16,7 +16,6 @@
 
 use std::{
     collections::HashMap,
-    sync::Arc,
     time::{Duration, Instant},
 };
 
@@ -476,7 +475,7 @@ async fn resolve_tls_config(
     tls_config: Option<&EndpointTlsConfig>,
     client: Option<&kube::Client>,
     provider_identity: &str,
-) -> Result<Option<Arc<rustls::ClientConfig>>, (super::endpoint_tls::TlsFailureReason, String)> {
+) -> Result<Option<super::tls_backend::ClientTlsConfig>, (super::endpoint_tls::TlsFailureReason, String)> {
     super::endpoint_tls::resolve_tls_config(tls_config, client, provider_identity).await
 }
 

--- a/operator/src/resources/tls_backend.rs
+++ b/operator/src/resources/tls_backend.rs
@@ -1,0 +1,403 @@
+//! TLS backend abstraction for the operator.
+//!
+//! Centralizes every TLS primitive the operator uses (client-config
+//! assembly, HTTPS connectors, the probe handshake, PEM validation gates,
+//! SNI parsing, and the process-wide crypto provider) behind one module so
+//! the underlying TLS stack can be swapped without touching call sites.
+//!
+//! This is the only non-test module that names the TLS stack
+//! (`rustls`/`hyper-rustls`/`tokio-rustls`); every other module refers to the
+//! aliases and functions exposed here.
+
+use std::sync::Arc;
+
+use hyper_util::client::legacy::connect::HttpConnector;
+use rustls::pki_types::{CertificateDer, PrivateKeyDer, ServerName as RustlsServerName, pem::PemObject as _};
+
+use crate::{metrics_scraper::MetricsScrapeError, resources::gateway_probe::GatewayProbeOutcome};
+
+/// Maximum number of intermediate certificates accepted in a peer chain.
+pub(crate) const MAX_CHAIN_DEPTH: usize = 4;
+
+/// Maximum number of CA certificates accepted from one trust Secret.
+pub(crate) const MAX_CA_CERTIFICATES: usize = 16;
+
+/// Maximum size (bytes) of any single certificate in a chain.
+pub(crate) const MAX_CERT_BYTES: usize = 16_384;
+
+/// Maximum encoded size of one certificate bundle read from a Secret.
+pub(crate) const MAX_CERT_BUNDLE_BYTES: usize = 262_144;
+
+/// Maximum encoded size of one private key read from a Secret.
+pub(crate) const MAX_PRIVATE_KEY_BYTES: usize = 65_536;
+
+/// Maximum size for a CA PEM bundle (256 KiB).
+pub(crate) const MAX_CA_PEM_BYTES: usize = 256 * 1024;
+
+/// Maximum size for a client certificate PEM (64 KiB).
+pub(crate) const MAX_CLIENT_CERT_PEM_BYTES: usize = 64 * 1024;
+
+/// Maximum size for a client private key PEM (64 KiB).
+pub(crate) const MAX_CLIENT_KEY_PEM_BYTES: usize = 64 * 1024;
+
+/// Maximum number of certificates in a CA or client chain (scrape path).
+const MAX_CERT_CHAIN_LENGTH: usize = 10;
+
+/// Client TLS configuration threaded through probe and scrape call sites.
+pub(crate) type ClientTlsConfig = Arc<rustls::ClientConfig>;
+
+/// Validated SNI server name for a gateway probe.
+pub(crate) type ServerName = RustlsServerName<'static>;
+
+/// HTTPS connector used by the hyper-based metrics scrape and health probe.
+pub(crate) type HttpsConnector = hyper_rustls::HttpsConnector<HttpConnector>;
+
+/// Established client TLS stream produced by [`connect`].
+pub(crate) type ClientTlsStream = tokio_rustls::client::TlsStream<tokio::net::TcpStream>;
+
+/// Install the process-wide crypto provider the TLS stack requires.
+///
+/// Installs `ring` once, up front, so both the `hyper-rustls` client
+/// (`with_native_roots`) and the `reqwest`-backed MCP probe (built with
+/// `rustls-no-provider`) have a default provider regardless of which
+/// reconciler runs first. A second install attempt is ignored.
+pub fn init_process_crypto() {
+    if rustls::crypto::ring::default_provider().install_default().is_err() {
+        tracing::warn!("rustls default CryptoProvider already installed; continuing");
+    }
+}
+
+/// Parse PEM-encoded CA certificates into a trust root store.
+///
+/// # Errors
+///
+/// Returns a description if no valid certificate could be parsed.
+pub(crate) fn parse_ca_roots(ca_pem: &[u8]) -> Result<rustls::RootCertStore, &'static str> {
+    if ca_pem.len() > MAX_CERT_BUNDLE_BYTES {
+        return Err("CA certificate bundle exceeds maximum size");
+    }
+    let mut roots = rustls::RootCertStore::empty();
+    let mut count = 0_usize;
+    for cert in CertificateDer::pem_slice_iter(ca_pem) {
+        let cert = cert.map_err(|_err| "CA PEM contains invalid certificate data")?;
+        if cert.as_ref().len() > MAX_CERT_BYTES {
+            return Err("CA certificate exceeds maximum size");
+        }
+        roots
+            .add(cert)
+            .map_err(|_err| "CA certificate failed trust store insertion")?;
+        count += 1;
+        if count > MAX_CA_CERTIFICATES {
+            return Err("CA certificate bundle exceeds maximum certificate count");
+        }
+    }
+    if count == 0 {
+        return Err("CA PEM contains no certificates");
+    }
+    Ok(roots)
+}
+
+/// Parse PEM-encoded client certificate chain.
+///
+/// # Errors
+///
+/// Returns a description if parsing fails or the chain is oversized.
+pub(crate) fn parse_client_certs(cert_pem: &[u8]) -> Result<Vec<CertificateDer<'static>>, &'static str> {
+    if cert_pem.len() > MAX_CERT_BUNDLE_BYTES {
+        return Err("client certificate bundle exceeds maximum size");
+    }
+    let mut certs = Vec::new();
+    for cert in CertificateDer::pem_slice_iter(cert_pem) {
+        let cert = cert.map_err(|_err| "client certificate PEM is malformed")?;
+        if cert.as_ref().len() > MAX_CERT_BYTES {
+            return Err("client certificate exceeds maximum size");
+        }
+        certs.push(cert);
+        if certs.len() > MAX_CHAIN_DEPTH {
+            return Err("client certificate chain exceeds maximum depth");
+        }
+    }
+    if certs.is_empty() {
+        return Err("client certificate PEM contains no certificates");
+    }
+    Ok(certs)
+}
+
+/// Parse a PEM-encoded private key (PKCS#8 or PKCS#1 or SEC1).
+///
+/// # Errors
+///
+/// Returns a description if parsing fails.
+pub(crate) fn parse_private_key(key_pem: &[u8]) -> Result<PrivateKeyDer<'static>, &'static str> {
+    if key_pem.len() > MAX_PRIVATE_KEY_BYTES {
+        return Err("private key PEM exceeds maximum size");
+    }
+    PrivateKeyDer::from_pem_slice(key_pem).map_err(|_err| "private key PEM is malformed or missing")
+}
+
+/// Build a client TLS configuration from parsed trust material.
+///
+/// Uses only the provided Grid CA roots (no system/native roots). When
+/// `client_certs` and `client_key` are provided, configures mTLS client
+/// authentication.
+///
+/// # Errors
+///
+/// Returns a description if the configuration fails.
+pub(crate) fn build_tls_config(
+    roots: rustls::RootCertStore,
+    client_certs: Option<Vec<CertificateDer<'static>>>,
+    client_key: Option<PrivateKeyDer<'static>>,
+) -> Result<ClientTlsConfig, &'static str> {
+    let provider = rustls::crypto::ring::default_provider();
+    let builder = rustls::ClientConfig::builder_with_provider(Arc::new(provider))
+        .with_safe_default_protocol_versions()
+        .map_err(|_err| "failed to configure TLS protocol versions")?
+        .with_root_certificates(roots);
+    let config = match (client_certs, client_key) {
+        (Some(certs), Some(key)) => builder
+            .with_client_auth_cert(certs, key)
+            .map_err(|_err| "client certificate and key are incompatible")?,
+        (None, None) => builder.with_no_client_auth(),
+        _ => return Err("client certificate and key must both be present or both absent"),
+    };
+    Ok(Arc::new(config))
+}
+
+/// Extract the first DER certificate from a PEM string.
+///
+/// # Errors
+///
+/// Returns a bounded description if the PEM is oversized, malformed, or
+/// contains no certificate.
+pub(crate) fn first_cert_der_from_pem(pem: &str) -> Result<Vec<u8>, &'static str> {
+    if pem.len() > MAX_CERT_BUNDLE_BYTES {
+        return Err("advertised certificate PEM exceeds maximum size");
+    }
+    let cert = CertificateDer::pem_slice_iter(pem.as_bytes())
+        .next()
+        .ok_or("advertised certificate PEM contains no certificate")?
+        .map_err(|_err| "advertised certificate PEM is malformed")?;
+    if cert.as_ref().len() > MAX_CERT_BYTES {
+        return Err("advertised certificate exceeds maximum size");
+    }
+    Ok(cert.as_ref().to_vec())
+}
+
+/// Parse and validate an SNI server name.
+///
+/// # Errors
+///
+/// Returns `Err(())` if the name is not a valid DNS name.
+pub(crate) fn parse_server_name(server_name: &str) -> Result<ServerName, ()> {
+    RustlsServerName::try_from(server_name.to_owned()).map_err(|_err| ())
+}
+
+/// Build a client TLS configuration from raw PEM bytes.
+///
+/// `ca_pem` is the CA certificate chain (required). `client_cert_pem` and
+/// `client_key_pem` are the client identity for mTLS (both required together,
+/// or both absent for one-way TLS).
+///
+/// # Security invariant
+///
+/// Private key bytes are consumed by the TLS stack and never written to logs,
+/// events, status fields, or Prometheus labels.
+///
+/// # Errors
+///
+/// Returns [`MetricsScrapeError::TlsMaterial`] when PEM parsing fails or the
+/// material is structurally invalid.
+#[expect(
+    clippy::too_many_lines,
+    reason = "sequential PEM parsing for CA, client cert, and client key with validation"
+)]
+pub(crate) fn build_tls_client_config(
+    ca_pem: &[u8],
+    client_cert_pem: Option<&[u8]>,
+    client_key_pem: Option<&[u8]>,
+) -> Result<rustls::ClientConfig, MetricsScrapeError> {
+    if ca_pem.len() > MAX_CA_PEM_BYTES {
+        return Err(MetricsScrapeError::TlsMaterial(format!(
+            "CA PEM exceeds maximum size ({} bytes > {MAX_CA_PEM_BYTES})",
+            ca_pem.len()
+        )));
+    }
+
+    let mut root_store = rustls::RootCertStore::empty();
+    let ca_certs = CertificateDer::pem_slice_iter(ca_pem)
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| MetricsScrapeError::TlsMaterial(format!("CA PEM parse failed: {e}")))?;
+    if ca_certs.is_empty() {
+        return Err(MetricsScrapeError::TlsMaterial(
+            "CA PEM contains no certificates".to_owned(),
+        ));
+    }
+    if ca_certs.len() > MAX_CERT_CHAIN_LENGTH {
+        return Err(MetricsScrapeError::TlsMaterial(format!(
+            "CA PEM contains too many certificates ({} > {MAX_CERT_CHAIN_LENGTH})",
+            ca_certs.len()
+        )));
+    }
+    for cert in &ca_certs {
+        root_store
+            .add(cert.clone())
+            .map_err(|e| MetricsScrapeError::TlsMaterial(format!("CA certificate invalid: {e}")))?;
+    }
+
+    let builder = rustls::ClientConfig::builder().with_root_certificates(root_store);
+
+    let config = match (client_cert_pem, client_key_pem) {
+        (Some(cert_pem), Some(key_pem)) => {
+            if cert_pem.len() > MAX_CLIENT_CERT_PEM_BYTES {
+                return Err(MetricsScrapeError::TlsMaterial(format!(
+                    "client cert PEM exceeds maximum size ({} bytes > {MAX_CLIENT_CERT_PEM_BYTES})",
+                    cert_pem.len()
+                )));
+            }
+            if key_pem.len() > MAX_CLIENT_KEY_PEM_BYTES {
+                return Err(MetricsScrapeError::TlsMaterial(format!(
+                    "client key PEM exceeds maximum size ({} bytes > {MAX_CLIENT_KEY_PEM_BYTES})",
+                    key_pem.len()
+                )));
+            }
+            let certs = CertificateDer::pem_slice_iter(cert_pem)
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|e| MetricsScrapeError::TlsMaterial(format!("client cert PEM parse failed: {e}")))?;
+            if certs.is_empty() {
+                return Err(MetricsScrapeError::TlsMaterial(
+                    "client cert PEM contains no certificates".to_owned(),
+                ));
+            }
+            if certs.len() > MAX_CERT_CHAIN_LENGTH {
+                return Err(MetricsScrapeError::TlsMaterial(format!(
+                    "client cert PEM contains too many certificates ({} > {MAX_CERT_CHAIN_LENGTH})",
+                    certs.len()
+                )));
+            }
+            let key = PrivateKeyDer::from_pem_slice(key_pem)
+                .map_err(|e| MetricsScrapeError::TlsMaterial(format!("client key PEM parse failed: {e}")))?;
+            builder
+                .with_client_auth_cert(certs, key)
+                .map_err(|e| MetricsScrapeError::TlsMaterial(format!("client identity construction failed: {e}")))?
+        },
+        (None, None) => builder.with_no_client_auth(),
+        _ => {
+            return Err(MetricsScrapeError::TlsMaterial(
+                "client cert and key must both be present or both absent".to_owned(),
+            ));
+        },
+    };
+
+    Ok(config)
+}
+
+/// Build an HTTPS connector using native root certificates.
+///
+/// # Errors
+///
+/// Returns [`MetricsScrapeError::Transport`] if native roots cannot be loaded.
+pub(crate) fn build_native_connector() -> Result<HttpsConnector, MetricsScrapeError> {
+    hyper_rustls::HttpsConnectorBuilder::new()
+        .with_native_roots()
+        .map(|b| b.https_or_http().enable_http1().build())
+        .map_err(|e| MetricsScrapeError::Transport(e.into()))
+}
+
+/// Build an HTTPS-only connector using a custom client TLS configuration.
+pub(crate) fn build_custom_tls_connector(config: &ClientTlsConfig) -> HttpsConnector {
+    hyper_rustls::HttpsConnectorBuilder::new()
+        .with_tls_config((**config).clone())
+        .https_only()
+        .enable_http1()
+        .build()
+}
+
+/// Perform the client TLS handshake over an established TCP stream.
+///
+/// # Errors
+///
+/// Returns the underlying I/O error if the handshake fails.
+pub(crate) async fn connect(
+    tcp_stream: tokio::net::TcpStream,
+    config: &ClientTlsConfig,
+    server_name: &ServerName,
+) -> Result<ClientTlsStream, std::io::Error> {
+    let connector = tokio_rustls::TlsConnector::from(Arc::clone(config));
+    connector.connect(server_name.clone(), tcp_stream).await
+}
+
+/// Borrow the peer certificate chain (DER) from an established stream.
+///
+/// Returns `None` if the peer presented no certificates. The slices borrow
+/// from `tls_stream`, so no certificate bytes are copied.
+pub(crate) fn peer_chain_der(tls_stream: &ClientTlsStream) -> Option<Vec<&[u8]>> {
+    let (_, server_conn) = tls_stream.get_ref();
+    Some(server_conn.peer_certificates()?.iter().map(AsRef::as_ref).collect())
+}
+
+/// Classify a TLS/handshake I/O error into a `GatewayProbeOutcome`.
+///
+/// Never exposes the raw error string in the outcome.
+pub(crate) fn classify_tls_error(err: &std::io::Error) -> GatewayProbeOutcome {
+    if let Some(rustls_err) = err.get_ref().and_then(|inner| inner.downcast_ref::<rustls::Error>()) {
+        return classify_rustls_error(rustls_err);
+    }
+    if err.kind() == std::io::ErrorKind::ConnectionRefused {
+        return GatewayProbeOutcome::ConnectionFailed;
+    }
+    if err.kind() == std::io::ErrorKind::TimedOut {
+        return GatewayProbeOutcome::ConnectTimeout;
+    }
+    GatewayProbeOutcome::TlsProtocolError
+}
+
+/// Map a rustls error to a `GatewayProbeOutcome`.
+#[expect(clippy::wildcard_enum_match_arm, reason = "external type with many variants")]
+pub(crate) fn classify_rustls_error(err: &rustls::Error) -> GatewayProbeOutcome {
+    use rustls::{CertificateError, Error};
+
+    match err {
+        Error::InvalidCertificate(cert_err) => match cert_err {
+            CertificateError::UnknownIssuer => GatewayProbeOutcome::UntrustedIssuer,
+            CertificateError::NotValidForName | CertificateError::NotValidForNameContext { .. } => {
+                GatewayProbeOutcome::IdentityMismatch
+            },
+            CertificateError::Expired | CertificateError::ExpiredContext { .. } => {
+                GatewayProbeOutcome::CertificateExpired
+            },
+            CertificateError::NotValidYet | CertificateError::NotValidYetContext { .. } => {
+                GatewayProbeOutcome::CertificateNotYetValid
+            },
+            _ => GatewayProbeOutcome::TrustMaterialInvalid,
+        },
+        _ => GatewayProbeOutcome::TlsProtocolError,
+    }
+}
+
+/// Structurally validate that `pem` decodes to at least one well-formed
+/// certificate.
+///
+/// # Errors
+///
+/// Returns a description if the PEM is malformed or contains no certificates.
+pub(crate) fn validate_pem_certificates(pem: &[u8]) -> Result<(), String> {
+    let certs = CertificateDer::pem_slice_iter(pem)
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| e.to_string())?;
+    if certs.is_empty() {
+        return Err("PEM contains no certificates".to_owned());
+    }
+    Ok(())
+}
+
+/// Structurally validate that `pem` decodes to a well-formed private key.
+///
+/// # Errors
+///
+/// Returns a description if the key PEM is malformed.
+pub(crate) fn validate_pem_private_key(pem: &[u8]) -> Result<(), String> {
+    PrivateKeyDer::from_pem_slice(pem)
+        .map(|_key| ())
+        .map_err(|e| e.to_string())
+}

--- a/operator/src/resources/tls_probe.rs
+++ b/operator/src/resources/tls_probe.rs
@@ -7,12 +7,15 @@
 //! All timeouts are bounded.  No private key material appears in return
 //! values, log fields, or error messages.
 
-use std::sync::Arc;
-
-use rustls::pki_types::{CertificateDer, PrivateKeyDer, ServerName, pem::PemObject as _};
 use tokio::time::Duration;
 
-use crate::resources::gateway_probe::{CanonicalFingerprint, GatewayProbeOutcome, fingerprint_matches_any};
+pub(crate) use crate::resources::tls_backend::{
+    build_tls_config, first_cert_der_from_pem, parse_ca_roots, parse_client_certs, parse_private_key,
+};
+use crate::resources::{
+    gateway_probe::{CanonicalFingerprint, GatewayProbeOutcome, fingerprint_matches_any},
+    tls_backend::{self, ClientTlsConfig, ServerName},
+};
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -23,21 +26,6 @@ const PROBE_DEADLINE: Duration = Duration::from_secs(10);
 
 /// Maximum TCP connect timeout (subset of [`PROBE_DEADLINE`]).
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
-
-/// Maximum number of intermediate certificates accepted in the chain.
-const MAX_CHAIN_DEPTH: usize = 4;
-
-/// Maximum number of CA certificates accepted from one trust Secret.
-const MAX_CA_CERTIFICATES: usize = 16;
-
-/// Maximum size (bytes) of any single certificate in the chain.
-const MAX_CERT_BYTES: usize = 16_384;
-
-/// Maximum encoded size of one certificate bundle read from a Secret.
-const MAX_CERT_BUNDLE_BYTES: usize = 262_144;
-
-/// Maximum encoded size of one private key read from a Secret.
-const MAX_PRIVATE_KEY_BYTES: usize = 65_536;
 
 // ---------------------------------------------------------------------------
 // Probe configuration
@@ -52,14 +40,12 @@ pub(crate) struct ProbeConfig {
     /// TCP address to connect to (host:port).
     pub address: String,
 
-    /// rustls [`ClientConfig`] with Grid-only trust roots and optional
+    /// Client TLS config with Grid-only trust roots and optional
     /// client identity.
-    ///
-    /// [`ClientConfig`]: rustls::ClientConfig
-    pub tls_config: Arc<rustls::ClientConfig>,
+    pub tls_config: ClientTlsConfig,
 
     /// Expected DNS server name for SNI and SAN verification.
-    pub server_name: ServerName<'static>,
+    pub server_name: ServerName,
 
     /// Canonical DER fingerprint pins (1–2 entries).
     pub pins: Vec<CanonicalFingerprint>,
@@ -67,109 +53,6 @@ pub(crate) struct ProbeConfig {
     /// Optional SWIM-advertised leaf cert DER, compared with the configured
     /// rotation pins for diagnostics only.
     pub advertised_leaf_der: Option<Vec<u8>>,
-}
-
-// ---------------------------------------------------------------------------
-// TLS material parsing
-// ---------------------------------------------------------------------------
-
-/// Parse PEM-encoded CA certificates into a rustls root store.
-///
-/// # Errors
-///
-/// Returns a description if no valid certificate could be parsed.
-pub(crate) fn parse_ca_roots(ca_pem: &[u8]) -> Result<rustls::RootCertStore, &'static str> {
-    if ca_pem.len() > MAX_CERT_BUNDLE_BYTES {
-        return Err("CA certificate bundle exceeds maximum size");
-    }
-    let mut roots = rustls::RootCertStore::empty();
-    let mut count = 0_usize;
-    for cert in CertificateDer::pem_slice_iter(ca_pem) {
-        let cert = cert.map_err(|_err| "CA PEM contains invalid certificate data")?;
-        if cert.as_ref().len() > MAX_CERT_BYTES {
-            return Err("CA certificate exceeds maximum size");
-        }
-        roots
-            .add(cert)
-            .map_err(|_err| "CA certificate failed trust store insertion")?;
-        count += 1;
-        if count > MAX_CA_CERTIFICATES {
-            return Err("CA certificate bundle exceeds maximum certificate count");
-        }
-    }
-    if count == 0 {
-        return Err("CA PEM contains no certificates");
-    }
-    Ok(roots)
-}
-
-/// Parse PEM-encoded client certificate chain.
-///
-/// # Errors
-///
-/// Returns a description if parsing fails or the chain is oversized.
-pub(crate) fn parse_client_certs(cert_pem: &[u8]) -> Result<Vec<CertificateDer<'static>>, &'static str> {
-    if cert_pem.len() > MAX_CERT_BUNDLE_BYTES {
-        return Err("client certificate bundle exceeds maximum size");
-    }
-    let mut certs = Vec::new();
-    for cert in CertificateDer::pem_slice_iter(cert_pem) {
-        let cert = cert.map_err(|_err| "client certificate PEM is malformed")?;
-        if cert.as_ref().len() > MAX_CERT_BYTES {
-            return Err("client certificate exceeds maximum size");
-        }
-        certs.push(cert);
-        if certs.len() > MAX_CHAIN_DEPTH {
-            return Err("client certificate chain exceeds maximum depth");
-        }
-    }
-    if certs.is_empty() {
-        return Err("client certificate PEM contains no certificates");
-    }
-    Ok(certs)
-}
-
-/// Parse a PEM-encoded private key (PKCS#8 or PKCS#1 or SEC1).
-///
-/// # Errors
-///
-/// Returns a description if parsing fails.
-pub(crate) fn parse_private_key(key_pem: &[u8]) -> Result<PrivateKeyDer<'static>, &'static str> {
-    if key_pem.len() > MAX_PRIVATE_KEY_BYTES {
-        return Err("private key PEM exceeds maximum size");
-    }
-    PrivateKeyDer::from_pem_slice(key_pem).map_err(|_err| "private key PEM is malformed or missing")
-}
-
-/// Build a rustls [`ClientConfig`] from parsed trust material.
-///
-/// Uses only the provided Grid CA roots — no system/native roots.
-/// When `client_certs` and `client_key` are provided, configures
-/// mTLS client authentication.
-///
-/// # Errors
-///
-/// Returns a description if the configuration fails.
-///
-/// [`ClientConfig`]: rustls::ClientConfig
-pub(crate) fn build_tls_config(
-    roots: rustls::RootCertStore,
-    client_certs: Option<Vec<CertificateDer<'static>>>,
-    client_key: Option<PrivateKeyDer<'static>>,
-) -> Result<Arc<rustls::ClientConfig>, &'static str> {
-    let provider = rustls::crypto::ring::default_provider();
-    let builder = rustls::ClientConfig::builder_with_provider(Arc::new(provider))
-        .with_safe_default_protocol_versions()
-        .map_err(|_err| "failed to configure TLS protocol versions")?
-        .with_root_certificates(roots);
-    let config = match (client_certs, client_key) {
-        (Some(certs), Some(key)) => builder
-            .with_client_auth_cert(certs, key)
-            .map_err(|_err| "client certificate and key are incompatible")?,
-        (None, None) => builder.with_no_client_auth(),
-        _ => return Err("client certificate and key must both be present or both absent"),
-    };
-    Ok(Arc::new(config))
 }
 
 // ---------------------------------------------------------------------------
@@ -202,12 +85,15 @@ pub(crate) async fn probe_gateway(config: &ProbeConfig) -> GatewayProbeOutcome {
         Err(_elapsed) => return GatewayProbeOutcome::ConnectTimeout,
     };
 
-    let connector = tokio_rustls::TlsConnector::from(Arc::clone(&config.tls_config));
-    let tls_result = tokio::time::timeout_at(deadline, connector.connect(config.server_name.clone(), tcp_stream)).await;
+    let tls_result = tokio::time::timeout_at(
+        deadline,
+        tls_backend::connect(tcp_stream, &config.tls_config, &config.server_name),
+    )
+    .await;
 
     let tls_stream = match tls_result {
         Ok(Ok(stream)) => stream,
-        Ok(Err(err)) => return classify_tls_error(&err),
+        Ok(Err(err)) => return tls_backend::classify_tls_error(&err),
         Err(_elapsed) => return GatewayProbeOutcome::HandshakeTimeout,
     };
 
@@ -215,20 +101,16 @@ pub(crate) async fn probe_gateway(config: &ProbeConfig) -> GatewayProbeOutcome {
 }
 
 /// Verify the peer certificate after a successful TLS handshake.
-fn verify_peer_certificate(
-    tls_stream: &tokio_rustls::client::TlsStream<tokio::net::TcpStream>,
-    config: &ProbeConfig,
-) -> GatewayProbeOutcome {
-    let (_, server_conn) = tls_stream.get_ref();
-    let Some(peer_certs) = server_conn.peer_certificates() else {
+fn verify_peer_certificate(tls_stream: &tls_backend::ClientTlsStream, config: &ProbeConfig) -> GatewayProbeOutcome {
+    let Some(peer_certs) = tls_backend::peer_chain_der(tls_stream) else {
         return GatewayProbeOutcome::TlsProtocolError;
     };
 
-    if peer_certs.len() > MAX_CHAIN_DEPTH {
+    if peer_certs.len() > tls_backend::MAX_CHAIN_DEPTH {
         return GatewayProbeOutcome::TrustMaterialInvalid;
     }
-    for cert in peer_certs {
-        if cert.as_ref().len() > MAX_CERT_BYTES {
+    for cert in &peer_certs {
+        if cert.len() > tls_backend::MAX_CERT_BYTES {
             return GatewayProbeOutcome::TrustMaterialInvalid;
         }
     }
@@ -237,7 +119,7 @@ fn verify_peer_certificate(
         return GatewayProbeOutcome::TlsProtocolError;
     };
 
-    let leaf_fp = CanonicalFingerprint::from_der(leaf_der.as_ref());
+    let leaf_fp = CanonicalFingerprint::from_der(leaf_der);
     if !fingerprint_matches_any(&leaf_fp, &config.pins) {
         return GatewayProbeOutcome::PinMismatch;
     }
@@ -250,77 +132,6 @@ fn verify_peer_certificate(
     }
 
     GatewayProbeOutcome::Verified
-}
-
-// ---------------------------------------------------------------------------
-// Error classification
-// ---------------------------------------------------------------------------
-
-/// Classify a rustls/TLS error into a `GatewayProbeOutcome`.
-///
-/// Never exposes the raw error string in the outcome — the controller
-/// maps the outcome to bounded status reason codes.
-fn classify_tls_error(err: &std::io::Error) -> GatewayProbeOutcome {
-    if let Some(rustls_err) = err.get_ref().and_then(|inner| inner.downcast_ref::<rustls::Error>()) {
-        return classify_rustls_error(rustls_err);
-    }
-    if err.kind() == std::io::ErrorKind::ConnectionRefused {
-        return GatewayProbeOutcome::ConnectionFailed;
-    }
-    if err.kind() == std::io::ErrorKind::TimedOut {
-        return GatewayProbeOutcome::ConnectTimeout;
-    }
-    GatewayProbeOutcome::TlsProtocolError
-}
-
-/// Map a rustls error to a `GatewayProbeOutcome`.
-#[expect(clippy::wildcard_enum_match_arm, reason = "external type with many variants")]
-fn classify_rustls_error(err: &rustls::Error) -> GatewayProbeOutcome {
-    use rustls::{CertificateError, Error};
-
-    match err {
-        Error::InvalidCertificate(cert_err) => match cert_err {
-            CertificateError::UnknownIssuer => GatewayProbeOutcome::UntrustedIssuer,
-            CertificateError::NotValidForName | CertificateError::NotValidForNameContext { .. } => {
-                GatewayProbeOutcome::IdentityMismatch
-            },
-            CertificateError::Expired | CertificateError::ExpiredContext { .. } => {
-                GatewayProbeOutcome::CertificateExpired
-            },
-            CertificateError::NotValidYet | CertificateError::NotValidYetContext { .. } => {
-                GatewayProbeOutcome::CertificateNotYetValid
-            },
-            _ => GatewayProbeOutcome::TrustMaterialInvalid,
-        },
-        _ => GatewayProbeOutcome::TlsProtocolError,
-    }
-}
-
-// ---------------------------------------------------------------------------
-// PEM DER extraction (for advertised cert comparison)
-// ---------------------------------------------------------------------------
-
-/// Extract the first DER certificate from a PEM string.
-///
-/// Used to parse `status.publicCertPem` for comparison against the
-/// live peer certificate.
-///
-/// # Errors
-///
-/// Returns a bounded description if the PEM is oversized, malformed, or
-/// contains no certificate.
-pub(crate) fn first_cert_der_from_pem(pem: &str) -> Result<Vec<u8>, &'static str> {
-    if pem.len() > MAX_CERT_BUNDLE_BYTES {
-        return Err("advertised certificate PEM exceeds maximum size");
-    }
-    let cert = CertificateDer::pem_slice_iter(pem.as_bytes())
-        .next()
-        .ok_or("advertised certificate PEM contains no certificate")?
-        .map_err(|_err| "advertised certificate PEM is malformed")?;
-    if cert.as_ref().len() > MAX_CERT_BYTES {
-        return Err("advertised certificate exceeds maximum size");
-    }
-    Ok(cert.as_ref().to_vec())
 }
 
 // ---------------------------------------------------------------------------
@@ -337,7 +148,14 @@ pub(crate) fn first_cert_der_from_pem(pem: &str) -> Result<Vec<u8>, &'static str
     reason = "tests"
 )]
 mod tests {
+    use std::sync::Arc;
+
+    use rustls::pki_types::{CertificateDer, pem::PemObject as _};
+
     use super::*;
+    use crate::resources::tls_backend::{
+        MAX_CA_CERTIFICATES, MAX_CERT_BUNDLE_BYTES, MAX_PRIVATE_KEY_BYTES, classify_rustls_error, classify_tls_error,
+    };
 
     fn test_ca() -> certs::CaCert {
         certs::generate_ca("test-grid").unwrap()

--- a/overlay-sync/Cargo.toml
+++ b/overlay-sync/Cargo.toml
@@ -10,6 +10,11 @@ license.workspace = true
 name = "grid-overlay-sync"
 path = "src/main.rs"
 
+[features]
+default = ["tls-rustls"]
+tls-rustls = ["kube/rustls-tls", "kube/ring"]
+fips = ["kube/openssl-tls"]
+
 [dependencies]
 axum = { workspace = true }
 clap = { workspace = true, features = ["env"] }

--- a/overlay-sync/src/main.rs
+++ b/overlay-sync/src/main.rs
@@ -14,6 +14,11 @@
     reason = "overlay-sync uses short closure params and index arithmetic pervasively"
 )]
 
+#[cfg(all(feature = "tls-rustls", feature = "fips"))]
+compile_error!(
+    "features `tls-rustls` and `fips` are mutually exclusive; build a FIPS binary with --no-default-features --features fips"
+);
+
 mod atomic_file;
 mod metrics;
 mod status;


### PR DESCRIPTION
Built on #144.

## Summary

Move every rustls, hyper-rustls, and tokio-rustls use in non-test operator code into a single `resources::tls_backend` module. It owns the core TLS types (`ClientTlsConfig`, `ServerName`, `HttpsConnector`, `ClientTlsStream`), the config and connector builders, the probe handshake, error classification, and the strict PEM gates, all behind one API. Every other module refers only to `tls_backend`.

## Motivation

It isolates the TLS backend behind one seam. A later change can then select the backend per feature (rustls by default, system OpenSSL under `fips`) without touching call sites across the crate.

## What Changed

Pure refactor, no behavior change. No Cargo or feature changes, and rustls stays the backend on both the default and `fips` builds. The OpenSSL implementation of this seam follows in a subsequent PR.
